### PR TITLE
Fix passing arguments for loadEntities

### DIFF
--- a/src/redux/actions/providers.js
+++ b/src/redux/actions/providers.js
@@ -20,21 +20,20 @@ import {
 import { doUpdateSource } from '../../api/doUpdateSource';
 import { doLoadSourceTypes } from '../../api/source_types';
 
-export const loadEntities = (options, optionsPending) => (dispatch, getState) => {
-    const { pageSize, pageNumber, sortBy, sortDirection, filterValue } = getState().providers;
-
+export const loadEntities = (options) => (dispatch, getState) => {
     dispatch({
         type: ACTION_TYPES.LOAD_ENTITIES_PENDING,
-        options: optionsPending
+        options
     });
+
+    const { pageSize, pageNumber, sortBy, sortDirection, filterValue } = getState().providers;
 
     return Promise.all([
         doLoadEntities({ pageSize, pageNumber, sortBy, sortDirection, filterValue }),
         doLoadCountOfSources(filterValue).then(({ meta: { count } }) => dispatch({ type: SET_COUNT, payload: { count } }))
     ]).then(([{ sources }]) => dispatch({
         type: ACTION_TYPES.LOAD_ENTITIES_FULFILLED,
-        payload: sources,
-        options
+        payload: sources
     })).catch(error => dispatch({
         type: ACTION_TYPES.LOAD_ENTITIES_REJECTED,
         payload: { error: { detail: error.detail || error.data, title: 'Fetching data failed, try refresh page' } }
@@ -115,7 +114,7 @@ export const removeSource = (sourceId, title) => (dispatch) => {
         }
     });
 
-    return doRemoveSource(sourceId).then(() => dispatch(loadEntities({}, { loaded: true })))
+    return doRemoveSource(sourceId).then(() => dispatch(loadEntities({ loaded: true })))
     .then(() => {
         dispatch({
             type: ACTION_TYPES.REMOVE_SOURCE_FULFILLED,

--- a/src/test/redux/actions.spec.js
+++ b/src/test/redux/actions.spec.js
@@ -196,12 +196,11 @@ describe('redux actions', () => {
             });
             expect(dispatch.mock.calls[2][0]).toEqual({
                 type: ACTION_TYPES.LOAD_ENTITIES_FULFILLED,
-                payload: sources,
-                options: undefined
+                payload: sources
             });
         });
 
-        it('passes options to fulfilled', async () => {
+        it('passes options to pending', async () => {
             const options = { custom: 'custom' };
 
             await loadEntities(options)(dispatch, getState);
@@ -210,28 +209,6 @@ describe('redux actions', () => {
 
             expect(dispatch.mock.calls[0][0]).toEqual({
                 type: ACTION_TYPES.LOAD_ENTITIES_PENDING,
-                options: undefined
-            });
-            expect(dispatch.mock.calls[1][0]).toEqual({
-                type: SET_COUNT,
-                payload: { count }
-            });
-            expect(dispatch.mock.calls[2][0]).toEqual({
-                type: ACTION_TYPES.LOAD_ENTITIES_FULFILLED,
-                payload: sources,
-                options
-            });
-        });
-
-        it('passes options to pending', async () => {
-            const options = { custom: 'custom' };
-
-            await loadEntities({}, options)(dispatch, getState);
-
-            expect(dispatch.mock.calls).toHaveLength(3);
-
-            expect(dispatch.mock.calls[0][0]).toEqual({
-                type: ACTION_TYPES.LOAD_ENTITIES_PENDING,
                 options
             });
             expect(dispatch.mock.calls[1][0]).toEqual({
@@ -240,8 +217,7 @@ describe('redux actions', () => {
             });
             expect(dispatch.mock.calls[2][0]).toEqual({
                 type: ACTION_TYPES.LOAD_ENTITIES_FULFILLED,
-                payload: sources,
-                options: {}
+                payload: sources
             });
         });
 


### PR DESCRIPTION
`getState().providers` has to be done after changing the state :man_facepalming: 

And I found that the first argument is obsolete, so I deleted it.