### PR TITLE
Allow editing Cluster Identifier for CM/Openshift

### DIFF
--- a/src/components/SourceEditForm/parser/parseSourceToSchema.js
+++ b/src/components/SourceEditForm/parser/parseSourceToSchema.js
@@ -7,7 +7,7 @@ export const parseSourceToSchema = (source, editing, setEdit, sourceType, appTyp
     fields: [
         ...genericInfo(editing, setEdit, source.source.id),
         ...authenticationFields(source.authentications, sourceType, editing, setEdit),
-        ...applicationsFields(source.applications, sourceType, editing, setEdit, appTypes, source.authentications),
-        endpointFields(sourceType, editing, setEdit)
+        ...applicationsFields(source.applications, sourceType, editing, setEdit, appTypes, source),
+        source.endpoints && source.endpoints.length > 0 ? endpointFields(sourceType, editing, setEdit) : false
     ].filter(Boolean)
 });

--- a/src/test/components/sourceEditForm/parseSourceToSchema.spec.js
+++ b/src/test/components/sourceEditForm/parseSourceToSchema.spec.js
@@ -1,5 +1,0 @@
-describe('parseSourceToSchema', () => {
-    it('ee', () => {
-        expect(true).toBe(true);
-    });
-});

--- a/src/test/components/sourceEditForm/parser/parseSourceToSchema.spec.js
+++ b/src/test/components/sourceEditForm/parser/parseSourceToSchema.spec.js
@@ -16,7 +16,8 @@ describe('parseSourceToSchema', () => {
         SOURCE = {
             source: { id: 'adsad' },
             authentications: [{ type: 'arn' }],
-            applications: []
+            applications: [],
+            endpoints: [{}]
         };
         EDITING = {};
         SET_EDIT = jest.fn();
@@ -72,13 +73,85 @@ describe('parseSourceToSchema', () => {
             EDITING,
             SET_EDIT,
             APP_TYPES,
-            SOURCE.authentications,
+            SOURCE,
         );
         expect(end.endpointFields).toHaveBeenCalledWith(
             SOURCE_TYPE,
             EDITING,
             SET_EDIT
         );
+    });
+
+    it('calls all subsections without endpoint', () => {
+        const SOURCE_WITH_NO_ENDPOINT = {
+            ...SOURCE,
+            endpoints: undefined
+        };
+
+        parseSourceToSchema(
+            SOURCE_WITH_NO_ENDPOINT,
+            EDITING,
+            SET_EDIT,
+            SOURCE_TYPE,
+            APP_TYPES
+        );
+
+        expect(gen.genericInfo).toHaveBeenCalledWith(
+            EDITING,
+            SET_EDIT,
+            SOURCE.source.id
+        );
+        expect(auth.authenticationFields).toHaveBeenCalledWith(
+            SOURCE.authentications,
+            SOURCE_TYPE,
+            EDITING,
+            SET_EDIT
+        );
+        expect(app.applicationsFields).toHaveBeenCalledWith(
+            SOURCE.applications,
+            SOURCE_TYPE,
+            EDITING,
+            SET_EDIT,
+            APP_TYPES,
+            SOURCE_WITH_NO_ENDPOINT,
+        );
+        expect(end.endpointFields).not.toHaveBeenCalled();
+    });
+
+    it('calls all subsections without endpoint of empty array', () => {
+        const SOURCE_WITH_NO_ENDPOINT = {
+            ...SOURCE,
+            endpoints: []
+        };
+
+        parseSourceToSchema(
+            SOURCE_WITH_NO_ENDPOINT,
+            EDITING,
+            SET_EDIT,
+            SOURCE_TYPE,
+            APP_TYPES
+        );
+
+        expect(gen.genericInfo).toHaveBeenCalledWith(
+            EDITING,
+            SET_EDIT,
+            SOURCE.source.id
+        );
+        expect(auth.authenticationFields).toHaveBeenCalledWith(
+            SOURCE.authentications,
+            SOURCE_TYPE,
+            EDITING,
+            SET_EDIT
+        );
+        expect(app.applicationsFields).toHaveBeenCalledWith(
+            SOURCE.applications,
+            SOURCE_TYPE,
+            EDITING,
+            SET_EDIT,
+            APP_TYPES,
+            SOURCE_WITH_NO_ENDPOINT,
+        );
+        expect(end.endpointFields).not.toHaveBeenCalled();
     });
 
     it('returns filtered fields', () => {


### PR DESCRIPTION
Closes #179 

Allows editing Clusted Identifier when Cost Management + Openshift type

![image](https://user-images.githubusercontent.com/32869456/70610135-508b2f80-1c03-11ea-8113-2236ad822e32.png)

@dccurtis