### PR TITLE
Add sentry to ErrorBoundary

### DIFF
--- a/src/components/ErrorBoundary.js
+++ b/src/components/ErrorBoundary.js
@@ -1,6 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import * as Sentry from '@sentry/browser';
 
 import { addMessage } from '../redux/actions/sources';
 
@@ -13,11 +14,12 @@ class ErrorBoundary extends Component {
         return { error, errorInfo };
     }
 
-    componentDidCatch(error, errorInfo) {
+    componentDidCatch(error) {
+        const sentryId = Sentry.captureException(error);
         this.props.dispatch(addMessage(
-            error.toString(),
+            `${error.toString()} (Sentry ID: ${sentryId})`,
             'danger',
-            errorInfo.componentStack
+            error.stack
         ));
     }
 

--- a/src/test/components/ErrorBoundary.spec.js
+++ b/src/test/components/ErrorBoundary.spec.js
@@ -3,6 +3,7 @@ import ErrorBoundary from '../../components/ErrorBoundary';
 import { componentWrapperIntl } from '../../Utilities/testsHelpers';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
+import * as sentry from '@sentry/browser';
 
 import * as actions from '../../redux/actions/sources';
 
@@ -16,7 +17,11 @@ describe('Error Boundary', () => {
     });
 
     it('dispatch message', () => {
-        const COMPONENT_STACK = expect.any(String);
+        const SENTRY_ID = '2132s1ad5s1ad5sa1d51sfd321sa';
+        sentry.captureException = jest.fn().mockImplementation(() => SENTRY_ID);
+
+        const ERROR_TO_STRING = expect.any(String);
+        const ERROR_STACK = expect.any(String);
         const tmpLog = console.error;
 
         console.error = jest.fn();
@@ -38,10 +43,16 @@ describe('Error Boundary', () => {
 
         expect(wrapper.text()).toEqual('Error occurred');
         expect(actions.addMessage).toHaveBeenCalledWith(
-            ERROR.toString(),
+            ERROR_TO_STRING,
             'danger',
-            COMPONENT_STACK
+            ERROR_STACK
         );
+
+        expect(actions.addMessage.mock.calls[0][0].includes(ERROR.toString()));
+        expect(actions.addMessage.mock.calls[0][0].includes('Sentry ID'));
+        expect(actions.addMessage.mock.calls[0][0].includes(SENTRY_ID));
+
+        expect(sentry.captureException).toHaveBeenCalledWith(ERROR);
 
         console.error = tmpLog;
     });


### PR DESCRIPTION
- Adds Sentry to ErrorBoundary
- SentryID is shown to the user
- Instead of component stack, error stack is shown

![image](https://user-images.githubusercontent.com/32869456/72342989-1ca59d00-36ce-11ea-9460-8191f53b38fb.png)