### PR TITLE
Send to endpoint API when editing url

### DIFF
--- a/src/api/doUpdateSource.js
+++ b/src/api/doUpdateSource.js
@@ -32,7 +32,7 @@ export const doUpdateSource = (source, formData, errorTitles) => {
         }));
     }
 
-    if (formData.endpoint) {
+    if (formData.endpoint || formData.url) {
         const { scheme, host, port, path } = urlOrHost(formData);
         const endPointPort = parseInt(port, 10);
 

--- a/src/test/api/doUpdateSource.spec.js
+++ b/src/test/api/doUpdateSource.spec.js
@@ -115,6 +115,23 @@ describe('doUpdateSource', () => {
         expect(authenticationSpy).not.toHaveBeenCalled();
     });
 
+    it('sends endpoint values only with URL', () => {
+        FORM_DATA = {
+            url: URL
+        };
+
+        const EXPECTED_ENDPOINT_VALUES_ONLY_WITH_URL = {
+            ...EXPECTED_URL_OBJECT,
+            port: Number(PORT)
+        };
+
+        doUpdateSource(SOURCE, FORM_DATA, ERROR_TITLES);
+
+        expect(sourceSpy).not.toHaveBeenCalled();
+        expect(endpointSpy).toHaveBeenCalledWith(ENDPOINT_ID, EXPECTED_ENDPOINT_VALUES_ONLY_WITH_URL);
+        expect(authenticationSpy).not.toHaveBeenCalled();
+    });
+
     it('sends authentication values', () => {
         const AUTH_ID = '1234234243';
         const AUTHENTICATION_VALUES = { password: '123456' };


### PR DESCRIPTION
@slemrmartin 

This should fix missing Endpoint's API call when editing URL values.