### PR TITLE
Do not edit not-auth names in authentication edit form

### DIFF
--- a/src/components/SourceEditForm/parser/authentication.js
+++ b/src/components/SourceEditForm/parser/authentication.js
@@ -21,7 +21,7 @@ export const getAdditionalAuthSteps = (sourceType, authtype) =>
     get(hardcodedSchemas, [sourceType, 'authentication', authtype, 'generic', 'includeStepKeyFields'], []);
 
 export const modifyAuthSchemas = (fields, id, editing, setEdit) => fields.map((field) => {
-    const editedName = createAuthFieldName(field.name, id);
+    const editedName = field.name.startsWith('authentication') ? createAuthFieldName(field.name, id) : field.name;
     const isEditing = editing[editedName];
 
     const finalField = ({

--- a/src/test/components/sourceEditForm/parser/authentication.spec.js
+++ b/src/test/components/sourceEditForm/parser/authentication.spec.js
@@ -105,7 +105,7 @@ describe('authentication edit source parser', () => {
         let FIELD_NAME;
 
         beforeEach(() => {
-            FIELD_NAME = 'sasas';
+            FIELD_NAME = 'authentication.sasas';
             FIELDS = [
                 { name: FIELD_NAME, component: componentTypes.TEXT_FIELD }
             ];
@@ -130,6 +130,28 @@ describe('authentication edit source parser', () => {
                 ...FIELDS[0],
                 component: EDIT_FIELD_NAME,
                 name: createAuthFieldName(FIELD_NAME, ID),
+                setEdit: SET_EDIT
+            }]);
+        });
+
+        it('does not change name for non-authentication values', () => {
+            const NOT_AUTH_NAME = 'source.source_ref';
+
+            FIELDS = [
+                { name: NOT_AUTH_NAME, component: componentTypes.TEXT_FIELD }
+            ];
+
+            const result = modifyAuthSchemas(
+                FIELDS,
+                ID,
+                EDITING,
+                SET_EDIT
+            );
+
+            expect(result).toEqual([{
+                ...FIELDS[0],
+                component: EDIT_FIELD_NAME,
+                name: NOT_AUTH_NAME,
                 setEdit: SET_EDIT
             }]);
         });


### PR DESCRIPTION
Since Sattelite ID contains `source.source_ref` in its authentication schema, these values' names need to be unchanged and sent to the right API endpoint.