### PR TITLE
Set pageNumber to 1 when filtering

### DIFF
--- a/src/pages/SourcesPage.js
+++ b/src/pages/SourcesPage.js
@@ -65,12 +65,6 @@ const SourcesPage = () => {
         }
     }, [checkEmptyState]);
 
-    useEffect(() => {
-        if (checkEmptyState) {
-            dispatch(loadEntities());
-        }
-    }, [filterValue]);
-
     const onSetPage = (_e, page) => dispatch(pageAndSize(page, pageSize));
 
     const onPerPageSelect = (_e, perPage) => dispatch(pageAndSize(1, perPage));

--- a/src/redux/actions/providers.js
+++ b/src/redux/actions/providers.js
@@ -76,10 +76,14 @@ export const pageAndSize = (page, size) => (dispatch) => {
     return dispatch(loadEntities());
 };
 
-export const filterProviders = (value) => ({
-    type: FILTER_PROVIDERS,
-    payload: { value }
-});
+export const filterProviders = (value) => (dispatch) => {
+    dispatch(({
+        type: FILTER_PROVIDERS,
+        payload: { value }
+    }));
+
+    return dispatch(loadEntities());
+};
 
 export const updateSource = (source, formData, title, description, errorTitles) => (dispatch) =>
     doUpdateSource(source, formData, errorTitles).then(_finished => dispatch({

--- a/src/redux/reducers/providers.js
+++ b/src/redux/reducers/providers.js
@@ -81,7 +81,8 @@ export const filterProviders = (state, { payload: { value } }) =>({
     filterValue: {
         ...state.filterValue,
         ...value
-    }
+    },
+    pageNumber: 1
 });
 
 const sourceEditRemovePending = (state, { meta }) => ({

--- a/src/test/redux/actions.spec.js
+++ b/src/test/redux/actions.spec.js
@@ -77,17 +77,19 @@ describe('redux actions', () => {
         );
     });
 
-    it('filterProviders creates an object', () => {
+    it('filterProviders creates an object', async () => {
         const filterValue = { name: 'name' };
 
-        expect(filterProviders(filterValue)).toEqual(
-            expect.objectContaining({
-                type: FILTER_PROVIDERS,
-                payload: {
-                    value: filterValue
-                }
-            })
-        );
+        await filterProviders(filterValue)(dispatch);
+
+        expect(dispatch.mock.calls).toHaveLength(2);
+        expect(dispatch.mock.calls[0][0]).toEqual({
+            type: FILTER_PROVIDERS,
+            payload: {
+                value: filterValue
+            }
+        });
+        expect(dispatch.mock.calls[1][0]).toEqual(expect.any(Function));
     });
 
     describe('updateSource', () => {

--- a/src/test/redux/reducer.spec.js
+++ b/src/test/redux/reducer.spec.js
@@ -64,13 +64,29 @@ describe('redux > sources reducer', () => {
     });
 
     describe('filterProviders', () => {
+        const value = { name: 'name' };
+
         it('sets filter value', () => {
-            const value = { name: 'name' };
             expect(filterProviders(defaultProvidersState, { payload: { value } })).toEqual({
                 ...defaultProvidersState,
                 filterValue: {
                     name: 'name'
                 }
+            });
+        });
+
+        it('switch to the first page', () => {
+            const stateOnSecondPage = {
+                ...defaultProvidersState,
+                pageNumber: 12
+            };
+
+            expect(filterProviders(stateOnSecondPage, { payload: { value } })).toEqual({
+                ...defaultProvidersState,
+                filterValue: {
+                    name: 'name'
+                },
+                pageNumber: 1
             });
         });
     });


### PR DESCRIPTION
**Description**

- refresh sources after filtering is handled by redux
- when filtering, pageNumber is set to 1, so it shows correctly paginated results