### PR TITLE
Dependabot: update deps weekly

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,7 +2,7 @@ version: 1
 update_configs:
   - package_manager: "javascript"
     directory: "/"
-    update_schedule: "live"
+    update_schedule: "weekly"
     default_reviewers:
       - "rvsia"
     allowed_updates:


### PR DESCRIPTION
**Description**

Sets the Dependabot to weekly updates according https://dependabot.com/docs/config-file/#update_schedule-required