### PR TITLE
Unsupported authtype fallback in edit form

### DIFF
--- a/src/Utilities/testsHelpers.js
+++ b/src/Utilities/testsHelpers.js
@@ -1,13 +1,22 @@
 import { IntlProvider } from 'react-intl';
 import { MemoryRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
 
-export const componentWrapperIntl = (children, store, initialEntries, initialIndex = 0) => (
-    <IntlProvider locale="en">
-        <Provider store={ store }>
-            <MemoryRouter initialEntries={ initialEntries } initialIndex={ initialIndex }>
-                { children }
-            </MemoryRouter>
-        </Provider>
-    </IntlProvider>
-);
+export const componentWrapperIntl = (children, store, initialEntries, initialIndex = 0) => {
+    if (!store) {
+        const mockStore = configureStore([]);
+
+        store = mockStore({});
+    }
+
+    return (
+        <IntlProvider locale="en">
+            <Provider store={ store }>
+                <MemoryRouter initialEntries={ initialEntries } initialIndex={ initialIndex }>
+                    { children }
+                </MemoryRouter>
+            </Provider>
+        </IntlProvider>
+    );
+};

--- a/src/components/SourceEditForm/parser/authentication.js
+++ b/src/components/SourceEditForm/parser/authentication.js
@@ -2,8 +2,10 @@ import React from 'react';
 import get from 'lodash/get';
 import { componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
 import { hardcodedSchemas } from '@redhat-cloud-services/frontend-components-sources';
-import { EDIT_FIELD_NAME } from '../../editField/EditField';
 import { FormattedMessage } from 'react-intl';
+
+import { EDIT_FIELD_NAME } from '../../editField/EditField';
+import { unsupportedAuthTypeField } from './unsupportedAuthType';
 
 export const createAuthFieldName = (fieldName, id) => `authentications.a${id}.${fieldName.replace('authentication.', '')}`;
 
@@ -56,6 +58,11 @@ export const authenticationFields = (authentications, sourceType, editing, setEd
 
     return authentications.map((auth) => {
         const schemaAuth = sourceType.schema.authentication.find(({ type }) => type === auth.authtype);
+
+        if (!schemaAuth) {
+            return unsupportedAuthTypeField(auth.authtype);
+        }
+
         const additionalStepKeys = getAdditionalAuthSteps(sourceType.name, auth.authtype);
 
         const enhancedFields = schemaAuth.fields

--- a/src/components/SourceEditForm/parser/unsupportedAuthType.js
+++ b/src/components/SourceEditForm/parser/unsupportedAuthType.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import {
+    TextContent,
+    Text,
+    TextVariants
+} from '@patternfly/react-core';
+
+export const unsupportedAuthTypeField = (type) => ({
+    component: 'description',
+    name: `${type}-unsupported`,
+    // eslint-disable-next-line react/display-name
+    Content: () => (
+        <TextContent>
+            <Text component={ TextVariants.p }>
+                <FormattedMessage
+                    id="sources.unsupportedAuthType"
+                    defaultMessage={`Authentication type of { type } is no longer supported.`}
+                    values={{ type }}
+                />
+            </Text>
+        </TextContent>
+    )
+});

--- a/src/test/components/sourceEditForm/parser/authentication.spec.js
+++ b/src/test/components/sourceEditForm/parser/authentication.spec.js
@@ -10,6 +10,7 @@ import {
     modifyAuthSchemas,
     removeRequiredValidator
 } from '../../../../components/SourceEditForm/parser/authentication';
+import { unsupportedAuthTypeField } from '../../../../components/SourceEditForm/parser/unsupportedAuthType';
 
 jest.mock('@redhat-cloud-services/frontend-components-sources', () => ({
     hardcodedSchemas: {
@@ -260,6 +261,22 @@ describe('authentication edit source parser', () => {
 
             expect(result).toEqual([
                 ARN_GROUP
+            ]);
+        });
+
+        it('returns unsupported authentication type when unsupported', () => {
+            const UNSUPPORTED_AUTHTYPE = 'openshift_default';
+            const UNSUPPORTED_AUTHENTICATIONS = [{ authtype: UNSUPPORTED_AUTHTYPE, id: ID }];
+
+            const result = authenticationFields(
+                UNSUPPORTED_AUTHENTICATIONS,
+                SOURCE_TYPE,
+                EDITING,
+                SET_EDIT
+            );
+
+            expect(result).toEqual([
+                { ...unsupportedAuthTypeField(UNSUPPORTED_AUTHTYPE), Content: expect.any(Function) }
             ]);
         });
     });

--- a/src/test/components/sourceEditForm/parser/unsupportedAuthType.spec.js
+++ b/src/test/components/sourceEditForm/parser/unsupportedAuthType.spec.js
@@ -1,0 +1,26 @@
+import { unsupportedAuthTypeField } from '../../../../components/SourceEditForm/parser/unsupportedAuthType';
+import { componentWrapperIntl } from '../../../../Utilities/testsHelpers';
+import { Text } from '@patternfly/react-core';
+
+describe('unsupportedAuthTypeField', () => {
+    const AUTHTYPE = 'openshift-default';
+
+    it('returns schema field', () => {
+        expect(unsupportedAuthTypeField(AUTHTYPE)).toEqual(
+            expect.objectContaining({
+                component: 'description',
+                name: `${AUTHTYPE}-unsupported`
+            })
+        );
+    });
+
+    it('renders content', () => {
+        const unsupportedAuthType = unsupportedAuthTypeField(AUTHTYPE);
+
+        // eslint-disable-next-line new-cap
+        const wrapper = mount(componentWrapperIntl(unsupportedAuthType.Content()));
+
+        expect(wrapper.find(Text)).toHaveLength(1);
+        expect(wrapper.find(Text).text().includes(AUTHTYPE)).toEqual(true);
+    });
+});


### PR DESCRIPTION
**Description**

This PR checks if a source has unsupported authtype (due to outdated DB and inconsistency) and if so, only a text is shown to user. (So, QA knows what is happening.)

(This should not be an issue on production.)

![image](https://user-images.githubusercontent.com/32869456/69617292-4a5c5700-1038-11ea-9ec7-af15440dc9c1.png)

cc @terezanovotna