### PR TITLE
Fix missing aria-label on Filter by name

### DIFF
--- a/src/pages/SourcesPage.js
+++ b/src/pages/SourcesPage.js
@@ -105,6 +105,10 @@ const SourcesPage = () => {
                             defaultMessage: 'Name'
                         }),
                         filterValues: {
+                            'aria-label': intl.formatMessage({
+                                id: 'sources.filterByName',
+                                defaultMessage: 'Filter by name'
+                            }),
                             onChange: (_event, value) => {
                                 setFilterValue(value);
                                 debouncedFiltering(() => setFilter('name', value, dispatch));


### PR DESCRIPTION
Fixes JS warning:

```
Text input: Text input requires either an id or aria-label to be specified
```