### PR TITLE
Prevent default of event on submit in edit form

### DIFF
--- a/src/components/SourceEditForm/HorizontalFormWrapper.js
+++ b/src/components/SourceEditForm/HorizontalFormWrapper.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Form } from '@patternfly/react-core';
 
-const HorizontalFormWrapper = ({ children }) => <Form isHorizontal>{children}</Form>;
+const HorizontalFormWrapper = ({ children }) => <Form isHorizontal onSubmit={(e) => e.preventDefault()}>{children}</Form>;
 
 HorizontalFormWrapper.propTypes = {
     children: PropTypes.node

--- a/src/test/components/sourceEditForm/HorizontalFormWrapper.spec.js
+++ b/src/test/components/sourceEditForm/HorizontalFormWrapper.spec.js
@@ -7,4 +7,16 @@ describe('horizontal form wrapper', () => {
 
         expect(wrapper.find(Form).props().isHorizontal).toEqual(true);
     });
+
+    it('calls preventDefault on submit', () => {
+        const wrapper = mount(<HorizontalFormWrapper />);
+
+        const mockEvent = {
+            preventDefault: jest.fn()
+        };
+
+        wrapper.find(Form).props().onSubmit(mockEvent);
+
+        expect(mockEvent.preventDefault).toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
Prevents default submit event on enter in source edit form

(workaround until this issue is fixed in DDF)