### PR TITLE
Redirect when editing imported source

### DIFF
--- a/src/components/SourceEditForm/SourceEditModal.js
+++ b/src/components/SourceEditForm/SourceEditModal.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useReducer } from 'react';
 import { useSelector, useDispatch, shallowEqual } from 'react-redux';
-import { withRouter } from 'react-router-dom';
-import PropTypes from 'prop-types';
+import { useParams, useHistory } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import { Modal, GridItem, Grid } from '@patternfly/react-core';
 import { Spinner } from '@redhat-cloud-services/frontend-components';
@@ -15,6 +14,8 @@ import Header from './Header';
 import { prepareInitialValues } from './helpers';
 import { onSubmit } from './onSubmit';
 
+import { redirectWhenImported } from './importedRedirect';
+
 const initialState = {
     loading: true,
     editing: {},
@@ -26,8 +27,10 @@ const initialState = {
 
 const reducer = (state, payload) => ({ ...state, ...payload });
 
-const SourceEditModal = ({ match: { params: { id } }, history }) => {
+const SourceEditModal = () => {
     const [state, setState] = useReducer(reducer, initialState);
+    const { id } = useParams();
+    const history = useHistory();
 
     const { loading, editing, source, initialValues, sourceType, schema } = state;
 
@@ -44,6 +47,10 @@ const SourceEditModal = ({ match: { params: { id } }, history }) => {
 
     useEffect(() => {
         doLoadSourceForEdit(id).then((source) => {
+            if (source.source.imported) {
+                redirectWhenImported(dispatch, intl, history, source.source.name);
+            }
+
             setState({ source });
         });
     }, []);
@@ -132,9 +139,4 @@ const SourceEditModal = ({ match: { params: { id } }, history }) => {
     );
 };
 
-SourceEditModal.propTypes = {
-    match: PropTypes.object.isRequired,
-    history: PropTypes.any.isRequired
-};
-
-export default withRouter(SourceEditModal);
+export default SourceEditModal;

--- a/src/components/SourceEditForm/importedRedirect.js
+++ b/src/components/SourceEditForm/importedRedirect.js
@@ -1,0 +1,17 @@
+import { paths } from '../../Routes';
+import { addMessage } from '../../redux/actions/providers';
+
+export const redirectWhenImported = (dispatch, intl, history, name) => {
+    dispatch(addMessage(
+        intl.formatMessage({
+            id: 'sources.importSourceCannotEdited',
+            defaultMessage: 'Source { name } is imported.'
+        }, { name }),
+        'danger',
+        intl.formatMessage({
+            id: 'sources.importedSourcesCannotEdited',
+            defaultMessage: 'Imported sources cannot be edited.'
+        }),
+    ));
+    history.push(paths.sources);
+};

--- a/src/test/components/sourceEditForm/SourceEditModal.spec.js
+++ b/src/test/components/sourceEditForm/SourceEditModal.spec.js
@@ -17,6 +17,7 @@ import { Modal, Button, FormGroup, TextInput } from '@patternfly/react-core';
 import * as api from '../../../api/entities';
 import EditFieldProvider from '../../../components/editField/EditField';
 import * as submit from '../../../components/SourceEditForm/onSubmit';
+import * as redirect from '../../../components/SourceEditForm/importedRedirect';
 
 jest.mock('@redhat-cloud-services/frontend-components-sources', () => ({
     asyncValidator: jest.fn()
@@ -77,6 +78,42 @@ describe('SourceEditModal', () => {
         expect(wrapper.find(Modal)).toHaveLength(1);
         expect(wrapper.find(EditFieldProvider).length).toBeGreaterThan(0);
         expect(wrapper.find(Button)).toHaveLength(BUTTONS.length);
+    });
+
+    it('calls redirectWhenImported when imported source', async() => {
+        const DISPATCH = expect.any(Function);
+        const INTL = expect.any(Object);
+        const HISTORY = expect.any(Object);
+        const SOURCE_NAME = 'some name';
+
+        redirect.redirectWhenImported = jest.fn();
+
+        api.doLoadSourceForEdit = jest.fn().mockImplementation(() => Promise.resolve({
+            source: {
+                name: SOURCE_NAME,
+                source_type_id: OPENSHIFT_ID,
+                imported: 'cfme'
+            },
+            applications: [],
+            endpoints: [],
+            authentications: []
+        }));
+
+        await act(async() => {
+            wrapper = mount(componentWrapperIntl(
+                <Route path={paths.sourcesEdit} render={ (...args) => <SourceEditModal { ...args }/> } />,
+                store,
+                initialEntry
+            ));
+        });
+        wrapper.update();
+
+        expect(redirect.redirectWhenImported).toHaveBeenCalledWith(
+            DISPATCH,
+            INTL,
+            HISTORY,
+            SOURCE_NAME
+        );
     });
 
     it('change editField component for name', async() => {

--- a/src/test/components/sourceEditForm/importedRedirect.spec.js
+++ b/src/test/components/sourceEditForm/importedRedirect.spec.js
@@ -1,0 +1,31 @@
+import { redirectWhenImported } from '../../../components/SourceEditForm/importedRedirect';
+import * as actions from '../../../redux/actions/providers';
+import { paths } from '../../../Routes';
+
+describe('redirectWhenImported', () => {
+    const DISPATCH = jest.fn();
+    const INTL = {
+        formatMessage: jest.fn().mockImplementation(({ defaultMessage }) => defaultMessage)
+    };
+    const HISTORY = {
+        push: jest.fn()
+    };
+    const NAME = 'imported source';
+
+    const EXPECT_TITLE =  expect.any(String);
+    const EXPECT_DESCRIPTION =  expect.any(String);
+
+    it('add a notification and redirects to root', () => {
+        actions.addMessage = jest.fn().mockImplementation();
+
+        redirectWhenImported(DISPATCH, INTL, HISTORY, NAME);
+
+        expect(DISPATCH).toHaveBeenCalled();
+        expect(actions.addMessage).toHaveBeenCalledWith(
+            EXPECT_TITLE,
+            'danger',
+            EXPECT_DESCRIPTION,
+        );
+        expect(HISTORY.push).toHaveBeenCalledWith(paths.sources);
+    });
+});


### PR DESCRIPTION
**Description**

If user tries to go to the edit source via url and the source is imported, the user is redirected to the root and a notification is shown.

![imported redirect](https://user-images.githubusercontent.com/32869456/69613876-91dfe480-1032-11ea-83be-ab7b3d8599f3.gif)

cc @terezanovotna