### PR TITLE
Allow to select editField by keyboard

### DIFF
--- a/src/components/editField/EditField.js
+++ b/src/components/editField/EditField.js
@@ -27,6 +27,13 @@ const EditField = ({ isRequired, label, helperText, hideLabel, meta, input, type
             helperText={ helperText }
             helperTextInvalid={ error }
             onClick={setEdit ? () => setEdit(input.name) : undefined}
+            tabIndex={0}
+            onKeyPress={(e) => {
+                if (e.charCode === 32 && setEdit) {
+                    e.preventDefault();
+                    setEdit(input.name);
+                }
+            }}
         >
             <div className={`pf-c-form__horizontal-group ins-c-sources__edit-field-group ${setEdit ? 'clickable' : ''}`}>
                 <TextContent className={`ins-c-sources__edit-field-group-text-content ${setEdit ? 'clickable' : ''}`}>

--- a/src/test/components/editField/editField.spec.js
+++ b/src/test/components/editField/editField.spec.js
@@ -9,6 +9,8 @@ describe('Edit field', () => {
     const NAME = 'name1234';
     const VALUE = 'password';
 
+    const SPACE_CODE = 32;
+
     beforeEach(() => {
         initialProps = {
             FieldProvider: MockFieldProvider,
@@ -135,5 +137,59 @@ describe('Edit field', () => {
         wrapper.find(FormGroup).simulate('click');
 
         expect(setEdit).toHaveBeenCalledWith(NAME);
+    });
+
+    it('calls setEdit with field name by pressing space', () => {
+        const setEdit = jest.fn();
+
+        const wrapper = mount(<EditField
+            {...initialProps}
+            setEdit={setEdit}
+        />);
+
+        const event = {
+            charCode: SPACE_CODE,
+            preventDefault: jest.fn()
+        };
+
+        wrapper.find(FormGroup).simulate('keypress', event);
+
+        expect(setEdit).toHaveBeenCalledWith(NAME);
+        expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it('do not call setEdit with field name by pressing different key than space', () => {
+        const setEdit = jest.fn();
+
+        const wrapper = mount(<EditField
+            {...initialProps}
+            setEdit={setEdit}
+        />);
+
+        const event = {
+            charCode: 31,
+            preventDefault: jest.fn()
+        };
+
+        wrapper.find(FormGroup).simulate('keypress', event);
+
+        expect(setEdit).not.toHaveBeenCalled();
+        expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('do nothing when setEdit is not set', () => {
+        const wrapper = mount(<EditField
+            {...initialProps}
+            setEdit={undefined}
+        />);
+
+        const event = {
+            charCode: SPACE_CODE,
+            preventDefault: jest.fn()
+        };
+
+        wrapper.find(FormGroup).simulate('keypress', event);
+
+        expect(event.preventDefault).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
Allow to control whole edit form with keyboard

![editfieldkeyd](https://user-images.githubusercontent.com/32869456/72331443-7d29df80-36b8-11ea-88d7-44402431f81c.gif)
