### PR TITLE
Fix column width in row loader

### DIFF
--- a/src/components/SourcesSimpleView/loaders.js
+++ b/src/components/SourcesSimpleView/loaders.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { RowWrapper } from '@patternfly/react-table';
 import { RowLoader } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
+import { COLUMN_COUNT } from '../../views/sourcesViewDefinition';
 
 export const PlaceHolderTable = () => (
     <table className="sources-placeholder-table pf-m-compact ins-entity-table">
@@ -12,7 +13,7 @@ export const PlaceHolderTable = () => (
 );
 
 export const RowWrapperLoader = ({ row: { isDeleting, ...row }, ...initialProps }) => (isDeleting ?
-    <tr><td colSpan="5"><RowLoader /></td></tr> :
+    <tr><td colSpan={COLUMN_COUNT}><RowLoader /></td></tr> :
     <RowWrapper {...initialProps} row={row} className='ins-c-sources__row-vertical-centered'/>
 );
 

--- a/src/test/components/SourcesSimpleView/loaders.spec.js
+++ b/src/test/components/SourcesSimpleView/loaders.spec.js
@@ -5,6 +5,7 @@ import { RowWrapper } from '@patternfly/react-table';
 import { RowLoader } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
 
 import { PlaceHolderTable, RowWrapperLoader } from '../../../components/SourcesSimpleView/loaders';
+import { COLUMN_COUNT } from '../../../views/sourcesViewDefinition';
 
 describe('loaders', () => {
     describe('PlaceholderTable', () => {
@@ -34,6 +35,7 @@ describe('loaders', () => {
 
             expect(wrapper.find(RowLoader).length).toEqual(1);
             expect(wrapper.find(RowWrapper).length).toEqual(0);
+            expect(wrapper.find('td').props().colSpan).toEqual(COLUMN_COUNT);
         });
 
         it('renders rowWrapper when item is not deleting', () => {

--- a/src/views/sourcesViewDefinition.js
+++ b/src/views/sourcesViewDefinition.js
@@ -1,13 +1,5 @@
 export const sourcesViewDefinition = {
-    displayName: 'Sources',
-    url: '/sources/',
     columns: (intl) => ([{
-        title: null,
-        value: 'id'
-    }, {
-        title: null,
-        value: 'uid'
-    }, {
         title: intl.formatMessage({
             id: 'sources.name',
             defaultMessage: 'Name'
@@ -43,9 +35,6 @@ export const sourcesViewDefinition = {
         formatter: 'dateFormatter',
         sortable: true
     }, {
-        title: null,
-        value: 'tenant_id'
-    }, {
         hidden: true,
         value: 'imported',
         formatter: 'importedFormatter'
@@ -60,3 +49,8 @@ export const sourcesViewDefinition = {
         sortable: true
     }])
 };
+
+const KEBAB_COLUMN = 1;
+const COUNT_OF_COLUMNS = sourcesViewDefinition.columns({ formatMessage: () => '' }).length;
+
+export const COLUMN_COUNT = COUNT_OF_COLUMNS + KEBAB_COLUMN;


### PR DESCRIPTION
RowLoader was smaller, because `imported` and `status` column were added, however `colSpan` of the loader stayed the same. So, the `colSpan` is now counted automatically.