### PR TITLE
Add empty state error screen when fetching fails

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -24,7 +24,7 @@ class App extends Component {
                 {},
                 [
                     thunk,
-                    notificationsMiddleware({ errorTitleKey: 'error', errorDescriptionKey: 'error' }),
+                    notificationsMiddleware({ errorTitleKey: 'error.title', errorDescriptionKey: 'error.detail' }),
                     logger
                 ]
             );

--- a/src/components/SourcesEmptyState.js
+++ b/src/components/SourcesEmptyState.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {
     Bullseye,
     Card,
@@ -15,23 +16,27 @@ import { WrenchIcon } from '@patternfly/react-icons'; // FIXME: different icon
 import { Link } from 'react-router-dom';
 import { paths } from '../Routes';
 
-const SourcesEmptyState = () => (
+const SourcesEmptyState = ({ title, body }) => (
     <Card>
         <CardBody>
             <Bullseye>
                 <EmptyState>
                     <EmptyStateIcon icon={WrenchIcon} />
                     <Title headingLevel="h5" size="lg">
-                        <FormattedMessage
-                            id="sources.emptyStateTitle"
-                            defaultMessage="No Sources"
-                        />
+                        {title ? title :
+                            <FormattedMessage
+                                id="sources.emptyStateTitle"
+                                defaultMessage="No Sources"
+                            />
+                        }
                     </Title>
                     <EmptyStateBody>
-                        <FormattedMessage
-                            id="sources.emptyStateBody"
-                            defaultMessage="No Sources have been defined. To start define a Source."
-                        />
+                        {body ? body :
+                            <FormattedMessage
+                                id="sources.emptyStateBody"
+                                defaultMessage="No Sources have been defined. To start define a Source."
+                            />
+                        }
                     </EmptyStateBody>
                     <Link to={paths.sourcesNew}>
                         <Button style={{ marginTop: 'var(--pf-c-empty-state--c-button--MarginTop)' }}
@@ -47,5 +52,10 @@ const SourcesEmptyState = () => (
         </CardBody>
     </Card>
 );
+
+SourcesEmptyState.propTypes = {
+    title: PropTypes.node,
+    body: PropTypes.node
+};
 
 export default SourcesEmptyState;

--- a/src/pages/SourcesPage.js
+++ b/src/pages/SourcesPage.js
@@ -102,7 +102,8 @@ class SourcesPage extends Component {
             intl,
             match,
             location,
-            loaded
+            loaded,
+            fetchingError
         } = this.props;
 
         const numberOfFilteredEntities = (
@@ -140,7 +141,13 @@ class SourcesPage extends Component {
                     })}/>
                 </PageHeader>
                 <Section type='content'>
-                    {displayEmptyState ? <SourcesEmptyState /> : this.renderMainContent(numberOfFilteredEntities, currentPage)}
+                    { (displayEmptyState || fetchingError) ?
+                        <SourcesEmptyState
+                            title={fetchingError ? fetchingError.title : undefined}
+                            body={fetchingError ? fetchingError.detail : undefined}
+                        />
+                        :
+                        this.renderMainContent(numberOfFilteredEntities, currentPage)}
                 </Section>
             </React.Fragment>
         );
@@ -161,6 +168,7 @@ SourcesPage.propTypes = {
     numberOfEntities: PropTypes.number.isRequired,
     pageSize: PropTypes.number.isRequired,
     pageNumber: PropTypes.number.isRequired,
+    fetchingError: PropTypes.object,
 
     filterValue: PropTypes.string,
     loaded: PropTypes.bool.isRequired,
@@ -198,10 +206,23 @@ const mapStateToProps = (
         entities,
         pageSize,
         pageNumber,
+        fetchingError,
         ...others
     }
     }) => (
-    { filterValue, loaded, numberOfEntities, sourceTypesLoaded, sourceTypes, appTypes, entities, pageSize, pageNumber, others }
+    {
+        filterValue,
+        loaded,
+        numberOfEntities,
+        sourceTypesLoaded,
+        sourceTypes,
+        appTypes,
+        entities,
+        pageSize,
+        pageNumber,
+        fetchingError,
+        others
+    }
 );
 
 export default injectIntl(connect(mapStateToProps, mapDispatchToProps)(withRouter(SourcesPage)));

--- a/src/redux/actions/providers.js
+++ b/src/redux/actions/providers.js
@@ -25,7 +25,10 @@ export const loadEntities = () => (dispatch) => {
             type: ACTION_TYPES.LOAD_ENTITIES_FULFILLED,
             payload: sources
         });
-    });
+    }).catch(error => dispatch({
+        type: ACTION_TYPES.LOAD_ENTITIES_REJECTED,
+        payload: { error: { detail: error.data, title: 'Fetching data failed, try refresh page' } }
+    }));
 };
 
 export const loadSourceTypes = () => (dispatch) => {

--- a/src/redux/reducers/providers.js
+++ b/src/redux/reducers/providers.js
@@ -31,6 +31,11 @@ const entitiesLoaded = (state, { payload: rows }) => ({
     numberOfEntities: rows.length
 });
 
+const entitiesRejected = (state, { payload: { error } }) => ({
+    ...state,
+    fetchingError: error
+});
+
 const sourceTypesPending = (state) => ({
     ...state,
     sourceTypes: [],
@@ -90,6 +95,7 @@ const sourceEditRequest = (state) => ({
 export default {
     [ACTION_TYPES.LOAD_ENTITIES_PENDING]: entitiesPending,
     [ACTION_TYPES.LOAD_ENTITIES_FULFILLED]: entitiesLoaded,
+    [ACTION_TYPES.LOAD_ENTITIES_REJECTED]: entitiesRejected,
     [ACTION_TYPES.LOAD_SOURCE_TYPES_PENDING]: sourceTypesPending,
     [ACTION_TYPES.LOAD_SOURCE_TYPES_FULFILLED]: sourceTypesLoaded,
     [ACTION_TYPES.LOAD_APP_TYPES_PENDING]: appTypesPending,

--- a/src/test/SourcesPage.spec.js
+++ b/src/test/SourcesPage.spec.js
@@ -91,6 +91,38 @@ describe('SourcesPage', () => {
     });
 
     it('renders empty state when there are no Sources', (done) => {
+        const error = {
+            detail: 'Detail of error',
+            title: 'Error title'
+        };
+
+        initialState = {
+            providers: {
+                ...initialState.providers,
+                fetchingError: {
+                    detail: error.detail,
+                    title: error.title
+                }
+            }
+        };
+
+        const store = mockStore(initialState);
+        mockInitialHttpRequests();
+
+        const page = mount(componentWrapperIntl(<SourcesPage { ...initialProps } />, store));
+        setImmediate(() => {
+            expect(page.find(SourcesEmptyState)).toHaveLength(1);
+            expect(page.find(SourcesFilter)).toHaveLength(0);
+            expect(page.find(SourcesSimpleView)).toHaveLength(0);
+            expect(page.find(SourcesEmptyState).props()).toEqual({
+                body: error.detail,
+                title: error.title
+            });
+            done();
+        });
+    });
+
+    it('renders empty state when there is fetching error', (done) => {
         const store = mockStore(initialState);
         mockInitialHttpRequests();
 

--- a/src/test/components/SourcesEmptyState.spec.js
+++ b/src/test/components/SourcesEmptyState.spec.js
@@ -1,0 +1,48 @@
+import SourcesEmptyState from '../../components/SourcesEmptyState';
+import { mount } from 'enzyme';
+import {
+    Bullseye,
+    Card,
+    CardBody,
+    Title,
+    Button,
+    EmptyState,
+    EmptyStateIcon,
+    EmptyStateBody
+} from '@patternfly/react-core';
+import { IntlProvider } from 'react-intl';
+import { MemoryRouter } from 'react-router-dom';
+
+describe('SourcesEmptyState', () => {
+    it('renders correctly', () => {
+        const wrapper = mount(
+            <IntlProvider locale="en" >
+                <MemoryRouter >
+                    <SourcesEmptyState />
+                </MemoryRouter>
+            </IntlProvider>
+        );
+
+        expect(wrapper.find(EmptyState)).toHaveLength(1);
+        expect(wrapper.find(Card)).toHaveLength(1);
+        expect(wrapper.find(EmptyStateIcon)).toHaveLength(1);
+        expect(wrapper.find(EmptyStateBody)).toHaveLength(1);
+        expect(wrapper.find(Button)).toHaveLength(1);
+        expect(wrapper.find(Title)).toHaveLength(1);
+        expect(wrapper.find(CardBody)).toHaveLength(1);
+        expect(wrapper.find(Bullseye)).toHaveLength(1);
+    });
+
+    it('renders correctly with custom props', () => {
+        const wrapper = mount(
+            <IntlProvider locale="en" >
+                <MemoryRouter >
+                    <SourcesEmptyState title="Chyba" body="Velmi oskliva chyba"/>
+                </MemoryRouter>
+            </IntlProvider>
+        );
+
+        expect(wrapper.find(Title).text().includes('Chyba')).toEqual(true);
+        expect(wrapper.find(EmptyStateBody).text().includes('Velmi oskliva chyba')).toEqual(true);
+    });
+});


### PR DESCRIPTION
**Description**

Due to current API blackout, I notice that FETCH error do not stop the loading.

- adds props for `SourcesEmptyState` to change the title and the body
- adds `fetchingError` property to the store

**Before**

![image](https://user-images.githubusercontent.com/32869456/64769361-7002b580-d54b-11e9-842e-1005d236261d.png)

**After**

![image](https://user-images.githubusercontent.com/32869456/64769266-49dd1580-d54b-11e9-902d-a931869c229b.png)


@miq-bot add_label bug

@Hyperkid123 