### PR TITLE
Update submit handling in edit form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1428,9 +1428,9 @@
       }
     },
     "@data-driven-forms/pf4-component-mapper": {
-      "version": "1.23.7",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/pf4-component-mapper/-/pf4-component-mapper-1.23.7.tgz",
-      "integrity": "sha512-yjfJXlWKxWatP8n+sRI9W5Nmv3Y6Z/Godqlf24yftpAJt+h2MwDRKchVqZihgAgMkrNboEYxJuQHuw4NBjYAQg==",
+      "version": "1.23.8",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/pf4-component-mapper/-/pf4-component-mapper-1.23.8.tgz",
+      "integrity": "sha512-4AOCox33w+gerlGqmMUg9qCVFMdTd4LvpYWTJRQRujXY6wXl7NfxwqS5Zr4JsCKzW6VZdcdx/tcKVeuyuAJJsg==",
       "requires": {
         "@patternfly/patternfly-next": "^1.0.175",
         "react-final-form-arrays": "2.0.3",
@@ -1438,9 +1438,9 @@
       }
     },
     "@data-driven-forms/react-form-renderer": {
-      "version": "1.23.7",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/react-form-renderer/-/react-form-renderer-1.23.7.tgz",
-      "integrity": "sha512-he4F2sDz8huzXLG9+mehptfvGaewAICg9sbp/IDD0QopZgQ4DH8+hARa+8cM/zMLUy5yMpPpHRvgv5ieUn9uJA==",
+      "version": "1.23.8",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/react-form-renderer/-/react-form-renderer-1.23.8.tgz",
+      "integrity": "sha512-66Gb1RcFt4+YNpGEXbD1TWe0ZgfGygIrP3VIBtK+tTH2HQtyzc9c3IJ5YEYOPEfQDczE7Vt6XxdsqaKrsRJWIA==",
       "requires": {
         "final-form": "^4.12.0",
         "final-form-arrays": "^3.0.1",
@@ -2348,9 +2348,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components-sources": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-sources/-/frontend-components-sources-0.0.24.tgz",
-      "integrity": "sha512-U0LHuGv23kI3P19c84gDoJIRVRtGXN0nWzL1Oo5txMIdmMfx/cLKhczpCbhu0I/+B0WUQBOeR9IUUd0TqAKAXA==",
+      "version": "0.0.26",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-sources/-/frontend-components-sources-0.0.26.tgz",
+      "integrity": "sha512-P89C8po4GkC3VyeCjzHKUrrIwAjJg142Y2bz+OrN+OhhHmZh3YVHr7u0x4pdwrj3qx5MdUF5sqdxrBRosnxiEQ==",
       "requires": {
         "@data-driven-forms/pf4-component-mapper": "^1.23.0",
         "@data-driven-forms/react-form-renderer": "^1.23.0",

--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
     "appname": "sources"
   },
   "dependencies": {
-    "@data-driven-forms/pf4-component-mapper": "^1.23.7",
-    "@data-driven-forms/react-form-renderer": "^1.23.7",
+    "@data-driven-forms/pf4-component-mapper": "^1.23.8",
+    "@data-driven-forms/react-form-renderer": "^1.23.8",
     "@patternfly/react-core": "^3.124.1",
     "@patternfly/react-icons": "^3.14.25",
     "@patternfly/react-table": "^2.24.41",
     "@redhat-cloud-services/frontend-components": "^0.0.43",
     "@redhat-cloud-services/frontend-components-notifications": "^0.0.7",
-    "@redhat-cloud-services/frontend-components-sources": "^0.0.24",
+    "@redhat-cloud-services/frontend-components-sources": "^0.0.26",
     "@redhat-cloud-services/frontend-components-utilities": "^0.0.14",
     "@redhat-cloud-services/sources-client": "^1.0.45",
     "react": "^16.12.0",

--- a/src/Utilities/SourcesFormRenderer.js
+++ b/src/Utilities/SourcesFormRenderer.js
@@ -18,7 +18,8 @@ const SourcesFormRenderer = props => (
             'add-application-summary': AddApplicationSummary,
             'edit-field': EditField
         }}
-        {...props} />
+        {...props}
+    />
 );
 
 export default SourcesFormRenderer;

--- a/src/components/SourceEditForm/SourceEditModal.js
+++ b/src/components/SourceEditForm/SourceEditModal.js
@@ -126,6 +126,7 @@ const SourceEditModal = () => {
                     FormWrapper: HorizontalFormWrapper
                 }}
                 canReset
+                disableSubmit={['submitting']}
                 onReset={() => setState({ editing: {} })}
                 initialValues={initialValues}
                 buttonsLabels={{ submitLabel: intl.formatMessage({

--- a/src/components/SourceEditForm/onSubmit.js
+++ b/src/components/SourceEditForm/onSubmit.js
@@ -34,6 +34,4 @@ export const onSubmit = (values, editing, dispatch, source, intl, push) => dispa
 .then(() => {
     push(paths.sources);
     dispatch(loadEntities());
-}).catch(_error => {
-    push(paths.sources);
 });

--- a/src/redux/actions/providers.js
+++ b/src/redux/actions/providers.js
@@ -94,10 +94,14 @@ export const updateSource = (source, formData, title, description, errorTitles) 
             description,
             dismissable: true
         }
-    })).catch(error => dispatch({
-        type: 'FOOBAR_REJECTED',
-        payload: error
-    }));
+    })).catch(error => {
+        dispatch({
+            type: 'FOOBAR_REJECTED',
+            payload: error
+        });
+
+        throw error;
+    });
 
 export const addMessage = (title, variant, description, customId) => (dispatch) => dispatch({
     type: ADD_NOTIFICATION,

--- a/src/test/components/sourceEditForm/SourceEditModal.spec.js
+++ b/src/test/components/sourceEditForm/SourceEditModal.spec.js
@@ -215,6 +215,12 @@ describe('SourceEditModal', () => {
 
         expect(wrapper.find(EditFieldProvider)).toHaveLength(UNEDITED_FIELDS - 1);
 
+        await act(async() => {
+            wrapper.find('input').instance().value = 'new value';
+            wrapper.find('input').simulate('change');
+        });
+        wrapper.update();
+
         const resetButton = wrapper.find(Button).at(RESET_POS);
 
         await act(async() => {

--- a/src/test/components/sourceEditForm/onSubmit.spec.js
+++ b/src/test/components/sourceEditForm/onSubmit.spec.js
@@ -78,16 +78,20 @@ describe('editSourceModal - on submit', () => {
         actions.updateSource = jest.fn().mockImplementation(() => Promise.reject('FAILS'));
         actions.loadEntities = jest.fn();
 
-        await onSubmit(
-            VALUES,
-            EDITING,
-            DISPATCH,
-            SOURCE,
-            INTL,
-            PUSH
-        );
+        expect.assertions(2);
 
-        expect(PUSH).toHaveBeenCalledWith(paths.sources);
-        expect(actions.loadEntities).not.toHaveBeenCalled();
+        try {
+            await onSubmit(
+                VALUES,
+                EDITING,
+                DISPATCH,
+                SOURCE,
+                INTL,
+                PUSH
+            );
+        } catch {
+            expect(PUSH).not.toHaveBeenCalled();
+            expect(actions.loadEntities).not.toHaveBeenCalled();
+        }
     });
 });

--- a/src/test/redux/actions.spec.js
+++ b/src/test/redux/actions.spec.js
@@ -121,14 +121,18 @@ describe('redux actions', () => {
             const ERROR = { detail: 'blabla' };
             updateSourceApi.doUpdateSource = jest.fn().mockImplementation(() => Promise.reject(ERROR));
 
-            const result = await updateSource(SOURCE, FORM_DATA, TITLE, DESCRIPTION, ERROR_TTITLES)(dispatch);
-
-            expect(result).toEqual(
-                expect.objectContaining({
-                    type: 'FOOBAR_REJECTED',
-                    payload: ERROR
-                })
-            );
+            expect.assertions(2);
+            try {
+                await updateSource(SOURCE, FORM_DATA, TITLE, DESCRIPTION, ERROR_TTITLES)(dispatch);
+            } catch (error) {
+                expect(dispatch).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        type: 'FOOBAR_REJECTED',
+                        payload: ERROR
+                    })
+                );
+                expect(error).toEqual(ERROR);
+            }
         });
     });
 


### PR DESCRIPTION
When successful:
- submit button is disabled, when finished, user is redirected to the list

![succ](https://user-images.githubusercontent.com/32869456/71001410-876ab500-20dd-11ea-8c15-c078a21406de.gif)

When error:
- submit is disabled, when finished, an error toast is shown, user can fix it

![err](https://user-images.githubusercontent.com/32869456/71001449-9b161b80-20dd-11ea-8472-55b1f6cadf1b.gif)

TODO:
- [x] https://github.com/RedHatInsights/frontend-components/pull/307