### PR TITLE
Use useParams in useSource hook

### DIFF
--- a/src/components/AddApplication/AddApplication.js
+++ b/src/components/AddApplication/AddApplication.js
@@ -1,5 +1,5 @@
 import React, { useReducer, useEffect } from 'react';
-import { useParams, useHistory } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { useIntl } from 'react-intl';
 
@@ -50,7 +50,6 @@ const reducer = (state, payload) => ({ ...state, ...payload });
 
 const AddApplication = () => {
     const intl = useIntl();
-    const { id } = useParams();
     const history = useHistory();
 
     const {
@@ -61,7 +60,7 @@ const AddApplication = () => {
         loaded
     } = useSelector(({ providers }) => providers, shallowEqual);
 
-    const source = useSource(id);
+    const source = useSource();
 
     const dispatch = useDispatch();
 

--- a/src/components/AddApplication/AddApplicationDescription.js
+++ b/src/components/AddApplication/AddApplicationDescription.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
-import { useParams } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import {
     TextContent,
@@ -16,11 +15,10 @@ import RedirectNoId from '../RedirectNoId/RedirectNoId';
 import { useSource } from '../../hooks/useSource';
 
 const AddApplicationDescription = () => {
-    const { id } = useParams();
     const [removingApp, setApplicationToRemove] = useState({});
 
     const sourceTypes = useSelector(({ providers }) => providers.sourceTypes);
-    const source = useSource(id);
+    const source = useSource();
 
     if (!source) {
         return <RedirectNoId />;

--- a/src/components/AddApplication/AuthTypeSetter.js
+++ b/src/components/AddApplication/AuthTypeSetter.js
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector, shallowEqual } from 'react-redux';
-import { useParams } from 'react-router-dom';
 import { useSource } from '../../hooks/useSource';
 import get from 'lodash/get';
 
@@ -44,10 +43,9 @@ export const innerSetter = ({ sourceTypes, source, appTypes, formOptions, checkA
 export const AuthTypeSetter = ({ formOptions, authenticationValues }) => {
     const [checkAuthType] = useState(() => checkAuthTypeMemo());
 
-    const { id } = useParams();
     const { appTypes, sourceTypes } = useSelector(({ providers }) => providers, shallowEqual);
 
-    const source = useSource(id);
+    const source = useSource();
 
     innerSetter({ sourceTypes, checkAuthType, formOptions, authenticationValues, appTypes, source });
 

--- a/src/components/AddApplication/RemoveAppModal.js
+++ b/src/components/AddApplication/RemoveAppModal.js
@@ -13,18 +13,16 @@ import {
     TextVariants
 } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
-import { useParams } from 'react-router-dom';
 
 import { removeApplication } from '../../redux/actions/providers';
 import RedirectNoId from '../RedirectNoId/RedirectNoId';
 import { useSource } from '../../hooks/useSource';
 
 const RemoveAppModal = ({ app, onCancel }) => {
-    const { id } = useParams();
     const intl = useIntl();
 
     const appTypes = useSelector(({ providers }) => providers.appTypes);
-    const source = useSource(id);
+    const source = useSource();
 
     const dispatch = useDispatch();
 

--- a/src/components/ApplicationsList/ApplicationList.js
+++ b/src/components/ApplicationsList/ApplicationList.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
-import { useParams } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import {
     TextContent,
@@ -17,9 +16,8 @@ import RedirectNoId from '../RedirectNoId/RedirectNoId';
 import { useSource } from '../../hooks/useSource';
 
 const ApplicationList = ({ setApplicationToRemove, breakpoints, namePrefix }) => {
-    const { id } = useParams();
     const appTypes = useSelector(({ providers }) => providers.appTypes);
-    const source = useSource(id);
+    const source = useSource();
 
     if (!source) {
         return <RedirectNoId/>;

--- a/src/components/SourceRemoveModal.js
+++ b/src/components/SourceRemoveModal.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useParams, useHistory } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import {
     Modal,
@@ -24,14 +24,13 @@ import RedirectNoId from './RedirectNoId/RedirectNoId';
 import { useSource } from '../hooks/useSource';
 
 const SourceRemoveModal = () => {
-    const { id } = useParams();
     const { push } = useHistory();
 
     const [acknowledge, setAcknowledge] = useState(false);
     const [removingApp, setApplicationToRemove] = useState({});
 
     const intl = useIntl();
-    const source = useSource(id);
+    const source = useSource();
 
     const dispatch = useDispatch();
 

--- a/src/hooks/useSource.js
+++ b/src/hooks/useSource.js
@@ -1,7 +1,9 @@
 import { useSelector } from 'react-redux';
+import { useParams } from 'react-router-dom';
 
-export const useSource = (id) => {
-    const source = useSelector(({ providers }) => providers.entities.find(source => source.id  === id));
+export const useSource = () => {
+    const { id } = useParams();
+    const source = useSelector(({ providers }) => providers.entities.find(source => source.id === id));
 
     return source;
 };

--- a/src/test/hooks/useSource.spec.js
+++ b/src/test/hooks/useSource.spec.js
@@ -1,5 +1,11 @@
 import * as redux from 'react-redux';
+
 import { useSource } from '../../hooks/useSource';
+
+jest.mock('react-router-dom', () => ({
+    __esModule: true,
+    useParams: jest.fn().mockImplementation(() => ({ id: '121311231' }))
+}));
 
 describe('useSource', () => {
     let INPUT_FN = expect.any(Function);
@@ -26,6 +32,6 @@ describe('useSource', () => {
     });
 
     it('returns object', () => {
-        expect(useSource(ID)).toEqual(ENTITY);
+        expect(useSource()).toEqual(ENTITY);
     });
 });


### PR DESCRIPTION
`useSource` does not need ID props anymore (but it is possible to use it). It takes the `id` right away from url via the `useParams` hook.