### PR TITLE
Test entries, exclude ReactDom from tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "collectCoverage": true,
     "collectCoverageFrom": [
       "src/**/*.{js,jsx}",
-      "!src/**/stories/*"
+      "!src/**/stories/*",
+      "!src/entry.js",
+      "!src/entry-dev.js"
     ],
     "setupFiles": [
       "<rootDir>/config/setupTests.js"

--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,8 @@ import React, { useEffect } from 'react';
 import { NotificationsPortal } from '@redhat-cloud-services/frontend-components-notifications';
 import { Main } from '@redhat-cloud-services/frontend-components';
 import { IntlProvider } from 'react-intl';
+import { BrowserRouter as Router } from 'react-router-dom';
+import { getBaseName } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
 
 import Routes from './Routes';
 import './App.scss';
@@ -18,14 +20,16 @@ const App = (props) => {
     }, []);
 
     return (
-        <IntlProvider locale="en">
-            <React.Fragment>
-                <NotificationsPortal />
-                <Main style={ { padding: 0 } } >
-                    <Routes childProps={props} />
-                </Main>
-            </React.Fragment>
-        </IntlProvider>
+        <Router basename={getBaseName(location.pathname)}>
+            <IntlProvider locale="en">
+                <React.Fragment>
+                    <NotificationsPortal />
+                    <Main style={ { padding: 0 } } >
+                        <Routes childProps={props} />
+                    </Main>
+                </React.Fragment>
+            </IntlProvider>
+        </Router>
     );
 };
 

--- a/src/entries.js
+++ b/src/entries.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import App from './App';
+import { getDevStore, getProdStore } from './Utilities/store';
+
+export const DevEntry = () => (<Provider store={getDevStore()}>
+    <App />
+</Provider>);
+
+export const ProdEntry = () => (<Provider store={getProdStore()}>
+    <App />
+</Provider>);

--- a/src/entry-dev.js
+++ b/src/entry-dev.js
@@ -1,16 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { BrowserRouter as Router } from 'react-router-dom';
-import { Provider } from 'react-redux';
-import App from './App';
-import { getBaseName } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
-import { getDevStore } from './Utilities/store';
+import { DevEntry } from './entries';
 
-ReactDOM.render(
-    <Provider store={getDevStore()}>
-        <Router basename={getBaseName(location.pathname)}>
-            <App />
-        </Router>
-    </Provider>,
-    document.getElementById('root')
-);
+ReactDOM.render(<DevEntry />, document.getElementById('root'));

--- a/src/entry.js
+++ b/src/entry.js
@@ -1,16 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { BrowserRouter as Router } from 'react-router-dom';
-import { Provider } from 'react-redux';
-import App from './App';
-import { getBaseName } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
-import { getProdStore } from './Utilities/store';
+import { ProdEntry } from './entries';
 
-ReactDOM.render(
-    <Provider store={getProdStore()}>
-        <Router basename={getBaseName(location.pathname)}>
-            <App />
-        </Router>
-    </Provider>,
-    document.getElementById('root')
-);
+ReactDOM.render(<ProdEntry />, document.getElementById('root'));

--- a/src/test/app.spec.js
+++ b/src/test/app.spec.js
@@ -4,6 +4,7 @@ import React from 'react';
 import { NotificationsPortal } from '@redhat-cloud-services/frontend-components-notifications';
 import { Main } from '@redhat-cloud-services/frontend-components';
 import { act } from 'react-dom/test-utils';
+import { BrowserRouter as Router } from 'react-router-dom';
 
 import App from '../App';
 import { componentWrapperIntl } from '../Utilities/testsHelpers';
@@ -81,5 +82,7 @@ describe('App spec js', () => {
         expect(wrapper.find(NotificationsPortal)).toHaveLength(1);
         expect(wrapper.find(Main)).toHaveLength(1);
         expect(wrapper.find(Routes)).toHaveLength(1);
+        expect(wrapper.find(Router)).toHaveLength(1);
+        expect(wrapper.find(Router).props().basename).toEqual('//');
     });
 });

--- a/src/test/entries.spec.js
+++ b/src/test/entries.spec.js
@@ -1,0 +1,37 @@
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+
+import { DevEntry, ProdEntry } from '../entries';
+import * as app from '../App';
+import * as stores from '../Utilities/store';
+
+describe('entries test', () => {
+    let store;
+
+    beforeEach(() => {
+        store = configureStore()({});
+        stores.getDevStore = jest.fn().mockImplementation(() => store);
+        stores.getProdStore = jest.fn().mockImplementation(() => store);
+
+        // eslint-disable-next-line react/display-name
+        app.default = () => <h1></h1>;
+    });
+
+    it('dev is rendered correctly', () => {
+        const wrapper = mount(<DevEntry />);
+
+        expect(wrapper.find(Provider)).toHaveLength(1);
+        expect(wrapper.find('h1')).toHaveLength(1);
+        expect(stores.getDevStore).toHaveBeenCalled();
+        expect(stores.getProdStore).not.toHaveBeenCalled();
+    });
+
+    it('prod is rendered correctly', () => {
+        const wrapper = mount(<ProdEntry />);
+
+        expect(wrapper.find(Provider)).toHaveLength(1);
+        expect(wrapper.find('h1')).toHaveLength(1);
+        expect(stores.getDevStore).not.toHaveBeenCalled();
+        expect(stores.getProdStore).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Entries are moved into separate components because of testability. ReactDOM functions are excluded from the testing, because it cannot be tested.