### PR TITLE
Change loaded logic from boolean to semaphore

### DIFF
--- a/src/components/AddApplication/AddApplication.js
+++ b/src/components/AddApplication/AddApplication.js
@@ -15,6 +15,7 @@ import { getSourcesApi } from '../../api/entities';
 
 import RedirectNoId from '../RedirectNoId/RedirectNoId';
 import { useSource } from '../../hooks/useSource';
+import { useIsLoaded } from '../../hooks/useIsLoaded';
 import { endpointToUrl } from '../SourcesSimpleView/formatters';
 import { paths } from '../../Routes';
 
@@ -52,12 +53,13 @@ const AddApplication = () => {
     const intl = useIntl();
     const history = useHistory();
 
+    const loaded = useIsLoaded();
+
     const {
         appTypes,
         sourceTypesLoaded,
         appTypesLoaded,
-        sourceTypes,
-        loaded
+        sourceTypes
     } = useSelector(({ sources }) => sources, shallowEqual);
 
     const source = useSource();

--- a/src/components/RedirectNoId/RedirectNoId.js
+++ b/src/components/RedirectNoId/RedirectNoId.js
@@ -5,12 +5,15 @@ import { useIntl } from 'react-intl';
 
 import { addMessage, addHiddenSource } from '../../redux/actions/sources';
 import { doLoadSource } from '../../api/entities';
+import { useIsLoaded } from '../../hooks/useIsLoaded';
 
 const RedirectNoId = () => {
     const { id } = useParams();
     const intl = useIntl();
 
-    const { loaded, appTypesLoaded, sourceTypesLoaded } = useSelector(({ sources }) => sources, shallowEqual);
+    const loaded = useIsLoaded();
+
+    const { appTypesLoaded, sourceTypesLoaded } = useSelector(({ sources }) => sources, shallowEqual);
     const dispatch = useDispatch();
 
     const [applicationIsLoaded, setIsApplicationLoaded] = useState(false);

--- a/src/components/SourcesSimpleView/SourcesSimpleView.js
+++ b/src/components/SourcesSimpleView/SourcesSimpleView.js
@@ -9,6 +9,7 @@ import { formatters } from './formatters';
 import { PlaceHolderTable, RowWrapperLoader } from './loaders';
 import { sourcesColumns, COLUMN_COUNT } from '../../views/sourcesViewDefinition';
 import EmptyStateTable from './EmptyStateTable';
+import { useIsLoaded } from '../../hooks/useIsLoaded';
 
 const itemToCells = (item, columns, sourceTypes, appTypes) => columns.filter(column => column.title || column.hidden)
 .map(col => ({
@@ -79,8 +80,9 @@ const SourcesSimpleView = () => {
     const { push } = useHistory();
     const intl = useIntl();
 
+    const loaded = useIsLoaded();
+
     const {
-        loaded,
         appTypes,
         entities,
         sourceTypes,
@@ -90,7 +92,6 @@ const SourcesSimpleView = () => {
         sortDirection,
         numberOfEntities
     } = useSelector(({ sources }) => sources, shallowEqual);
-
     const reduxDispatch = useDispatch();
 
     const [state, dispatch] = useReducer(reducer, initialState(sourcesColumns(intl)));

--- a/src/hooks/useIsLoaded.js
+++ b/src/hooks/useIsLoaded.js
@@ -1,0 +1,7 @@
+import { useSelector } from 'react-redux';
+
+export const useIsLoaded = () => {
+    const isLoaded = useSelector(({ sources }) => sources.loaded);
+
+    return isLoaded === 0;
+};

--- a/src/pages/SourcesPage.js
+++ b/src/pages/SourcesPage.js
@@ -32,18 +32,20 @@ import {
     loadedTypes
 } from './SourcesPage/helpers';
 import PaginationLoader from './SourcesPage/PaginationLoader';
+import { useIsLoaded } from '../hooks/useIsLoaded';
 
 const SourcesPage = () => {
     const [showEmptyState, setShowEmptyState] = useState(false);
     const [checkEmptyState, setCheckEmptyState] = useState(false);
     const [filter, setFilterValue] = useState();
 
+    const loaded = useIsLoaded();
+
     const history = useHistory();
     const intl = useIntl();
 
     const {
         filterValue,
-        loaded,
         numberOfEntities,
         appTypes,
         pageSize,
@@ -101,7 +103,7 @@ const SourcesPage = () => {
         variant: 'bottom'
     };
 
-    const showPaginationLoader = !loaded && !paginationClicked;
+    const showPaginationLoader = (!loaded || !appTypesLoaded || !sourceTypesLoaded) && !paginationClicked;
 
     const mainContent = () => (
         <React.Fragment>

--- a/src/redux/actions/sources.js
+++ b/src/redux/actions/sources.js
@@ -123,7 +123,7 @@ export const removeSource = (sourceId, title) => (dispatch) => {
         }
     });
 
-    return doRemoveSource(sourceId).then(() => dispatch(loadEntities({ loaded: true })))
+    return doRemoveSource(sourceId).then(() => dispatch(loadEntities({ loaded: 0 })))
     .then(() => {
         dispatch({
             type: ACTION_TYPES.REMOVE_SOURCE_FULFILLED,

--- a/src/redux/reducers/sources.js
+++ b/src/redux/reducers/sources.js
@@ -12,7 +12,7 @@ import {
 } from '../action-types-sources';
 
 export const defaultSourcesState = {
-    loaded: false,
+    loaded: 0,
     pageSize: 50,
     pageNumber: 1,
     entities: [],
@@ -27,14 +27,14 @@ export const defaultSourcesState = {
 
 export const entitiesPending = (state, { options }) => ({
     ...state,
-    loaded: false,
+    loaded: state.loaded + 1,
     paginationClicked: false,
     ...options
 });
 
 export const entitiesLoaded = (state, { payload: rows, options }) => ({
     ...state,
-    loaded: true,
+    loaded: state.loaded - 1,
     entities: rows,
     ...options
 });

--- a/src/test/components/SourcesSimpleView/SourcesSimpleView.spec.js
+++ b/src/test/components/SourcesSimpleView/SourcesSimpleView.spec.js
@@ -32,7 +32,7 @@ describe('SourcesSimpleView', () => {
         initialState = {
             sources:
             {
-                loaded: true,
+                loaded: 0,
                 rows: [],
                 entities: [],
                 numberOfEntities: 0,
@@ -41,7 +41,7 @@ describe('SourcesSimpleView', () => {
             }
         };
         loadedProps = {
-            loaded: true,
+            loaded: 0,
             appTypesLoaded: true,
             sourceTypesLoaded: true,
             entities: sourcesDataGraphQl,
@@ -162,16 +162,8 @@ describe('SourcesSimpleView', () => {
             }
         });
 
-        const store = mockStore(
-            jest.fn()
-            .mockImplementationOnce(() => initialState)
-            .mockImplementationOnce(() => initialState)
-            .mockImplementationOnce(() => initialState)
-            .mockImplementationOnce(() => initialState)
-            .mockImplementationOnce(() => initialState)
-            // 5 initial renders :()
-            .mockImplementation(() => initialStateUpdated)
-        );
+        let mockStoreFn = jest.fn().mockImplementation(() => initialState);
+        const store = mockStore(mockStoreFn);
 
         await act(async () => {
             wrapper = mount(componentWrapperIntl(<SourcesSimpleView { ...initialProps } />, store));
@@ -179,6 +171,8 @@ describe('SourcesSimpleView', () => {
 
         wrapper.update();
         expect(wrapper.find(RowWrapper)).toHaveLength(sourcesDataGraphQl.length);
+
+        mockStoreFn.mockImplementation(() => initialStateUpdated);
 
         // trigger render
         await act(async () => {

--- a/src/test/components/addApplication/AddApplication.spec.js
+++ b/src/test/components/addApplication/AddApplication.spec.js
@@ -52,7 +52,7 @@ describe('AddApplication', () => {
                 sourceTypes: sourceTypesData.data,
                 appTypesLoaded: true,
                 sourceTypesLoaded: true,
-                loaded: true
+                loaded: 0
             }
         });
         entities.getSourcesApi = () => ({
@@ -110,7 +110,7 @@ describe('AddApplication', () => {
                 sourceTypes: sourceTypesData.data,
                 appTypesLoaded: true,
                 sourceTypesLoaded: true,
-                loaded: true
+                loaded: 0
             }
         });
 
@@ -186,7 +186,7 @@ describe('AddApplication', () => {
                 sourceTypes: sourceTypesData.data,
                 appTypesLoaded: true,
                 sourceTypesLoaded: true,
-                loaded: true
+                loaded: 0
             }
         });
 
@@ -218,7 +218,7 @@ describe('AddApplication', () => {
                     sourceTypes: sourceTypesData.data,
                     appTypesLoaded: true,
                     sourceTypesLoaded: true,
-                    loaded: true
+                    loaded: 0
                 }
             });
         });

--- a/src/test/components/addApplication/AuthTypeSetter.spec.js
+++ b/src/test/components/addApplication/AuthTypeSetter.spec.js
@@ -69,7 +69,7 @@ describe('AuthTypeSetter', () => {
                 sourceTypes: sourceTypesData.data,
                 appTypesLoaded: true,
                 sourceTypesLoaded: true,
-                loaded: true
+                loaded: 0
             }
         });
 

--- a/src/test/components/redirectNoId/RedirectNoId.spec.js
+++ b/src/test/components/redirectNoId/RedirectNoId.spec.js
@@ -26,7 +26,7 @@ describe('RedirectNoId', () => {
 
     it('Renders null if not loaded', () => {
         initialStore = mockStore({
-            sources: { loaded: false, appTypesLoaded: true, sourceTypesLoaded: true }
+            sources: { loaded: 1, appTypesLoaded: true, sourceTypesLoaded: true }
         });
 
         const wrapper = mount(componentWrapperIntl(
@@ -43,7 +43,7 @@ describe('RedirectNoId', () => {
         api.doLoadSource = jest.fn().mockImplementation(() => Promise.resolve({  sources: [] }));
 
         initialStore = mockStore({
-            sources: { loaded: true, appTypesLoaded: true, sourceTypesLoaded: true }
+            sources: { loaded: 0, appTypesLoaded: true, sourceTypesLoaded: true }
         });
 
         await act(async () => {
@@ -66,7 +66,7 @@ describe('RedirectNoId', () => {
         api.doLoadSource = jest.fn().mockImplementation(() => Promise.resolve({  sources: [SOURCE] }));
 
         initialStore = mockStore({
-            sources: { loaded: true, appTypesLoaded: true, sourceTypesLoaded: true }
+            sources: { loaded: 0, appTypesLoaded: true, sourceTypesLoaded: true }
         });
 
         await act(async () => {

--- a/src/test/hooks/useIsLoaded.spec.js
+++ b/src/test/hooks/useIsLoaded.spec.js
@@ -1,0 +1,38 @@
+import * as redux from 'react-redux';
+
+import { useIsLoaded } from '../../hooks/useIsLoaded';
+
+describe('useIsLoaded', () => {
+    let inputFn;
+    let mockStore;
+
+    beforeEach(() => {
+        inputFn = expect.any(Function);
+    });
+
+    it('returns true when is loaded', () => {
+        mockStore = {
+            sources: { loaded: 0 }
+        };
+
+        redux.useSelector = jest.fn().mockImplementation(fn => fn(mockStore));
+
+        const result = useIsLoaded();
+
+        expect(result).toEqual(true);
+        expect(redux.useSelector).toHaveBeenCalledWith(inputFn);
+    });
+
+    it('returns false when is not loaded', () => {
+        mockStore = {
+            sources: { loaded: 1 }
+        };
+
+        redux.useSelector = jest.fn().mockImplementation(fn => fn(mockStore));
+
+        const result = useIsLoaded();
+
+        expect(result).toEqual(false);
+        expect(redux.useSelector).toHaveBeenCalledWith(inputFn);
+    });
+});

--- a/src/test/pages/SourcesPage.spec.js
+++ b/src/test/pages/SourcesPage.spec.js
@@ -106,7 +106,7 @@ describe('SourcesPage', () => {
     });
 
     it('renders table and filtering - loading with paginationClicked: true, do not show paginationLoader', async () => {
-        const modifiedState = { ...defaultSourcesState, paginationClicked: true, numberOfEntities: 5 };
+        const modifiedState = { ...defaultSourcesState, loaded: 1, paginationClicked: true, numberOfEntities: 5 };
 
         store = createStore(
             combineReducers({ sources: applyReducerHash(ReducersProviders, modifiedState) }),

--- a/src/test/redux/reducer.spec.js
+++ b/src/test/redux/reducer.spec.js
@@ -13,11 +13,13 @@ describe('redux > sources reducer', () => {
         const EXPECTED_STATE = {
             ...defaultSourcesState,
             entities: SOURCES,
-            loaded: true
+            loaded: 0
         };
 
+        const unloadedInitialState = { ...defaultSourcesState, loaded: 1 };
+
         it('loads the entities', () => {
-            expect(sourcesReducer.entitiesLoaded(defaultSourcesState, DATA)).toEqual(
+            expect(sourcesReducer.entitiesLoaded(unloadedInitialState, DATA)).toEqual(
                 expect.objectContaining(EXPECTED_STATE)
             );
         });
@@ -32,7 +34,7 @@ describe('redux > sources reducer', () => {
                 ...ADDITIONAL_OPTIONS
             };
 
-            expect(sourcesReducer.entitiesLoaded(defaultSourcesState, NEW_DATA)).toEqual(
+            expect(sourcesReducer.entitiesLoaded(unloadedInitialState, NEW_DATA)).toEqual(
                 expect.objectContaining({
                     ...EXPECTED_STATE,
                     ...ADDITIONAL_OPTIONS
@@ -122,7 +124,7 @@ describe('redux > sources reducer', () => {
 
         expect(sourcesReducer.entitiesPending(defaultSourcesState, payload)).toEqual({
             ...defaultSourcesState,
-            loaded: false,
+            loaded: 1,
             custom: 'custom',
             paginationClicked: false
         });
@@ -135,7 +137,7 @@ describe('redux > sources reducer', () => {
 
         expect(sourcesReducer.entitiesPending(defaultSourcesState, payload)).toEqual({
             ...defaultSourcesState,
-            loaded: false,
+            loaded: 1,
             paginationClicked: true
         });
     });


### PR DESCRIPTION
When there are multiple loading events, there is no data pop-in anymore.

**Before**

![datapopin](https://user-images.githubusercontent.com/32869456/72598681-9036ec80-3910-11ea-990d-d4fe715ccde5.gif)

**After**

![datapopinafter](https://user-images.githubusercontent.com/32869456/72598688-9331dd00-3910-11ea-8f2a-c02d44d0220a.gif)