### PR TITLE
Fetch and update cost management values in edit

### DIFF
--- a/src/api/doLoadSourceForEdit.js
+++ b/src/api/doLoadSourceForEdit.js
@@ -1,0 +1,34 @@
+import { getSourcesApi } from './entities';
+import { getCmValues } from './getCmValues';
+
+export const doLoadSourceForEdit = sourceId => Promise.all([
+    getSourcesApi().showSource(sourceId),
+    getSourcesApi().listSourceEndpoints(sourceId),
+    getSourcesApi().listSourceApplications(sourceId),
+    getCmValues(sourceId).catch(() => undefined)
+]).then(([sourceData, endpoints, applications, costManagement]) => {
+    const endpoint = endpoints && endpoints.data && endpoints.data[0];
+
+    let basicValues = {
+        source: sourceData,
+        applications: applications.data
+    };
+
+    if (costManagement) {
+        basicValues = {
+            ...basicValues,
+            billing_source: costManagement.billing_source,
+            credentials: costManagement.authentication
+        };
+    }
+
+    if (!endpoint) { // bail out
+        return basicValues;
+    }
+
+    return getSourcesApi().listEndpointAuthentications(endpoint.id).then(authentications => ({
+        ...basicValues,
+        endpoints: endpoints.data,
+        authentications: authentications.data
+    }));
+});

--- a/src/api/doUpdateSource.js
+++ b/src/api/doUpdateSource.js
@@ -1,5 +1,6 @@
 import { defaultPort } from '../components/SourcesSimpleView/formatters';
 import { getSourcesApi } from './entities';
+import { patchCmValues } from './patchCmValues';
 
 export const parseUrl = url => {
     if (!url) {
@@ -57,6 +58,27 @@ export const doUpdateSource = (source, formData, errorTitles) => {
                 throw { error: { title: errorTitles.authentication, detail: error.errors[0].detail } };
             }));
         });
+    }
+
+    if (formData.billing_source || formData.credentials) {
+        let cmDataOut = {};
+
+        if (formData.credentials) {
+            cmDataOut = {
+                credentials: formData.credentials
+            };
+        }
+
+        if (formData.billing_source) {
+            cmDataOut = {
+                ...cmDataOut,
+                billing_source: formData.billing_source
+            };
+        }
+
+        promises.push(patchCmValues(source.source.id, cmDataOut).catch((error) => {
+            throw { error: { title: errorTitles.costManagement, detail: error.errors[0].detail } };
+        }));
     }
 
     return Promise.all(promises);

--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -25,28 +25,6 @@ export const doRemoveSource = (sourceId) => getSourcesApi().deleteSource(sourceI
     throw { error: { detail: error.errors[0].detail } };
 });
 
-export const doLoadSourceForEdit = sourceId => Promise.all([
-    getSourcesApi().showSource(sourceId),
-    getSourcesApi().listSourceEndpoints(sourceId),
-    getSourcesApi().listSourceApplications(sourceId)
-]).then(([sourceData, endpoints, applications]) => {
-    const endpoint = endpoints && endpoints.data && endpoints.data[0];
-
-    if (!endpoint) { // bail out
-        return {
-            source: sourceData,
-            applications: applications.data
-        };
-    }
-
-    return getSourcesApi().listEndpointAuthentications(endpoint.id).then(authentications => ({
-        source: sourceData,
-        endpoints: endpoints.data,
-        authentications: authentications.data,
-        applications: applications.data
-    }));
-});
-
 export const pagination = (pageSize, pageNumber) =>
     `limit:${pageSize}, offset:${(pageNumber - 1) * pageSize}`;
 

--- a/src/api/getCmValues.js
+++ b/src/api/getCmValues.js
@@ -1,0 +1,4 @@
+import { axiosInstance } from './entities';
+import { COST_MANAGEMENT_API_BASE } from './constants';
+
+export const getCmValues = (id) => axiosInstance.get(`${COST_MANAGEMENT_API_BASE}/sources/${id}/`);

--- a/src/api/patchCmValues.js
+++ b/src/api/patchCmValues.js
@@ -1,0 +1,4 @@
+import { axiosInstance } from './entities';
+import { COST_MANAGEMENT_API_BASE } from './constants';
+
+export const patchCmValues = (id, data) => axiosInstance.patch(`${COST_MANAGEMENT_API_BASE}/sources/${id}/`, data);

--- a/src/components/SourceEditForm/SourceEditModal.js
+++ b/src/components/SourceEditForm/SourceEditModal.js
@@ -8,7 +8,7 @@ import { layoutMapper } from '@data-driven-forms/pf4-component-mapper';
 
 import SourcesFormRenderer from '../../Utilities/SourcesFormRenderer';
 import { parseSourceToSchema } from './parser/parseSourceToSchema';
-import { doLoadSourceForEdit } from '../../api/entities';
+import { doLoadSourceForEdit } from '../../api/doLoadSourceForEdit';
 import HorizontalFormWrapper from './HorizontalFormWrapper';
 import Header from './Header';
 import { prepareInitialValues } from './helpers';

--- a/src/components/SourceEditForm/helpers.js
+++ b/src/components/SourceEditForm/helpers.js
@@ -15,7 +15,7 @@ export const selectOnlyEditedValues = (values, editing) => {
     return filteredValues;
 };
 
-export const prepareInitialValues = ({ source, endpoints, authentications }, sourceTypeName) => {
+export const prepareInitialValues = ({ endpoints, authentications, ...rest }, sourceTypeName) => {
     const auhenticationsFinal = {};
 
     if (authentications && authentications.length > 0) {
@@ -36,10 +36,10 @@ export const prepareInitialValues = ({ source, endpoints, authentications }, sou
     }
 
     return ({
-        source,
         source_type: sourceTypeName,
         endpoint,
         authentications: auhenticationsFinal,
-        url
+        url,
+        ...rest
     });
 };

--- a/src/components/SourceEditForm/onSubmit.js
+++ b/src/components/SourceEditForm/onSubmit.js
@@ -25,6 +25,10 @@ export const onSubmit = (values, editing, dispatch, source, intl, push) => dispa
         endpoint: intl.formatMessage({
             id: 'sources.sourceEditEndpointFailure',
             defaultMessage: 'Endpoint update failure.'
+        }),
+        costManagement: intl.formatMessage({
+            id: 'sources.sourceCostmanagementFailure',
+            defaultMessage: 'Cost Management update failure.'
         })
     }))
 .then(() => {

--- a/src/test/api/doLoadSourceForEdit.spec.js
+++ b/src/test/api/doLoadSourceForEdit.spec.js
@@ -1,0 +1,171 @@
+import * as api from '../../api/entities';
+import * as cmApi from '../../api/getCmValues';
+import { doLoadSourceForEdit } from '../../api/doLoadSourceForEdit';
+
+describe('doLoadSourceForEdit', () => {
+    const SOURCE_ID = '2324232321';
+    let mocks;
+
+    const SOURCE_DATA = {
+        name: 'source',
+        created_at: '12-12-2022'
+    };
+
+    const EMPTY_DATA = {
+        data: []
+    };
+
+    const ENDPOINT_ID = '8643928983';
+
+    const ENDPOINT_DATA = {
+        data: [{
+            id: ENDPOINT_ID,
+            receptor_node: 'node',
+            scheme: 'https://',
+            port: 6578
+        }]
+    };
+
+    const AUTHENTICATION_DATA = {
+        data: [{
+            id: '2323',
+            authtype: 'receptor_node'
+        }]
+    };
+
+    const CM_SOURCE_DATA = {
+        name: 'name',
+        billing_source: {
+            bucket: 'nugget'
+        },
+        authentication: {
+            subscription: '23234232'
+        }
+    };
+
+    beforeEach(() => {
+        mocks = {
+            showSource: jest.fn().mockImplementation(() => Promise.resolve(SOURCE_DATA)),
+            listSourceEndpoints: jest.fn().mockImplementation(() => Promise.resolve(EMPTY_DATA)),
+            listSourceApplications: jest.fn().mockImplementation(() => Promise.resolve(EMPTY_DATA)),
+            listEndpointAuthentications: jest.fn().mockImplementation(() => Promise.resolve(EMPTY_DATA))
+        };
+
+        api.getSourcesApi = () => mocks;
+        cmApi.getCmValues = jest.fn().mockImplementation(() => Promise.reject());
+    });
+
+    it('return source without endpoint', async () => {
+        const result = await doLoadSourceForEdit(SOURCE_ID);
+
+        expect(mocks.showSource).toHaveBeenCalledWith(SOURCE_ID);
+        expect(mocks.listSourceEndpoints).toHaveBeenCalledWith(SOURCE_ID);
+        expect(mocks.listSourceApplications).toHaveBeenCalledWith(SOURCE_ID);
+        expect(cmApi.getCmValues).toHaveBeenCalledWith(SOURCE_ID);
+        expect(mocks.listEndpointAuthentications).not.toHaveBeenCalled();
+
+        expect(result).toEqual({
+            source: SOURCE_DATA,
+            applications: []
+        });
+    });
+
+    it('return source without endpoint and with applications', async () => {
+        const APPLICATION_DATA = {
+            data: [{
+                id: '2323322'
+            }]
+        };
+
+        mocks = {
+            ...mocks,
+            listSourceApplications: jest.fn().mockImplementation(() => Promise.resolve(APPLICATION_DATA))
+        };
+
+        api.getSourcesApi = () => mocks;
+
+        const result = await doLoadSourceForEdit(SOURCE_ID);
+
+        expect(mocks.showSource).toHaveBeenCalledWith(SOURCE_ID);
+        expect(mocks.listSourceEndpoints).toHaveBeenCalledWith(SOURCE_ID);
+        expect(mocks.listSourceApplications).toHaveBeenCalledWith(SOURCE_ID);
+        expect(cmApi.getCmValues).toHaveBeenCalledWith(SOURCE_ID);
+        expect(mocks.listEndpointAuthentications).not.toHaveBeenCalled();
+
+        expect(result).toEqual({
+            source: SOURCE_DATA,
+            applications: APPLICATION_DATA.data
+        });
+    });
+
+    it('return source with endpoint and auth', async () => {
+        mocks = {
+            ...mocks,
+            listSourceEndpoints: jest.fn().mockImplementation(() => Promise.resolve(ENDPOINT_DATA)),
+            listEndpointAuthentications: jest.fn().mockImplementation(() => Promise.resolve(AUTHENTICATION_DATA))
+        };
+
+        api.getSourcesApi = () => mocks;
+
+        const result = await doLoadSourceForEdit(SOURCE_ID);
+
+        expect(mocks.showSource).toHaveBeenCalledWith(SOURCE_ID);
+        expect(mocks.listSourceEndpoints).toHaveBeenCalledWith(SOURCE_ID);
+        expect(mocks.listSourceApplications).toHaveBeenCalledWith(SOURCE_ID);
+        expect(cmApi.getCmValues).toHaveBeenCalledWith(SOURCE_ID);
+        expect(mocks.listEndpointAuthentications).toHaveBeenCalledWith(ENDPOINT_ID);
+
+        expect(result).toEqual({
+            source: SOURCE_DATA,
+            applications: [],
+            endpoints: ENDPOINT_DATA.data,
+            authentications: AUTHENTICATION_DATA.data
+        });
+    });
+
+    it('return source with cost management values', async () => {
+        cmApi.getCmValues = jest.fn().mockImplementation(() => Promise.resolve(CM_SOURCE_DATA));
+
+        const result = await doLoadSourceForEdit(SOURCE_ID);
+
+        expect(mocks.showSource).toHaveBeenCalledWith(SOURCE_ID);
+        expect(mocks.listSourceEndpoints).toHaveBeenCalledWith(SOURCE_ID);
+        expect(mocks.listSourceApplications).toHaveBeenCalledWith(SOURCE_ID);
+        expect(cmApi.getCmValues).toHaveBeenCalledWith(SOURCE_ID);
+        expect(mocks.listEndpointAuthentications).not.toHaveBeenCalled();
+
+        expect(result).toEqual({
+            source: SOURCE_DATA,
+            applications: [],
+            billing_source: CM_SOURCE_DATA.billing_source,
+            credentials: CM_SOURCE_DATA.authentication
+        });
+    });
+
+    it('return source with cost management values and endpoint', async () => {
+        mocks = {
+            ...mocks,
+            listSourceEndpoints: jest.fn().mockImplementation(() => Promise.resolve(ENDPOINT_DATA)),
+            listEndpointAuthentications: jest.fn().mockImplementation(() => Promise.resolve(AUTHENTICATION_DATA))
+        };
+        api.getSourcesApi = () => mocks;
+        cmApi.getCmValues = jest.fn().mockImplementation(() => Promise.resolve(CM_SOURCE_DATA));
+
+        const result = await doLoadSourceForEdit(SOURCE_ID);
+
+        expect(mocks.showSource).toHaveBeenCalledWith(SOURCE_ID);
+        expect(mocks.listSourceEndpoints).toHaveBeenCalledWith(SOURCE_ID);
+        expect(mocks.listSourceApplications).toHaveBeenCalledWith(SOURCE_ID);
+        expect(cmApi.getCmValues).toHaveBeenCalledWith(SOURCE_ID);
+        expect(mocks.listEndpointAuthentications).toHaveBeenCalledWith(ENDPOINT_ID);
+
+        expect(result).toEqual({
+            source: SOURCE_DATA,
+            applications: [],
+            billing_source: CM_SOURCE_DATA.billing_source,
+            credentials: CM_SOURCE_DATA.authentication,
+            endpoints: ENDPOINT_DATA.data,
+            authentications: AUTHENTICATION_DATA.data
+        });
+    });
+});

--- a/src/test/api/doUpdateSource.spec.js
+++ b/src/test/api/doUpdateSource.spec.js
@@ -1,5 +1,6 @@
 import * as api from '../../api/entities';
 import { doUpdateSource, parseUrl, urlOrHost } from '../../api/doUpdateSource';
+import * as cmApi from '../../api/patchCmValues';
 
 describe('doUpdateSource', () => {
     const HOST = 'mycluster.net';
@@ -29,7 +30,8 @@ describe('doUpdateSource', () => {
     const ERROR_TITLES = {
         authentication: 'authentication error',
         source: 'source error',
-        endpoint: 'endpoint error'
+        endpoint: 'endpoint error',
+        costManagement: 'cost management error'
     };
 
     let FORM_DATA;
@@ -37,23 +39,27 @@ describe('doUpdateSource', () => {
     let sourceSpy;
     let endpointSpy;
     let authenticationSpy;
+    let patchCostManagementSpy;
 
     beforeEach(() => {
         sourceSpy = jest.fn().mockImplementation(() => Promise.resolve('ok'));
         endpointSpy = jest.fn().mockImplementation(() => Promise.resolve('ok'));
         authenticationSpy = jest.fn().mockImplementation(() => Promise.resolve('ok'));
+        patchCostManagementSpy = jest.fn().mockImplementation(() => Promise.resolve('ok'));
 
         api.getSourcesApi = () => ({
             updateSource: sourceSpy,
             updateEndpoint: endpointSpy,
             updateAuthentication: authenticationSpy
         });
+        cmApi.patchCmValues = patchCostManagementSpy;
     });
 
     afterEach(() => {
         sourceSpy.mockReset();
         endpointSpy.mockReset();
         authenticationSpy.mockReset();
+        patchCostManagementSpy.mockReset();
     });
 
     it('sends nothing', () => {
@@ -64,6 +70,7 @@ describe('doUpdateSource', () => {
         expect(sourceSpy).not.toHaveBeenCalled();
         expect(endpointSpy).not.toHaveBeenCalled();
         expect(authenticationSpy).not.toHaveBeenCalled();
+        expect(patchCostManagementSpy).not.toHaveBeenCalled();
     });
 
     it('sends source values', () => {
@@ -78,6 +85,7 @@ describe('doUpdateSource', () => {
         expect(sourceSpy).toHaveBeenCalledWith(SOURCE_ID, SOURCE_VALUES);
         expect(endpointSpy).not.toHaveBeenCalled();
         expect(authenticationSpy).not.toHaveBeenCalled();
+        expect(patchCostManagementSpy).not.toHaveBeenCalled();
     });
 
     it('sends endpoint values', () => {
@@ -92,6 +100,7 @@ describe('doUpdateSource', () => {
         expect(sourceSpy).not.toHaveBeenCalled();
         expect(endpointSpy).toHaveBeenCalledWith(ENDPOINT_ID, ENDPOINT_VALUES);
         expect(authenticationSpy).not.toHaveBeenCalled();
+        expect(patchCostManagementSpy).not.toHaveBeenCalled();
     });
 
     it('sends endpoint values with URL', () => {
@@ -113,6 +122,7 @@ describe('doUpdateSource', () => {
         expect(sourceSpy).not.toHaveBeenCalled();
         expect(endpointSpy).toHaveBeenCalledWith(ENDPOINT_ID, EXPECTED_ENDPOINT_VALUES_WITH_URL);
         expect(authenticationSpy).not.toHaveBeenCalled();
+        expect(patchCostManagementSpy).not.toHaveBeenCalled();
     });
 
     it('sends endpoint values only with URL', () => {
@@ -130,6 +140,7 @@ describe('doUpdateSource', () => {
         expect(sourceSpy).not.toHaveBeenCalled();
         expect(endpointSpy).toHaveBeenCalledWith(ENDPOINT_ID, EXPECTED_ENDPOINT_VALUES_ONLY_WITH_URL);
         expect(authenticationSpy).not.toHaveBeenCalled();
+        expect(patchCostManagementSpy).not.toHaveBeenCalled();
     });
 
     it('sends authentication values', () => {
@@ -145,6 +156,7 @@ describe('doUpdateSource', () => {
         expect(sourceSpy).not.toHaveBeenCalled();
         expect(endpointSpy).not.toHaveBeenCalled();
         expect(authenticationSpy).toHaveBeenCalledWith(AUTH_ID, AUTHENTICATION_VALUES);
+        expect(patchCostManagementSpy).not.toHaveBeenCalled();
     });
 
     it('sends multiple authentication values', () => {
@@ -164,6 +176,7 @@ describe('doUpdateSource', () => {
 
         expect(sourceSpy).not.toHaveBeenCalled();
         expect(endpointSpy).not.toHaveBeenCalled();
+        expect(patchCostManagementSpy).not.toHaveBeenCalled();
 
         expect(authenticationSpy.mock.calls.length).toEqual(Object.keys(FORM_DATA.authentications).length);
 
@@ -172,6 +185,58 @@ describe('doUpdateSource', () => {
 
         expect(authenticationSpy.mock.calls[1][0]).toBe(AUTH_ID_2);
         expect(authenticationSpy.mock.calls[1][1]).toBe(AUTHENTICATION_VALUES_2);
+    });
+
+    describe('cost management endpoint', () => {
+        const BILLING_SOURCE_VALUES = { bucket: '123456' };
+        const CREDENTIALS_VALUES = { subscription_id: '123456' };
+
+        it('sends billing_source values', () => {
+            FORM_DATA = {
+                billing_source: BILLING_SOURCE_VALUES
+            };
+
+            const EXPECTED_CM_DATA = { ...FORM_DATA };
+
+            doUpdateSource(SOURCE, FORM_DATA, ERROR_TITLES);
+
+            expect(sourceSpy).not.toHaveBeenCalled();
+            expect(endpointSpy).not.toHaveBeenCalled();
+            expect(authenticationSpy).not.toHaveBeenCalled();
+            expect(patchCostManagementSpy).toHaveBeenCalledWith(SOURCE_ID, EXPECTED_CM_DATA);
+        });
+
+        it('sends credentials values', () => {
+            FORM_DATA = {
+                credentials: CREDENTIALS_VALUES
+            };
+
+            const EXPECTED_CM_DATA = { ...FORM_DATA };
+
+            doUpdateSource(SOURCE, FORM_DATA, ERROR_TITLES);
+
+            expect(sourceSpy).not.toHaveBeenCalled();
+            expect(endpointSpy).not.toHaveBeenCalled();
+            expect(authenticationSpy).not.toHaveBeenCalled();
+            expect(patchCostManagementSpy).toHaveBeenCalledWith(SOURCE_ID, EXPECTED_CM_DATA);
+        });
+
+        it('sends credentials + billing_source values', () => {
+            FORM_DATA = {
+                billing_source: BILLING_SOURCE_VALUES,
+                credentials: CREDENTIALS_VALUES
+            };
+
+            const EXPECTED_CM_DATA = { ...FORM_DATA };
+
+            doUpdateSource(SOURCE, FORM_DATA, ERROR_TITLES);
+
+            expect(sourceSpy).not.toHaveBeenCalled();
+            expect(endpointSpy).not.toHaveBeenCalled();
+            expect(authenticationSpy).not.toHaveBeenCalled();
+            expect(patchCostManagementSpy).toHaveBeenCalledWith(SOURCE_ID, EXPECTED_CM_DATA);
+        });
+
     });
 
     describe('failures', () => {
@@ -198,6 +263,7 @@ describe('doUpdateSource', () => {
 
             try {
                 await doUpdateSource(SOURCE, FORM_DATA, ERROR_TITLES);
+                throw ('should not be here');
             } catch (error) {
                 expect(error).toEqual(EXPECTED_ERROR);
             }
@@ -219,6 +285,7 @@ describe('doUpdateSource', () => {
 
             try {
                 await doUpdateSource(SOURCE, FORM_DATA, ERROR_TITLES);
+                throw ('should not be here');
             } catch (error) {
                 expect(error).toEqual(EXPECTED_ERROR);
             }
@@ -241,6 +308,27 @@ describe('doUpdateSource', () => {
 
             try {
                 await doUpdateSource(SOURCE, FORM_DATA, ERROR_TITLES);
+                throw ('should not be here');
+            } catch (error) {
+                expect(error).toEqual(EXPECTED_ERROR);
+            }
+        });
+
+        it('handle CM failure', async () => {
+            cmApi.patchCmValues = jest.fn().mockImplementation(() => Promise.reject(ERROR_OBJECT));
+
+            const EXPECTED_ERROR = { error: {
+                detail: ERROR_TEXT,
+                title: ERROR_TITLES.costManagement
+            } };
+
+            FORM_DATA = {
+                billing_source: { bucket: 'aaa' }
+            };
+
+            try {
+                await doUpdateSource(SOURCE, FORM_DATA, ERROR_TITLES);
+                throw ('should not be here');
             } catch (error) {
                 expect(error).toEqual(EXPECTED_ERROR);
             }

--- a/src/test/components/sourceEditForm/SourceEditModal.spec.js
+++ b/src/test/components/sourceEditForm/SourceEditModal.spec.js
@@ -14,7 +14,7 @@ import { applicationTypesData } from '../../applicationTypesData';
 import { sourceTypesData, OPENSHIFT_ID } from '../../sourceTypesData';
 import { sourcesDataGraphQl } from '../../sourcesData';
 import { Modal, Button, FormGroup, TextInput } from '@patternfly/react-core';
-import * as api from '../../../api/entities';
+import * as editApi from '../../../api/doLoadSourceForEdit';
 import EditFieldProvider from '../../../components/editField/EditField';
 import * as submit from '../../../components/SourceEditForm/onSubmit';
 import * as redirect from '../../../components/SourceEditForm/importedRedirect';
@@ -54,7 +54,7 @@ describe('SourceEditModal', () => {
             }
         });
 
-        api.doLoadSourceForEdit = jest.fn().mockImplementation(() => Promise.resolve({
+        editApi.doLoadSourceForEdit = jest.fn().mockImplementation(() => Promise.resolve({
             source: {
                 name: 'Name',
                 source_type_id: OPENSHIFT_ID
@@ -88,7 +88,7 @@ describe('SourceEditModal', () => {
 
         redirect.redirectWhenImported = jest.fn();
 
-        api.doLoadSourceForEdit = jest.fn().mockImplementation(() => Promise.resolve({
+        editApi.doLoadSourceForEdit = jest.fn().mockImplementation(() => Promise.resolve({
             source: {
                 name: SOURCE_NAME,
                 source_type_id: OPENSHIFT_ID,

--- a/src/test/components/sourceEditForm/helpers.spec.js
+++ b/src/test/components/sourceEditForm/helpers.spec.js
@@ -127,5 +127,21 @@ describe('edit form helpers', () => {
 
             expect(prepareInitialValues(SOURCE_WITH_UNDEF_ENDPOINTS, SOURCE_TYPE_NAME)).toEqual(EXPECTED_INITIAL_VALUES_WITH_UNDEF_ENDPOINTS);
         });
+
+        it('prepares initial values with cost management values', () => {
+            const SOURCE_WITH_UNDEF_ENDPOINTS = {
+                ...SOURCE,
+                billing_source: { bucket: 'bucket' },
+                credentials: { subscription_id: '122' }
+            };
+
+            const EXPECTED_INITIAL_VALUES_WITH_UNDEF_ENDPOINTS = {
+                ...EXPECTED_INITIAL_VALUES,
+                billing_source: { bucket: 'bucket' },
+                credentials: { subscription_id: '122' }
+            };
+
+            expect(prepareInitialValues(SOURCE_WITH_UNDEF_ENDPOINTS, SOURCE_TYPE_NAME)).toEqual(EXPECTED_INITIAL_VALUES_WITH_UNDEF_ENDPOINTS);
+        });
     });
 });

--- a/src/test/components/sourceEditForm/onSubmit.spec.js
+++ b/src/test/components/sourceEditForm/onSubmit.spec.js
@@ -66,7 +66,8 @@ describe('editSourceModal - on submit', () => {
             {
                 authentication: EXPECTED_TRANSLATED_MESSAGE,
                 source: EXPECTED_TRANSLATED_MESSAGE,
-                endpoint: EXPECTED_TRANSLATED_MESSAGE
+                endpoint: EXPECTED_TRANSLATED_MESSAGE,
+                costManagement: EXPECTED_TRANSLATED_MESSAGE
             }
         );
         expect(PUSH).toHaveBeenCalledWith(paths.sources);


### PR DESCRIPTION
closes #187 

- Fetches cost management values in edit form
- Updates these values after the submit (via PATCH request)
- Also adds tests for fetching all edit data

![cmedit](https://user-images.githubusercontent.com/32869456/70798358-02af2c80-1da7-11ea-8076-c70d07fa0fd2.gif)