### PR TITLE
Add application bugs cleanup

### DIFF
--- a/src/api/doAttachApp.js
+++ b/src/api/doAttachApp.js
@@ -75,29 +75,36 @@ export const doAttachApp = async (values, formApi, authenticationInitialValues) 
 
         const promises = [];
 
-        if (filteredValues.source) {
+        if (filteredValues.source && !isEmpty(filteredValues.source)) {
             promises.push(getSourcesApi().updateSource(sourceId, filteredValues.source));
         }
 
-        if (filteredValues.endpoint || filteredValues.url) {
+        const hasModifiedEndpoint = filteredValues.endpoint && !isEmpty(filteredValues.endpoint);
+        const hasModifiedUrl = filteredValues.url && !isEmpty(filteredValues.url);
+
+        if (hasModifiedEndpoint || hasModifiedUrl) {
             const { scheme, host, port, path } = urlOrHost(filteredValues);
 
             const endPointPort = parseInt(port, 10);
 
-            const endpointData = {
+            const endpointData = removeEmpty({
                 ...filteredValues.endpoint,
-                default: true,
-                source_id: sourceId,
                 scheme,
                 host,
                 port: isNaN(endPointPort) ? undefined : endPointPort,
                 path
-            };
+            });
 
             if (endpointId) {
                 promises.push(getSourcesApi().updateEndpoint(endpointId, endpointData));
             } else {
-                const endpoint = await getSourcesApi().createEndpoint(endpointData);
+                const createEndpointData = {
+                    ...endpointData,
+                    default: true,
+                    source_id: sourceId
+                };
+
+                const endpoint = await getSourcesApi().createEndpoint(createEndpointData);
                 endpointId = endpoint.id;
             }
         }

--- a/src/api/doUpdateSource.js
+++ b/src/api/doUpdateSource.js
@@ -3,6 +3,15 @@ import { getSourcesApi } from './entities';
 import { patchCmValues } from './patchCmValues';
 
 export const parseUrl = url => {
+    if (url === null) {
+        return {
+            scheme: null,
+            host: null,
+            port: null,
+            path: null
+        };
+    }
+
     if (!url) {
         return ({});
     }
@@ -22,7 +31,8 @@ export const parseUrl = url => {
     }
 };
 
-export const urlOrHost = formData => formData.url ? parseUrl(formData.url) : formData.endpoint ? formData.endpoint : formData;
+export const urlOrHost = formData =>
+    formData.url || formData.url === null ? parseUrl(formData.url) : formData.endpoint ? formData.endpoint : formData;
 
 export const doUpdateSource = (source, formData, errorTitles) => {
     const promises = [];
@@ -33,15 +43,15 @@ export const doUpdateSource = (source, formData, errorTitles) => {
         }));
     }
 
-    if (formData.endpoint || formData.url) {
+    if (formData.endpoint || formData.url || formData.url === null) {
         const { scheme, host, port, path } = urlOrHost(formData);
-        const endPointPort = parseInt(port, 10);
+        const endPointPort = port === null ? null : parseInt(port, 10);
 
         const endpointData = {
             scheme,
             host,
             path,
-            port: isNaN(endPointPort) ? undefined : endPointPort,
+            port: endPointPort === null ? null : isNaN(endPointPort) ? undefined : endPointPort,
             ...formData.endpoint
         };
 

--- a/src/components/SourcesSimpleView/formatters.js
+++ b/src/components/SourcesSimpleView/formatters.js
@@ -21,7 +21,7 @@ export const schemaToPort = (schema, port) => port && String(port) !== defaultPo
 export const endpointToUrl = (endpoint) => {
     const onlyTrueEndpointValues = Object.keys(endpoint).reduce((acc, curr) => ({ ...acc, [curr]: endpoint[curr] || '' }), {});
 
-    const { scheme, host, path, port } = onlyTrueEndpointValues;
+    const { scheme = '', host = '', path = '', port = '' } = onlyTrueEndpointValues;
 
     const url = `${scheme}://${host}${schemaToPort(scheme, port)}${path}`;
 

--- a/src/components/SourcesSimpleView/formatters.js
+++ b/src/components/SourcesSimpleView/formatters.js
@@ -18,9 +18,19 @@ export const importsTexts = (value) => ({
 
 export const schemaToPort = (schema, port) => port && String(port) !== defaultPort(schema) ? `:${port}` : '';
 
-export const endpointToUrl = ({ scheme, host, path, port }) => (
-    `${scheme}://${host}${schemaToPort(scheme, port)}${path || ''}`
-);
+export const endpointToUrl = (endpoint) => {
+    const onlyTrueEndpointValues = Object.keys(endpoint).reduce((acc, curr) => ({ ...acc, [curr]: endpoint[curr] || '' }), {});
+
+    const { scheme, host, path, port } = onlyTrueEndpointValues;
+
+    const url = `${scheme}://${host}${schemaToPort(scheme, port)}${path}`;
+
+    if (url === '://') {
+        return;
+    }
+
+    return url;
+};
 
 export const sourceIsOpenShift = (source, sourceTypes) => {
     const type = sourceTypes.find((type) => type.id === source.source_type_id);

--- a/src/test/api/doAttachApp.spec.js
+++ b/src/test/api/doAttachApp.spec.js
@@ -268,11 +268,9 @@ describe('doAttachApp', () => {
         expect(authUpdate).not.toHaveBeenCalled();
         expect(endpointUpdate).toHaveBeenCalledWith(ENDPOINT_ID, {
             port: 2323,
-            default: true,
             host: undefined,
             path: undefined,
-            scheme: undefined,
-            source_id: SOURCE_ID
+            scheme: undefined
         });
         expect(authCreate).not.toHaveBeenCalled();
         expect(endpointCreate).not.toHaveBeenCalled();
@@ -302,12 +300,35 @@ describe('doAttachApp', () => {
         expect(authUpdate).not.toHaveBeenCalled();
         expect(endpointUpdate).toHaveBeenCalledWith(ENDPOINT_ID, {
             port: undefined,
-            default: true,
             host: undefined,
             path: undefined,
-            scheme: undefined,
-            source_id: SOURCE_ID
+            scheme: undefined
         });
+        expect(authCreate).not.toHaveBeenCalled();
+        expect(endpointCreate).not.toHaveBeenCalled();
+        expect(appCreate).not.toHaveBeenCalled();
+    });
+
+    it('empty endpoint', async () => {
+        FORM_API = prepareFormApi({
+            source: {
+                id: SOURCE_ID
+            },
+            endpoint: {
+                id: ENDPOINT_ID
+            }
+        });
+
+        VALUES = {
+            endpoint: { }
+        };
+
+        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT);
+
+        expect(mockPatchSourceSpy).not.toHaveBeenCalled();
+        expect(sourceUpdate).not.toHaveBeenCalled();
+        expect(authUpdate).not.toHaveBeenCalled();
+        expect(endpointUpdate).not.toHaveBeenCalled();
         expect(authCreate).not.toHaveBeenCalled();
         expect(endpointCreate).not.toHaveBeenCalled();
         expect(appCreate).not.toHaveBeenCalled();
@@ -334,11 +355,9 @@ describe('doAttachApp', () => {
         expect(authUpdate).not.toHaveBeenCalled();
         expect(endpointUpdate).toHaveBeenCalledWith(ENDPOINT_ID, {
             port: 8989,
-            default: true,
             host: 'redhat.com',
             path: '/mypage',
-            scheme: 'https',
-            source_id: SOURCE_ID
+            scheme: 'https'
         });
         expect(authCreate).not.toHaveBeenCalled();
         expect(endpointCreate).not.toHaveBeenCalled();

--- a/src/test/api/doUpdateSource.spec.js
+++ b/src/test/api/doUpdateSource.spec.js
@@ -143,6 +143,26 @@ describe('doUpdateSource', () => {
         expect(patchCostManagementSpy).not.toHaveBeenCalled();
     });
 
+    it('sends endpoint values removed url', () => {
+        FORM_DATA = {
+            url: null
+        };
+
+        const EXPECTED_ENDPOINT_VALUES_ONLY_WITH_URL = {
+            scheme: null,
+            host: null,
+            port: null,
+            path: null
+        };
+
+        doUpdateSource(SOURCE, FORM_DATA, ERROR_TITLES);
+
+        expect(sourceSpy).not.toHaveBeenCalled();
+        expect(endpointSpy).toHaveBeenCalledWith(ENDPOINT_ID, EXPECTED_ENDPOINT_VALUES_ONLY_WITH_URL);
+        expect(authenticationSpy).not.toHaveBeenCalled();
+        expect(patchCostManagementSpy).not.toHaveBeenCalled();
+    });
+
     it('sends authentication values', () => {
         const AUTH_ID = '1234234243';
         const AUTHENTICATION_VALUES = { password: '123456' };
@@ -368,6 +388,15 @@ describe('doUpdateSource', () => {
 
                 expect(parseUrl(WRONG_URL)).toEqual(EMPTY_OBJECT);
             });
+
+            it('parses null (removed)', () => {
+                expect(parseUrl(null)).toEqual({
+                    scheme: null,
+                    host: null,
+                    port: null,
+                    path: null
+                });
+            });
         });
 
         describe('urlOrHost', () => {
@@ -382,6 +411,15 @@ describe('doUpdateSource', () => {
 
             it('returns parsed url', () => {
                 expect(urlOrHost({ url: URL })).toEqual(EXPECTED_URL_OBJECT);
+            });
+
+            it('returns remove url', () => {
+                expect(urlOrHost({ url: null })).toEqual({
+                    scheme: null,
+                    host: null,
+                    port: null,
+                    path: null
+                });
             });
         });
     });

--- a/src/test/components/SourcesSimpleView/formatters.spec.js
+++ b/src/test/components/SourcesSimpleView/formatters.spec.js
@@ -232,6 +232,17 @@ describe('formatters', () => {
             };
         });
 
+        it('returns undefined when there are no positive values', () => {
+            endpoint = {
+                scheme: null,
+                port: undefined,
+                path: false,
+                host: ''
+            };
+
+            expect(endpointToUrl(endpoint)).toEqual(undefined);
+        });
+
         it('correctly parses URL with default port', () => {
             expect(endpointToUrl(endpoint)).toEqual('https://my.best.page/');
         });

--- a/src/test/components/SourcesSimpleView/formatters.spec.js
+++ b/src/test/components/SourcesSimpleView/formatters.spec.js
@@ -250,6 +250,12 @@ describe('formatters', () => {
         it('correctly parses URL with custom port', () => {
             expect(endpointToUrl({ ...endpoint, port: CUSTOM_PORT })).toEqual(`https://my.best.page:${CUSTOM_PORT}/`);
         });
+
+        it('correctly parses this specific endpoint', () => {
+            endpoint = { id: '123', scheme: 'https', host: 'redhat.com' };
+
+            expect(endpointToUrl(endpoint)).toEqual('https://redhat.com');
+        });
     });
 
     describe('availability status', () => {


### PR DESCRIPTION
Fixes several bugs in addApplication wizard
 
- when endpoint has not set up URL, the url is empty (not `null://null...` anymore)
- when modifying endpoint, `source_id` and `default: true` are no longer appended (no permissions errors)

cc @slemrmartin 