### PR TITLE
Add empty state for table when filtering is on

### DIFF
--- a/src/components/SourcesSimpleView/EmptyStateTable.js
+++ b/src/components/SourcesSimpleView/EmptyStateTable.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Bullseye, EmptyState, EmptyStateVariant, EmptyStateIcon, Title, EmptyStateBody, Button } from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
+import { FormattedMessage } from 'react-intl';
+import { useDispatch } from 'react-redux';
+
+import { clearFilters } from '../../redux/actions/providers';
+
+const EmptyStateTable = () => {
+    const dispatch = useDispatch();
+
+    return (
+        <Bullseye>
+            <EmptyState variant={EmptyStateVariant.small}>
+                <EmptyStateIcon icon={SearchIcon} />
+                <Title headingLevel="h2" size="lg">
+                    <FormattedMessage
+                        defaultMessage="No results found"
+                        id="sources.noResultsFoundTitle"
+                    />
+                </Title>
+                <EmptyStateBody>
+                    <FormattedMessage
+                        defaultMessage="No results match the filter criteria. Remove
+                    all filters or clear all filters to show results."
+                        id="sources.noResultsFoundDescription"
+                    />
+                </EmptyStateBody>
+                <Button variant="link" onClick={() => dispatch(clearFilters())}>
+                    <FormattedMessage
+                        defaultMessage="Clear all filters"
+                        id="sources.clearAllFilters"
+                    />
+                </Button>
+            </EmptyState>
+        </Bullseye>
+    );};
+
+export default EmptyStateTable;

--- a/src/redux/action-types-providers.js
+++ b/src/redux/action-types-providers.js
@@ -25,3 +25,4 @@ export const UNDO_ADD_SOURCE = 'UNDO_ADDD_SOURCE';
 export const CLEAR_ADD_SOURCE = 'CLEAR_ADD_SOURCE';
 export const SET_COUNT = 'SET_COUNT';
 export const ADD_HIDDEN_SOURCE = 'ADD_HIDDEN_SOURCE';
+export const CLEAR_FILTERS = 'CLEAR_FILTERS';

--- a/src/redux/actions/providers.js
+++ b/src/redux/actions/providers.js
@@ -8,7 +8,8 @@ import {
     UNDO_ADD_SOURCE,
     CLEAR_ADD_SOURCE,
     SET_COUNT,
-    ADD_HIDDEN_SOURCE
+    ADD_HIDDEN_SOURCE,
+    CLEAR_FILTERS
 } from '../action-types-providers';
 import {
     doLoadAppTypes,
@@ -186,3 +187,11 @@ export const addHiddenSource = (source) => ({
         source
     }
 });
+
+export const clearFilters = () => (dispatch) => {
+    dispatch({
+        type: CLEAR_FILTERS
+    });
+
+    return dispatch(loadEntities());
+};

--- a/src/redux/reducers/providers.js
+++ b/src/redux/reducers/providers.js
@@ -7,7 +7,8 @@ import {
     UNDO_ADD_SOURCE,
     CLEAR_ADD_SOURCE,
     SET_COUNT,
-    ADD_HIDDEN_SOURCE
+    ADD_HIDDEN_SOURCE,
+    CLEAR_FILTERS
 } from '../action-types-providers';
 
 export const defaultProvidersState = {
@@ -171,6 +172,12 @@ export const addHiddenSource = (state, { payload: { source } }) => ({
     ]
 });
 
+export const clearFilters = (state) =>({
+    ...state,
+    filterValue: {},
+    pageNumber: 1
+});
+
 export default {
     [ACTION_TYPES.LOAD_ENTITIES_PENDING]: entitiesPending,
     [ACTION_TYPES.LOAD_ENTITIES_FULFILLED]: entitiesLoaded,
@@ -194,5 +201,6 @@ export default {
     [CLEAR_ADD_SOURCE]: clearAddSource,
     [ADD_APP_TO_SOURCE]: addAppToSource,
     [SET_COUNT]: setCount,
-    [ADD_HIDDEN_SOURCE]: addHiddenSource
+    [ADD_HIDDEN_SOURCE]: addHiddenSource,
+    [CLEAR_FILTERS]: clearFilters
 };

--- a/src/test/components/SourcesSimpleView/EmptyStateTable.spec.js
+++ b/src/test/components/SourcesSimpleView/EmptyStateTable.spec.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Bullseye, Button, EmptyState, EmptyStateBody } from '@patternfly/react-core';
+
+import { componentWrapperIntl } from '../../../Utilities/testsHelpers';
+import EmptyStateTable from '../../../components/SourcesSimpleView/EmptyStateTable';
+import * as actions from '../../../redux/actions/providers';
+
+describe('EmptyStateTable', () => {
+    it('render correctly', () => {
+        const wrapper = mount(componentWrapperIntl(<EmptyStateTable />));
+
+        expect(wrapper.find(Bullseye)).toHaveLength(1);
+        expect(wrapper.find(Button)).toHaveLength(1);
+        expect(wrapper.find(EmptyState)).toHaveLength(1);
+        expect(wrapper.find(EmptyStateBody)).toHaveLength(1);
+    });
+
+    it('calls clear filters when click on button', () => {
+        actions.clearFilters = jest.fn().mockImplementation(() => ({ type: 'cosi' }));
+
+        const wrapper = mount(componentWrapperIntl(<EmptyStateTable />));
+
+        wrapper.find(Button).simulate('click');
+
+        expect(actions.clearFilters).toHaveBeenCalled();
+    });
+});

--- a/src/test/pages/SourcesPage.spec.js
+++ b/src/test/pages/SourcesPage.spec.js
@@ -20,6 +20,7 @@ import { componentWrapperIntl } from '../../Utilities/testsHelpers';
 import ReducersProviders, { defaultProvidersState } from '../../redux/reducers/providers';
 import * as api from '../../api/entities';
 import * as typesApi from '../../api/source_types';
+import EmptyStateTable from '../../components/SourcesSimpleView/EmptyStateTable';
 
 describe('SourcesPage', () => {
     const middlewares = [thunk, notificationsMiddleware()];
@@ -189,6 +190,31 @@ describe('SourcesPage', () => {
 
                 expect(wrapper.find(clearFillterButtonSelector)).toHaveLength(0);
                 done();
+            }, 500);
+        });
+
+        it('renders emptyStateTable when no entities found', (done) => {
+            setTimeout(async () => {
+                wrapper.update();
+
+                api.doLoadEntities = jest.fn().mockImplementation(() => Promise.resolve({ sources: [] }));
+                api.doLoadCountOfSources = jest.fn().mockImplementation(() => Promise.resolve({ meta: { count: 0 } }));
+
+                const totalNonsense = '122#$@#%#^$#@!^$#^$#^546454abcerd';
+
+                await act(async() => {
+                    filterInput(wrapper).simulate('change', { target: { value: totalNonsense } });
+                });
+
+                setTimeout(() => {
+                    wrapper.update();
+                    expect(store.getState().providers.filterValue).toEqual({
+                        name: totalNonsense
+                    });
+                    expect(store.getState().providers.numberOfEntities).toEqual(0);
+                    expect(wrapper.find(EmptyStateTable)).toHaveLength(1);
+                    done();
+                }, 500);
             }, 500);
         });
     });

--- a/src/test/redux/actions.spec.js
+++ b/src/test/redux/actions.spec.js
@@ -8,7 +8,8 @@ import {
     loadEntities,
     sortEntities,
     removeSource,
-    filterProviders
+    filterProviders,
+    clearFilters
 } from '../../redux/actions/providers';
 import {
     UNDO_ADD_SOURCE,
@@ -18,7 +19,8 @@ import {
     ACTION_TYPES,
     SET_COUNT,
     SORT_ENTITIES,
-    FILTER_PROVIDERS
+    FILTER_PROVIDERS,
+    CLEAR_FILTERS
 } from '../../redux/action-types-providers';
 import { REMOVE_NOTIFICATION, ADD_NOTIFICATION } from '@redhat-cloud-services/frontend-components-notifications';
 import * as updateSourceApi from '../../api/doUpdateSource';
@@ -299,5 +301,13 @@ describe('redux actions', () => {
                 }
             });
         });
+    });
+
+    it('clearFilters creates an object', async () => {
+        await clearFilters()(dispatch);
+
+        expect(dispatch.mock.calls).toHaveLength(2);
+        expect(dispatch.mock.calls[0][0]).toEqual({ type: CLEAR_FILTERS });
+        expect(dispatch.mock.calls[1][0]).toEqual(expect.any(Function));
     });
 });

--- a/src/test/redux/reducer.spec.js
+++ b/src/test/redux/reducer.spec.js
@@ -1,4 +1,4 @@
-import { entitiesLoaded, defaultProvidersState, undoAddSource, clearAddSource, filterProviders } from '../../redux/reducers/providers';
+import { entitiesLoaded, defaultProvidersState, undoAddSource, clearAddSource, filterProviders, clearFilters } from '../../redux/reducers/providers';
 
 describe('redux > sources reducer', () => {
     describe('entitiesLoaded', () => {
@@ -86,6 +86,25 @@ describe('redux > sources reducer', () => {
                 filterValue: {
                     name: 'name'
                 },
+                pageNumber: 1
+            });
+        });
+    });
+
+    describe('clearFilters', () => {
+        const state = {
+            ...defaultProvidersState,
+            filterValue: {
+                xxx: 'yyy',
+                name: [1, 2, 3]
+            },
+            pageNumber: 12
+        };
+
+        it('clears filter', () => {
+            expect(clearFilters(state)).toEqual({
+                ...defaultProvidersState,
+                filterValue: {},
                 pageNumber: 1
             });
         });

--- a/src/views/sourcesViewDefinition.js
+++ b/src/views/sourcesViewDefinition.js
@@ -1,5 +1,5 @@
 export const sourcesViewDefinition = {
-    columns: (intl) => ([{
+    columns: (intl, notSortable = false) => ([{
         title: intl.formatMessage({
             id: 'sources.name',
             defaultMessage: 'Name'
@@ -7,7 +7,7 @@ export const sourcesViewDefinition = {
         value: 'name',
         searchable: true,
         formatter: 'nameFormatter',
-        sortable: true
+        sortable: !notSortable
     }, {
         title: intl.formatMessage({
             id: 'sources.type',
@@ -33,7 +33,7 @@ export const sourcesViewDefinition = {
         }),
         value: 'created_at',
         formatter: 'dateFormatter',
-        sortable: true
+        sortable: !notSortable
     }, {
         hidden: true,
         value: 'imported',
@@ -46,7 +46,7 @@ export const sourcesViewDefinition = {
         value: 'availability_status',
         searchable: true,
         formatter: 'availabilityFormatter',
-        sortable: true
+        sortable: !notSortable
     }])
 };
 


### PR DESCRIPTION
Adds empty state for table when user filters

According to https://www.patternfly.org/v4/documentation/react/components/table#empty-state

**Before**

![image](https://user-images.githubusercontent.com/32869456/71895234-c32ef280-3150-11ea-8158-f368382332de.png)

**After**

![image](https://user-images.githubusercontent.com/32869456/71895183-9c70bc00-3150-11ea-93a9-4bbce0f1c043.png)

Interaction

![clearFilters gif](https://user-images.githubusercontent.com/32869456/71895270-e6f23880-3150-11ea-8e6b-f267a824c2a9.gif)
