### PR TITLE
Do not pass empty types into wizard

### DIFF
--- a/src/pages/SourcesPage.js
+++ b/src/pages/SourcesPage.js
@@ -28,7 +28,8 @@ import {
     debouncedFiltering,
     prepareSourceTypeSelection,
     afterSuccess,
-    onCloseAddSourceWizard
+    onCloseAddSourceWizard,
+    loadedTypes
 } from './SourcesPage/helpers';
 import PaginationLoader from './SourcesPage/PaginationLoader';
 
@@ -51,7 +52,9 @@ const SourcesPage = () => {
         addSourceInitialValues,
         sourceTypes,
         entities,
-        paginationClicked
+        paginationClicked,
+        appTypesLoaded,
+        sourceTypesLoaded
     } = useSelector(({ sources }) => sources, shallowEqual);
 
     const dispatch = useDispatch();
@@ -168,8 +171,8 @@ const SourcesPage = () => {
             <Route exact path={paths.sourceManageApps} component={ AddApplication } />
             <Route exact path={paths.sourcesRemove} component={ SourceRemoveModal } />
             <Route exact path={paths.sourcesNew} render={ () => (<AddSourceWizard
-                sourceTypes={sourceTypes}
-                applicationTypes={appTypes}
+                sourceTypes={loadedTypes(sourceTypes, sourceTypesLoaded)}
+                applicationTypes={loadedTypes(appTypes, appTypesLoaded)}
                 isOpen={true}
                 onClose={(values) => onCloseAddSourceWizard({ values, dispatch, history, intl })}
                 afterSuccess={() => afterSuccess(dispatch)}

--- a/src/pages/SourcesPage/helpers.js
+++ b/src/pages/SourcesPage/helpers.js
@@ -87,3 +87,5 @@ export const removeChips = (chips, filterValue, deleteAll) => {
         [chip.key]: chip.chips ? filterValue[chip.key].filter((value) => value !== chip.chips[0].value) : undefined
     });
 };
+
+export const loadedTypes = (types, loaded) => loaded && types.length > 0 ? types : undefined;

--- a/src/test/pages/SourcePage/helpers.spec.js
+++ b/src/test/pages/SourcePage/helpers.spec.js
@@ -5,7 +5,8 @@ import {
     chipsFormatters,
     prepareSourceTypeSelection,
     removeChips,
-    prepareChips
+    prepareChips,
+    loadedTypes
 } from '../../../pages/SourcesPage/helpers';
 
 import * as actions from '../../../redux/actions/sources';
@@ -188,6 +189,32 @@ describe('Source page helpers', () => {
                 chipsFormatters('name', filterValue, sourceTypesData.data)(),
                 chipsFormatters('source_type_id', filterValue, sourceTypesData.data)()
             ]);
+        });
+    });
+
+    describe('loadedTypes', () => {
+        let types;
+        let loaded;
+
+        it('returns types when loaded and length > 0', () => {
+            types = [1, 2];
+            loaded = true;
+
+            expect(loadedTypes(types, loaded)).toEqual(types);
+        });
+
+        it('returns undefined when not loaded', () => {
+            types = [1, 2];
+            loaded = false;
+
+            expect(loadedTypes(types, loaded)).toEqual(undefined);
+        });
+
+        it('returns undefined when length < 0', () => {
+            types = [];
+            loaded = true;
+
+            expect(loadedTypes(types, loaded)).toEqual(undefined);
         });
     });
 });


### PR DESCRIPTION
When wizard is loaded before the application, types are empty and user needs to re-open the wizard to get all available types