### PR TITLE
Refactor routes to use one source of truth for all functionality

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -12,17 +12,33 @@ const Loader = () => (
     </ContentLoader>
 );
 
-export const paths = {
-    sources: '/',
-    sourcesNew: '/new',
-    sourcesEdit: '/edit/:id',
-    sourcesRemove: '/remove/:id',
-    sourceManageApps: '/manage_apps/:id'
+export const routes = {
+    sources: {
+        path: '/'
+    },
+    sourcesNew: {
+        path: '/new',
+        writeAccess: true
+    },
+    sourcesEdit: {
+        path: '/edit/:id',
+        writeAccess: true
+    },
+    sourcesRemove: {
+        path: '/remove/:id',
+        redirectNoId: true,
+        writeAccess: true
+    },
+    sourceManageApps: {
+        path: '/manage_apps/:id',
+        redirectNoId: true,
+        writeAccess: true
+    }
 };
 
 const Routes = () =>  (
     <Suspense fallback={<Loader/>}>
-        <Route path={paths.sources} component={SourcesPage} />
+        <Route path={routes.sources.path} component={SourcesPage} />
     </Suspense>
 );
 

--- a/src/components/AddApplication/AddApplication.js
+++ b/src/components/AddApplication/AddApplication.js
@@ -17,7 +17,7 @@ import RedirectNoId from '../RedirectNoId/RedirectNoId';
 import { useSource } from '../../hooks/useSource';
 import { useIsLoaded } from '../../hooks/useIsLoaded';
 import { endpointToUrl } from '../SourcesSimpleView/formatters';
-import { paths } from '../../Routes';
+import { routes } from '../../Routes';
 
 import { doAttachApp } from '../../api/doAttachApp';
 
@@ -113,7 +113,7 @@ const AddApplication = () => {
         }
     }, [source]);
 
-    const goToSources = () => history.push(paths.sources);
+    const goToSources = () => history.push(routes.sources.path);
 
     if (!appTypesLoaded || !sourceTypesLoaded || !loaded) {
         return  (

--- a/src/components/AddApplication/AddApplication.js
+++ b/src/components/AddApplication/AddApplication.js
@@ -13,7 +13,6 @@ import WizardBody from './WizardBody';
 
 import { getSourcesApi } from '../../api/entities';
 
-import RedirectNoId from '../RedirectNoId/RedirectNoId';
 import { useSource } from '../../hooks/useSource';
 import { useIsLoaded } from '../../hooks/useIsLoaded';
 import { endpointToUrl } from '../SourcesSimpleView/formatters';
@@ -122,10 +121,6 @@ const AddApplication = () => {
                 step={<LoadingStep />}
             />
         );
-    }
-
-    if (!source) {
-        return <RedirectNoId />;
     }
 
     if (state.state === 'loading' || state.state === 'submitting') {

--- a/src/components/AddApplication/AddApplicationDescription.js
+++ b/src/components/AddApplication/AddApplicationDescription.js
@@ -11,7 +11,6 @@ import {
 
 import RemoveAppModal from './RemoveAppModal';
 import ApplicationList from '../ApplicationsList/ApplicationList';
-import RedirectNoId from '../RedirectNoId/RedirectNoId';
 import { useSource } from '../../hooks/useSource';
 
 const AddApplicationDescription = () => {
@@ -19,10 +18,6 @@ const AddApplicationDescription = () => {
 
     const sourceTypes = useSelector(({ sources }) => sources.sourceTypes);
     const source = useSource();
-
-    if (!source) {
-        return <RedirectNoId />;
-    }
 
     const sourceType = sourceTypes.find((type) => type.id === source.source_type_id);
     const apps = source.applications.filter((app) => !app.isDeleting);

--- a/src/components/AddApplication/RemoveAppModal.js
+++ b/src/components/AddApplication/RemoveAppModal.js
@@ -15,7 +15,6 @@ import {
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 
 import { removeApplication } from '../../redux/sources/actions';
-import RedirectNoId from '../RedirectNoId/RedirectNoId';
 import { useSource } from '../../hooks/useSource';
 
 const RemoveAppModal = ({ app, onCancel }) => {
@@ -25,10 +24,6 @@ const RemoveAppModal = ({ app, onCancel }) => {
     const source = useSource();
 
     const dispatch = useDispatch();
-
-    if (!source) {
-        return <RedirectNoId/>;
-    }
 
     const dependentApps = app.dependent_applications.map(appName => {
         const appType = appTypes.find(({ name }) => name === appName);

--- a/src/components/ApplicationsList/ApplicationList.js
+++ b/src/components/ApplicationsList/ApplicationList.js
@@ -12,16 +12,11 @@ import {
     ButtonVariant
 } from '@patternfly/react-core';
 
-import RedirectNoId from '../RedirectNoId/RedirectNoId';
 import { useSource } from '../../hooks/useSource';
 
 const ApplicationList = ({ setApplicationToRemove, breakpoints, namePrefix }) => {
     const appTypes = useSelector(({ sources }) => sources.appTypes);
     const source = useSource();
-
-    if (!source) {
-        return <RedirectNoId/>;
-    }
 
     const sourceAppsNames = source.applications
     .map(({ application_type_id }) => {

--- a/src/components/CustomRoute/CustomRoute.js
+++ b/src/components/CustomRoute/CustomRoute.js
@@ -7,7 +7,7 @@ import { useSource } from '../../hooks/useSource';
 import RedirectNoId from '../RedirectNoId/RedirectNoId';
 
 const CustomRouteInternal = ({ route, children }) => {
-    const source = useSource();
+    const source = route.redirectNoId ? useSource() : undefined;
 
     if (!source && route.redirectNoId) {
         return <RedirectNoId />;

--- a/src/components/CustomRoute/CustomRoute.js
+++ b/src/components/CustomRoute/CustomRoute.js
@@ -30,19 +30,13 @@ CustomRouteInternal.propTypes = {
     children: PropTypes.node.isRequired
 };
 
-const CustomRoute = ({ route, componentProps, Component, ...props }) => {
-    return (
-        <Route
-            {...props}
-            path={route.path}
-            render={() => (
-                <CustomRouteInternal route={route}>
-                    <Component  {...componentProps}/>
-                </CustomRouteInternal>
-            )}
-        />
-    );
-};
+const CustomRoute = ({ route, componentProps, Component, ...props }) =>  (
+    <Route {...props} path={route.path}>
+        <CustomRouteInternal route={route}>
+            <Component  {...componentProps}/>
+        </CustomRouteInternal>
+    </Route>
+);
 
 CustomRoute.propTypes = {
     route: PropTypes.shape({

--- a/src/components/CustomRoute/CustomRoute.js
+++ b/src/components/CustomRoute/CustomRoute.js
@@ -9,7 +9,7 @@ import RedirectNoId from '../RedirectNoId/RedirectNoId';
 const CustomRouteInternal = ({ route, children }) => {
     const source = useSource();
 
-    if (!source) {
+    if (!source && route.redirectNoId) {
         return <RedirectNoId />;
     }
 

--- a/src/components/CustomRoute/CustomRoute.js
+++ b/src/components/CustomRoute/CustomRoute.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Route } from 'react-router-dom';
+import PropTypes from 'prop-types';
+
+import RedirectNotAdmin from '../RedirectNotAdmin/RedirectNotAdmin';
+import { useSource } from '../../hooks/useSource';
+import RedirectNoId from '../RedirectNoId/RedirectNoId';
+
+const CustomRouteInternal = ({ route, children }) => {
+    const source = useSource();
+
+    if (!source) {
+        return <RedirectNoId />;
+    }
+
+    return (
+        <React.Fragment>
+            {route.writeAccess && <RedirectNotAdmin />}
+            {children}
+        </React.Fragment>
+    );
+};
+
+CustomRouteInternal.propTypes = {
+    route: PropTypes.shape({
+        path: PropTypes.string.isRequired,
+        redirectNoId: PropTypes.bool,
+        writeAccess: PropTypes.bool
+    }).isRequired,
+    children: PropTypes.node.isRequired
+};
+
+const CustomRoute = ({ route, componentProps, Component, ...props }) => {
+    return (
+        <Route
+            {...props}
+            path={route.path}
+            render={() => (
+                <CustomRouteInternal route={route}>
+                    <Component  {...componentProps}/>
+                </CustomRouteInternal>
+            )}
+        />
+    );
+};
+
+CustomRoute.propTypes = {
+    route: PropTypes.shape({
+        path: PropTypes.string.isRequired,
+        redirectNoId: PropTypes.bool,
+        writeAccess: PropTypes.bool
+    }).isRequired,
+    componentProps: PropTypes.any,
+    Component: PropTypes.func.isRequired
+};
+
+export default CustomRoute;

--- a/src/components/SourceEditForm/SourceEditModal.js
+++ b/src/components/SourceEditForm/SourceEditModal.js
@@ -15,6 +15,7 @@ import { prepareInitialValues } from './helpers';
 import { onSubmit } from './onSubmit';
 
 import { redirectWhenImported } from './importedRedirect';
+import { routes } from '../../Routes';
 
 const initialState = {
     loading: true,
@@ -85,6 +86,8 @@ const SourceEditModal = () => {
 
     const isLoading = !appTypesLoaded || !sourceTypesLoaded || loading;
 
+    const returnToSources = () => history.push(routes.sources.path);
+
     if (isLoading) {
         return (
             <Modal
@@ -95,7 +98,7 @@ const SourceEditModal = () => {
                 header={<Header />}
                 isOpen={true}
                 isLarge
-                onClose={() => history.push('/')}
+                onClose={returnToSources}
             >
                 <div className="ins-c-sources__dialog--spinnerContainer">
                     <Spinner />
@@ -113,10 +116,10 @@ const SourceEditModal = () => {
             header={<Header />}
             isOpen={true}
             isLarge
-            onClose={() => history.push('/')}
+            onClose={returnToSources}
         >
             <SourcesFormRenderer
-                onCancel={() => history.push('/')}
+                onCancel={returnToSources}
                 schema={schema}
                 onSubmit={
                     (values, formApi) => onSubmit(values, formApi.getState().dirtyFields, dispatch, source, intl, history.push)

--- a/src/components/SourceEditForm/importedRedirect.js
+++ b/src/components/SourceEditForm/importedRedirect.js
@@ -1,4 +1,4 @@
-import { paths } from '../../Routes';
+import { routes } from '../../Routes';
 import { addMessage } from '../../redux/sources/actions';
 
 export const redirectWhenImported = (dispatch, intl, history, name) => {
@@ -13,5 +13,5 @@ export const redirectWhenImported = (dispatch, intl, history, name) => {
             defaultMessage: 'Imported sources cannot be edited.'
         }),
     ));
-    history.push(paths.sources);
+    history.push(routes.sources.path);
 };

--- a/src/components/SourceEditForm/onSubmit.js
+++ b/src/components/SourceEditForm/onSubmit.js
@@ -1,6 +1,6 @@
 import { selectOnlyEditedValues } from './helpers';
 import { updateSource, loadEntities } from '../../redux/sources/actions';
-import { paths } from '../../Routes';
+import { routes } from '../../Routes';
 
 export const onSubmit = (values, editing, dispatch, source, intl, push) => dispatch(updateSource(
     source,
@@ -32,6 +32,6 @@ export const onSubmit = (values, editing, dispatch, source, intl, push) => dispa
         })
     }))
 .then(() => {
-    push(paths.sources);
+    push(routes.sources.path);
     dispatch(loadEntities());
 });

--- a/src/components/SourceRemoveModal.js
+++ b/src/components/SourceRemoveModal.js
@@ -21,6 +21,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import ApplicationList from './ApplicationsList/ApplicationList';
 import RemoveAppModal from './AddApplication/RemoveAppModal';
 import { useSource } from '../hooks/useSource';
+import { routes } from '../Routes';
 
 const SourceRemoveModal = () => {
     const { push } = useHistory();
@@ -33,20 +34,20 @@ const SourceRemoveModal = () => {
 
     const dispatch = useDispatch();
 
+    const returnToSources = () => push(routes.sources.path);
+
     const onSubmit = () => {
-        push('/');
+        returnToSources();
         dispatch(removeSource(source.id, intl.formatMessage({
             id: 'sources.notificationDeleteMessage',
             defaultMessage: `{title} was deleted successfully.`
         }, { title: source.name })));
     };
 
-    const onCancel = () => push('/');
-
     const sourceHasActiveApp = source.applications.some((app) => !app.isDeleting);
 
     const actions = source.applications.length > 0 ? [
-        <Button id="deleteCancel" key="cancel" variant="link" type="button" onClick={ onCancel }>
+        <Button id="deleteCancel" key="cancel" variant="link" type="button" onClick={ returnToSources }>
             <FormattedMessage
                 id="sources.close"
                 defaultMessage="Close"
@@ -61,7 +62,7 @@ const SourceRemoveModal = () => {
                 defaultMessage="Delete this source and its data"
             />
         </Button>,
-        <Button id="deleteCancel" key="cancel" variant="link" type="button" onClick={ onCancel }>
+        <Button id="deleteCancel" key="cancel" variant="link" type="button" onClick={ returnToSources }>
             <FormattedMessage
                 id="sources.deleteCancel"
                 defaultMessage="Do not delete this source"
@@ -163,7 +164,7 @@ const SourceRemoveModal = () => {
             }
             isOpen
             isSmall
-            onClose={ onCancel }
+            onClose={ returnToSources }
             actions={ actions }
             isFooterLeftAligned
         >

--- a/src/components/SourceRemoveModal.js
+++ b/src/components/SourceRemoveModal.js
@@ -20,7 +20,6 @@ import { FormattedMessage, useIntl } from 'react-intl';
 
 import ApplicationList from './ApplicationsList/ApplicationList';
 import RemoveAppModal from './AddApplication/RemoveAppModal';
-import RedirectNoId from './RedirectNoId/RedirectNoId';
 import { useSource } from '../hooks/useSource';
 
 const SourceRemoveModal = () => {
@@ -33,10 +32,6 @@ const SourceRemoveModal = () => {
     const source = useSource();
 
     const dispatch = useDispatch();
-
-    if (!source) {
-        return <RedirectNoId/>;
-    }
 
     const onSubmit = () => {
         push('/');

--- a/src/components/SourcesEmptyState.js
+++ b/src/components/SourcesEmptyState.js
@@ -14,7 +14,7 @@ import { FormattedMessage } from 'react-intl';
 
 import { WrenchIcon } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
-import { paths } from '../Routes';
+import { routes } from '../Routes';
 import { useIsOrgAdmin } from '../hooks/useIsOrgAdmin';
 
 const SourcesEmptyState = ({ title, body }) => {
@@ -45,7 +45,7 @@ const SourcesEmptyState = ({ title, body }) => {
                                 defaultMessage="To define a source, you have to be an organisation admin."
                             />}
                         </EmptyStateBody>
-                        {isOrgAdmin && <Link to={paths.sourcesNew}>
+                        {isOrgAdmin && <Link to={routes.sourcesNew.path}>
                             <Button style={{ marginTop: 'var(--pf-c-empty-state--c-button--MarginTop)' }}
                                 variant="primary">
                                 <FormattedMessage

--- a/src/components/UndoButton/UndoButtonAdd.js
+++ b/src/components/UndoButton/UndoButtonAdd.js
@@ -6,7 +6,7 @@ import { useHistory } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 
 import { removeMessage, undoAddSource } from '../../redux/sources/actions';
-import { paths } from '../../Routes';
+import { routes } from '../../Routes';
 import { refreshPage } from './refreshPage';
 
 const UndoButton = ({ messageId, values }) => {
@@ -24,12 +24,12 @@ const UndoButton = ({ messageId, values }) => {
 
             dispatch(undoAddSource(values));
 
-            const isOnWizard = history.location.pathname === paths.sourcesNew;
+            const isOnWizard = history.location.pathname === routes.sourcesNew.path;
 
             if (isOnWizard) {
                 refreshPage(history);
             } else {
-                history.push(paths.sourcesNew);
+                history.push(routes.sourcesNew.path);
             }
         }}>
             <FormattedMessage

--- a/src/components/UndoButton/refreshPage.js
+++ b/src/components/UndoButton/refreshPage.js
@@ -1,4 +1,6 @@
+import { routes } from '../../Routes';
+
 export const refreshPage = history => {
-    history.push('/');
+    history.push(routes.sources.path);
     history.goBack();
 };

--- a/src/pages/SourcesPage.js
+++ b/src/pages/SourcesPage.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { PageHeader, PageHeaderTitle, Section } from '@redhat-cloud-services/frontend-components';
-import { Link, useHistory, Route } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import {
     loadAppTypes,
     loadEntities,
@@ -19,7 +19,7 @@ import SourceEditModal from '../components/SourceEditForm/SourceEditModal';
 import SourceRemoveModal from '../components/SourceRemoveModal';
 import AddApplication from '../components/AddApplication/AddApplication';
 import { pageAndSize } from '../redux/sources/actions';
-import { paths } from '../Routes';
+import { routes } from '../Routes';
 
 import {
     prepareChips,
@@ -33,8 +33,8 @@ import {
 } from './SourcesPage/helpers';
 import PaginationLoader from './SourcesPage/PaginationLoader';
 import { useIsLoaded } from '../hooks/useIsLoaded';
-import RedirectNotAdmin from '../components/RedirectNotAdmin/RedirectNotAdmin';
 import { useIsOrgAdmin } from '../hooks/useIsOrgAdmin';
+import CustomRoute from '../components/CustomRoute/CustomRoute';
 
 const SourcesPage = () => {
     const [showEmptyState, setShowEmptyState] = useState(false);
@@ -114,7 +114,7 @@ const SourcesPage = () => {
                 pagination={showPaginationLoader ? <PaginationLoader /> : numberOfEntities > 0 ? paginationConfig : undefined}
                 actionsConfig={isOrgAdmin ? {
                     actions: [
-                        <Link to={paths.sourcesNew} key="addSourceButton">
+                        <Link to={routes.sourcesNew.path} key="addSourceButton">
                             <Button variant='primary'>
                                 <FormattedMessage
                                     id="sources.addSource"
@@ -173,42 +173,23 @@ const SourcesPage = () => {
 
     return (
         <React.Fragment>
-            <Route
-                exact path={paths.sourceManageApps}
-                render={ () => (<React.Fragment>
-                    <RedirectNotAdmin />
-                    <AddApplication/>
-                </React.Fragment>) }
+            <CustomRoute exact route={routes.sourceManageApps} Component={AddApplication}/>
+            <CustomRoute exact route={routes.sourcesRemove} Component={SourceRemoveModal}/>
+            <CustomRoute
+                exact
+                route={routes.sourcesNew}
+                Component={AddSourceWizard}
+                componentProps={{
+                    sourceTypes: loadedTypes(sourceTypes, sourceTypesLoaded),
+                    applicationTypes: loadedTypes(appTypes, appTypesLoaded),
+                    isOpen: true,
+                    onClose: (values) => onCloseAddSourceWizard({ values, dispatch, history, intl }),
+                    afterSuccess: () => afterSuccess(dispatch),
+                    hideSourcesButton: true,
+                    initialValues: addSourceInitialValues
+                }}
             />
-            <Route
-                exact path={paths.sourcesRemove}
-                render={ () => (<React.Fragment>
-                    <RedirectNotAdmin />
-                    <SourceRemoveModal />
-                </React.Fragment>) }
-            />
-            <Route
-                exact path={paths.sourcesNew}
-                render={ () => (<React.Fragment>
-                    <RedirectNotAdmin />
-                    <AddSourceWizard
-                        sourceTypes={loadedTypes(sourceTypes, sourceTypesLoaded)}
-                        applicationTypes={loadedTypes(appTypes, appTypesLoaded)}
-                        isOpen={true}
-                        onClose={(values) => onCloseAddSourceWizard({ values, dispatch, history, intl })}
-                        afterSuccess={() => afterSuccess(dispatch)}
-                        hideSourcesButton={true}
-                        initialValues={addSourceInitialValues}
-                    />
-                </React.Fragment>) }
-            />
-            <Route
-                exact path={paths.sourcesEdit}
-                render={ () => (<React.Fragment>
-                    <RedirectNotAdmin />
-                    <SourceEditModal />
-                </React.Fragment>) }
-            />
+            <CustomRoute exact route={routes.sourcesEdit} Component={SourceEditModal}/>
             <PageHeader>
                 <PageHeaderTitle title={intl.formatMessage({
                     id: 'sources.sources',

--- a/src/pages/SourcesPage/helpers.js
+++ b/src/pages/SourcesPage/helpers.js
@@ -10,6 +10,7 @@ import {
     addMessage
 } from '../../redux/sources/actions';
 import UndoButtonAdd from '../../components/UndoButton/UndoButtonAdd';
+import { routes } from '../../Routes';
 
 export const onCloseAddSourceWizard = ({ values, dispatch, history, intl }) => {
     if (values && !isEmpty(values)) {
@@ -30,7 +31,7 @@ export const onCloseAddSourceWizard = ({ values, dispatch, history, intl }) => {
     }
 
     dispatch(clearAddSource());
-    history.push('/');
+    history.push(routes.sources.path);
 };
 
 export const debouncedFiltering = awesomeDebounce((refresh) => refresh(), 500);

--- a/src/test/components/SourceRemoveModal.spec.js
+++ b/src/test/components/SourceRemoveModal.spec.js
@@ -14,6 +14,7 @@ import { sourcesDataGraphQl } from '../sourcesData';
 import { applicationTypesData } from '../applicationTypesData';
 import RemoveAppModal from '../../components/AddApplication/RemoveAppModal';
 import ApplicationList from '../../components/ApplicationsList/ApplicationList';
+import { routes } from '../../Routes';
 
 describe('SourceRemoveModal', () => {
     const middlewares = [thunk, notificationsMiddleware()];
@@ -71,7 +72,7 @@ describe('SourceRemoveModal', () => {
 
             const source = sourcesDataGraphQl.find((s) => s.id === '14');
 
-            expect(wrapper.find(MemoryRouter).instance().history.location.pathname).toEqual('/'); // modal was closed
+            expect(wrapper.find(MemoryRouter).instance().history.location.pathname).toEqual(routes.sources.path); // modal was closed
             expect(actions.removeSource).toHaveBeenCalledWith('14', `${source.name} was deleted successfully.`); // calls removeSource with id of the source and right message
         });
     });

--- a/src/test/components/SourceRemoveModal.spec.js
+++ b/src/test/components/SourceRemoveModal.spec.js
@@ -14,7 +14,6 @@ import { sourcesDataGraphQl } from '../sourcesData';
 import { applicationTypesData } from '../applicationTypesData';
 import RemoveAppModal from '../../components/AddApplication/RemoveAppModal';
 import ApplicationList from '../../components/ApplicationsList/ApplicationList';
-import RedirectNoId from '../../components/RedirectNoId/RedirectNoId';
 
 describe('SourceRemoveModal', () => {
     const middlewares = [thunk, notificationsMiddleware()];
@@ -39,20 +38,6 @@ describe('SourceRemoveModal', () => {
             expect(wrapper.find('input')).toHaveLength(1); // checkbox
             expect(wrapper.find(Button)).toHaveLength(3); // cancel modal, cancel delete, delete
             expect(wrapper.find('button[id="deleteSubmit"]').props().disabled).toEqual(true); // delete is disabled
-        });
-
-        it('renders redirect app when no source', () => {
-            store = mockStore({
-                sources: { entities: [], appTypes: applicationTypesData.data }
-            });
-
-            const wrapper = mount(componentWrapperIntl(
-                <Route path="/remove/:id" render={ (...args) => <SourceRemoveModal { ...args } /> } />,
-                store,
-                ['/remove/14'])
-            );
-
-            expect(wrapper.find(RedirectNoId)).toHaveLength(1);
         });
 
         it('enables submit button', () => {

--- a/src/test/components/addApplication/AddApplication.spec.js
+++ b/src/test/components/addApplication/AddApplication.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { Button, EmptyStateBody } from '@patternfly/react-core';
-import { Route, MemoryRouter } from 'react-router-dom';
+import { Route } from 'react-router-dom';
 import { notificationsMiddleware } from '@redhat-cloud-services/frontend-components-notifications';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
@@ -174,34 +174,6 @@ describe('AddApplication', () => {
         });
 
         expect(wrapper.find(LoadingStep)).toHaveLength(1);
-    });
-
-    it('redirects to table when the source does not exist', async () => {
-        entities.doLoadSource = jest.fn().mockImplementation(() => Promise.resolve({ sources: [] }));
-
-        store = mockStore({
-            sources: {
-                entities: [],
-                appTypes: applicationTypesData.data,
-                sourceTypes: sourceTypesData.data,
-                appTypesLoaded: true,
-                sourceTypesLoaded: true,
-                loaded: 0
-            }
-        });
-
-        let wrapper;
-
-        await act(async () => {
-            wrapper = mount(componentWrapperIntl(
-                <Route path={routes.sourceManageApps.path} render={ (...args) => <AddApplication { ...args }/> } />,
-                store,
-                initialEntry
-            ));
-        });
-        wrapper.update();
-
-        expect(wrapper.find(MemoryRouter).instance().history.location.pathname).toEqual(routes.sources.path);
     });
 
     describe('imported source - not need to edit any value', () => {

--- a/src/test/components/addApplication/AddApplication.spec.js
+++ b/src/test/components/addApplication/AddApplication.spec.js
@@ -19,7 +19,7 @@ import { SOURCE_ALL_APS_ID, SOURCE_NO_APS_ID } from '../../sourcesData';
 import { applicationTypesData, COSTMANAGEMENT_APP, TOPOLOGICALINVENTORY_APP } from '../../applicationTypesData';
 import AddApplicationDescription from '../../../components/AddApplication/AddApplicationDescription';
 import LoadingStep from '../../../components/steps/LoadingStep';
-import { paths } from '../../../Routes';
+import { routes } from '../../../Routes';
 import FinishedStep from '../../../components/steps/FinishedStep';
 import ErroredStepAttach from '../../../components/AddApplication/steps/ErroredStep';
 
@@ -65,7 +65,7 @@ describe('AddApplication', () => {
 
         await act(async () => {
             wrapper = mount(componentWrapperIntl(
-                <Route path={paths.sourceManageApps} render={ (...args) => <AddApplication { ...args }/> } />,
+                <Route path={routes.sourceManageApps.path} render={ (...args) => <AddApplication { ...args }/> } />,
                 store,
                 initialEntry
             ));
@@ -118,7 +118,7 @@ describe('AddApplication', () => {
 
         await act(async () => {
             wrapper = mount(componentWrapperIntl(
-                <Route path={paths.sourceManageApps} render={ (...args) => <AddApplication { ...args }/> } />,
+                <Route path={routes.sourceManageApps.path} render={ (...args) => <AddApplication { ...args }/> } />,
                 store,
                 initialEntry
             ));
@@ -138,7 +138,7 @@ describe('AddApplication', () => {
 
         await act(async () => {
             wrapper = mount(componentWrapperIntl(
-                <Route path={paths.sourceManageApps} render={ (...args) => <AddApplication { ...args }/> } />,
+                <Route path={routes.sourceManageApps.path} render={ (...args) => <AddApplication { ...args }/> } />,
                 store,
                 [`${PATH}${SOURCE_ALL_APS_ID}`]
             ));
@@ -167,7 +167,7 @@ describe('AddApplication', () => {
 
         await act(async () => {
             wrapper = mount(componentWrapperIntl(
-                <Route path={paths.sourceManageApps} render={ (...args) => <AddApplication { ...args }/> } />,
+                <Route path={routes.sourceManageApps.path} render={ (...args) => <AddApplication { ...args }/> } />,
                 store,
                 initialEntry
             ));
@@ -194,14 +194,14 @@ describe('AddApplication', () => {
 
         await act(async () => {
             wrapper = mount(componentWrapperIntl(
-                <Route path={paths.sourceManageApps} render={ (...args) => <AddApplication { ...args }/> } />,
+                <Route path={routes.sourceManageApps.path} render={ (...args) => <AddApplication { ...args }/> } />,
                 store,
                 initialEntry
             ));
         });
         wrapper.update();
 
-        expect(wrapper.find(MemoryRouter).instance().history.location.pathname).toEqual(paths.sources);
+        expect(wrapper.find(MemoryRouter).instance().history.location.pathname).toEqual(routes.sources.path);
     });
 
     describe('imported source - not need to edit any value', () => {
@@ -225,7 +225,7 @@ describe('AddApplication', () => {
 
         it('renders review', () => {
             const wrapper = mount(componentWrapperIntl(
-                <Route path={paths.sourceManageApps} render={ (...args) => <AddApplication { ...args }/> } />,
+                <Route path={routes.sourceManageApps.path} render={ (...args) => <AddApplication { ...args }/> } />,
                 store,
                 initialEntry
             ));
@@ -245,7 +245,7 @@ describe('AddApplication', () => {
             entities.doLoadCountOfSources = jest.fn().mockImplementation(() => Promise.resolve({ meta: { count: 0 } }));
 
             const wrapper = mount(componentWrapperIntl(
-                <Route path={paths.sourceManageApps} render={ (...args) => <AddApplication { ...args }/> } />,
+                <Route path={routes.sourceManageApps.path} render={ (...args) => <AddApplication { ...args }/> } />,
                 store,
                 initialEntry
             ));
@@ -286,7 +286,7 @@ describe('AddApplication', () => {
             attachSource.doAttachApp = jest.fn().mockImplementation(() => new Promise((res, reject) => reject(ERROR_MESSAGE)));
 
             const wrapper = mount(componentWrapperIntl(
-                <Route path={paths.sourceManageApps} render={ (...args) => <AddApplication { ...args }/> } />,
+                <Route path={routes.sourceManageApps.path} render={ (...args) => <AddApplication { ...args }/> } />,
                 store,
                 initialEntry
             ));
@@ -326,7 +326,7 @@ describe('AddApplication', () => {
             attachSource.doAttachApp = jest.fn().mockImplementation(() => Promise.resolve('ok'));
 
             const wrapper = mount(componentWrapperIntl(
-                <Route path={paths.sourceManageApps} render={ (...args) => <AddApplication { ...args }/> } />,
+                <Route path={routes.sourceManageApps.path} render={ (...args) => <AddApplication { ...args }/> } />,
                 store,
                 initialEntry
             ));

--- a/src/test/components/addApplication/AddApplicationDescription.spec.js
+++ b/src/test/components/addApplication/AddApplicationDescription.spec.js
@@ -14,7 +14,6 @@ import { sourcesDataGraphQl } from '../../sourcesData';
 import { applicationTypesData } from '../../applicationTypesData';
 import RemoveAppModal from '../../../components/AddApplication/RemoveAppModal';
 import ApplicationList from '../../../components/ApplicationsList/ApplicationList';
-import RedirectNoId from '../../../components/RedirectNoId/RedirectNoId';
 
 describe('AddApplicationDescription', () => {
     let store;
@@ -49,24 +48,6 @@ describe('AddApplicationDescription', () => {
         expect(wrapper.find(ApplicationList).length).toEqual(0);
         expect(wrapper.find(FormattedMessage).last().text()).toEqual('No applications');
         expect(wrapper.find(Button).length).toEqual(0);
-    });
-
-    it('renders RedirectNoId', () => {
-        store = mockStore({
-            sources: {
-                entities: [],
-                appTypes: applicationTypesData.data,
-                sourceTypes: sourceTypesData.data
-            }
-        });
-
-        const wrapper = mount(componentWrapperIntl(
-            <Route path="/add_application/:id" render={ (...args) => <AddApplicationDescription { ...args }/> } />,
-            store,
-            initialEntry
-        ));
-
-        expect(wrapper.find(RedirectNoId)).toHaveLength(1);
     });
 
     it('renders correctly with application', () => {

--- a/src/test/components/addApplication/AuthTypeSetter.spec.js
+++ b/src/test/components/addApplication/AuthTypeSetter.spec.js
@@ -7,7 +7,7 @@ import { Route } from 'react-router-dom';
 import { componentWrapperIntl } from '../../../Utilities/testsHelpers';
 import { sourceTypesData, OPENSHIFT_ID } from '../../sourceTypesData';
 import { AuthTypeSetter, checkAuthTypeMemo, innerSetter } from '../../../components/AddApplication/AuthTypeSetter';
-import { paths } from '../../../Routes';
+import { routes } from '../../../Routes';
 
 describe('AuthTypeSetter', () => {
     let store;
@@ -88,7 +88,7 @@ describe('AuthTypeSetter', () => {
 
     it('sets authentication when authentication_type on undefined', () => {
         mount(componentWrapperIntl(
-            <Route path={paths.sourceManageApps} render={ (...args) => <AuthTypeSetter { ...args } {...initialProps}/> } />,
+            <Route path={routes.sourceManageApps.path} render={ (...args) => <AuthTypeSetter { ...args } {...initialProps}/> } />,
             store,
             initialEntry
         ));
@@ -114,7 +114,7 @@ describe('AuthTypeSetter', () => {
         };
 
         mount(componentWrapperIntl(
-            <Route path={paths.sourceManageApps} render={ (...args) => <AuthTypeSetter { ...args } {...initialProps}/> } />,
+            <Route path={routes.sourceManageApps.path} render={ (...args) => <AuthTypeSetter { ...args } {...initialProps}/> } />,
             store,
             initialEntry
         ));

--- a/src/test/components/addApplication/RemoveAppModal.spec.js
+++ b/src/test/components/addApplication/RemoveAppModal.spec.js
@@ -9,7 +9,6 @@ import RemoveAppModal from '../../../components/AddApplication/RemoveAppModal';
 import * as actions from '../../../redux/sources/actions';
 import { routes } from '../../../Routes';
 import { componentWrapperIntl } from '../../../Utilities/testsHelpers';
-import RedirectNoId from '../../../components/RedirectNoId/RedirectNoId';
 
 describe('RemoveAppModal', () => {
     let store;
@@ -74,25 +73,6 @@ describe('RemoveAppModal', () => {
         expect(wrapper.find(FormattedMessage).length).toEqual(3);
         expect(wrapper.find(Button).at(1).text()).toEqual('Remove');
         expect(wrapper.find(Button).last().text()).toEqual('Cancel');
-    });
-
-    it('renders correctly RedirectNoId with no source', () => {
-        initialStore = {
-            sources: {
-                appTypes: [],
-                entities: []
-            }
-        };
-
-        store = mockStore(initialStore);
-
-        const wrapper = mount(componentWrapperIntl(
-            <Route path={routes.sourceManageApps.path} render={ (...args) =>  <RemoveAppModal {...args} {...initialProps} /> } />,
-            store,
-            initialEntry
-        ));
-
-        expect(wrapper.find(RedirectNoId)).toHaveLength(1);
     });
 
     it('renders correctly with attached dependent applications', () => {

--- a/src/test/components/addApplication/RemoveAppModal.spec.js
+++ b/src/test/components/addApplication/RemoveAppModal.spec.js
@@ -7,7 +7,7 @@ import { Route } from 'react-router-dom';
 
 import RemoveAppModal from '../../../components/AddApplication/RemoveAppModal';
 import * as actions from '../../../redux/sources/actions';
-import { paths } from '../../../Routes';
+import { routes } from '../../../Routes';
 import { componentWrapperIntl } from '../../../Utilities/testsHelpers';
 import RedirectNoId from '../../../components/RedirectNoId/RedirectNoId';
 
@@ -64,7 +64,7 @@ describe('RemoveAppModal', () => {
 
     it('renders correctly', () => {
         const wrapper = mount(componentWrapperIntl(
-            <Route path={paths.sourceManageApps} render={ (...args) =>  <RemoveAppModal {...args} {...initialProps} /> } />,
+            <Route path={routes.sourceManageApps.path} render={ (...args) =>  <RemoveAppModal {...args} {...initialProps} /> } />,
             store,
             initialEntry
         ));
@@ -87,7 +87,7 @@ describe('RemoveAppModal', () => {
         store = mockStore(initialStore);
 
         const wrapper = mount(componentWrapperIntl(
-            <Route path={paths.sourceManageApps} render={ (...args) =>  <RemoveAppModal {...args} {...initialProps} /> } />,
+            <Route path={routes.sourceManageApps.path} render={ (...args) =>  <RemoveAppModal {...args} {...initialProps} /> } />,
             store,
             initialEntry
         ));
@@ -111,7 +111,7 @@ describe('RemoveAppModal', () => {
         });
 
         const wrapper = mount(componentWrapperIntl(
-            <Route path={paths.sourceManageApps} render={ (...args) =>  <RemoveAppModal {...args} {...initialProps} app={app}/> } />,
+            <Route path={routes.sourceManageApps.path} render={ (...args) =>  <RemoveAppModal {...args} {...initialProps} app={app}/> } />,
             store,
             initialEntry
         ));
@@ -137,7 +137,7 @@ describe('RemoveAppModal', () => {
         });
 
         const wrapper = mount(componentWrapperIntl(
-            <Route path={paths.sourceManageApps} render={ (...args) =>  <RemoveAppModal {...args} {...initialProps} app={app}/> } />,
+            <Route path={routes.sourceManageApps.path} render={ (...args) =>  <RemoveAppModal {...args} {...initialProps} app={app}/> } />,
             store,
             initialEntry
         ));
@@ -149,7 +149,7 @@ describe('RemoveAppModal', () => {
 
     it('calls cancel', () => {
         const wrapper = mount(componentWrapperIntl(
-            <Route path={paths.sourceManageApps} render={ (...args) =>  <RemoveAppModal {...args} {...initialProps}/> } />,
+            <Route path={routes.sourceManageApps.path} render={ (...args) =>  <RemoveAppModal {...args} {...initialProps}/> } />,
             store,
             initialEntry
         ));
@@ -162,7 +162,7 @@ describe('RemoveAppModal', () => {
         actions.removeApplication = jest.fn().mockImplementation(() => ({ type: 'REMOVE_APP' }));
 
         const wrapper = mount(componentWrapperIntl(
-            <Route path={paths.sourceManageApps} render={ (...args) =>  <RemoveAppModal {...args} {...initialProps}/> } />,
+            <Route path={routes.sourceManageApps.path} render={ (...args) =>  <RemoveAppModal {...args} {...initialProps}/> } />,
             store,
             initialEntry
         ));

--- a/src/test/components/applicationList/ApplicationList.spec.js
+++ b/src/test/components/applicationList/ApplicationList.spec.js
@@ -10,7 +10,6 @@ import ApplicationList from '../../../components/ApplicationsList/ApplicationLis
 import { sourceTypesData } from '../../sourceTypesData';
 import { sourcesDataGraphQl, SOURCE_ALL_APS_ID, SOURCE_ONE_APS_ID } from '../../sourcesData';
 import { applicationTypesData } from '../../applicationTypesData';
-import RedirectNoId from '../../../components/RedirectNoId/RedirectNoId';
 
 describe('ApplicationList', () => {
     let store;
@@ -57,27 +56,6 @@ describe('ApplicationList', () => {
 
         expect(wrapper.find(Text).first().text()).toEqual(applicationType.display_name);
         expect(wrapper.find(Button)).toHaveLength(1);
-    });
-
-    it('renders RedirectNoId with source', () => {
-        initialEntry = [`${PATH}${SOURCE_ONE_APS_ID}`];
-
-        initialStore = {
-            sources: {
-                entities: [],
-                appTypes: applicationTypesData.data,
-                sourceTypes: sourceTypesData.data
-            }
-        };
-        store = mockStore(initialStore);
-
-        const wrapper = mount(componentWrapperIntl(
-            <Route path="/manage_apps/:id" render={ (...args) => <ApplicationList {...initialProps} { ...args }/> } />,
-            store,
-            initialEntry
-        ));
-
-        expect(wrapper.find(RedirectNoId)).toHaveLength(1);
     });
 
     it('renders correctly with prefix', () => {

--- a/src/test/components/customRoute/CustomRoute.spec.js
+++ b/src/test/components/customRoute/CustomRoute.spec.js
@@ -28,7 +28,6 @@ describe('CustomRoute', () => {
         expect(wrapper.find(Route).props().exact).toEqual(true);
         expect(wrapper.find(Route).props().path).toEqual(route.path);
         expect(wrapper.find(Route).props().component).toEqual(undefined);
-        expect(wrapper.find(Route).props().render).toEqual(expect.any(Function));
         expect(wrapper.find(PokusComponent)).toHaveLength(0);
         expect(wrapper.find(RedirectNotAdmin)).toHaveLength(0);
         expect(wrapper.find(RedirectNoId)).toHaveLength(0);

--- a/src/test/components/customRoute/CustomRoute.spec.js
+++ b/src/test/components/customRoute/CustomRoute.spec.js
@@ -1,0 +1,91 @@
+/* eslint-disable react/display-name */
+import React from 'react';
+import { Route } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
+
+import { componentWrapperIntl } from '../../../Utilities/testsHelpers';
+import CustomRoute from '../../../components/CustomRoute/CustomRoute';
+import RedirectNotAdmin from '../../../components/RedirectNotAdmin/RedirectNotAdmin';
+import * as RedirectNoId from '../../../components/RedirectNoId/RedirectNoId';
+import * as useSource from '../../../hooks/useSource';
+
+describe('CustomRoute', () => {
+    const PokusComponent = (props) => <h1 {...props}>Custom component</h1>;
+
+    let route;
+    let store;
+
+    beforeEach(() => {
+        route = {
+            path: '/path'
+        };
+    });
+
+    it('renders route component', () => {
+        const wrapper = mount(componentWrapperIntl(<CustomRoute exact route={route} Component={PokusComponent}/>));
+
+        expect(wrapper.find(Route)).toHaveLength(1);
+        expect(wrapper.find(Route).props().exact).toEqual(true);
+        expect(wrapper.find(Route).props().path).toEqual(route.path);
+        expect(wrapper.find(Route).props().component).toEqual(undefined);
+        expect(wrapper.find(Route).props().render).toEqual(expect.any(Function));
+        expect(wrapper.find(PokusComponent)).toHaveLength(0);
+        expect(wrapper.find(RedirectNotAdmin)).toHaveLength(0);
+        expect(wrapper.find(RedirectNoId)).toHaveLength(0);
+    });
+
+    it('renders custom component', () => {
+        const wrapper = mount(componentWrapperIntl(<CustomRoute exact route={route} Component={PokusComponent}/>, undefined, ['/path']));
+
+        expect(wrapper.find(PokusComponent)).toHaveLength(1);
+    });
+
+    it('renders custom component and passes props', () => {
+        const wrapper = mount(componentWrapperIntl(
+            <CustomRoute exact route={route} Component={PokusComponent} componentProps={{ className: 'pepa', style: { color: 'red' } }}/>,
+            undefined,
+            ['/path'])
+        );
+
+        expect(wrapper.find(PokusComponent)).toHaveLength(1);
+        expect(wrapper.find(PokusComponent).props().className).toEqual('pepa');
+        expect(wrapper.find(PokusComponent).props().style).toEqual({ color: 'red' });
+    });
+
+    it('renders RedirectNotAdmin when writeAccess set', () => {
+        store = configureStore([])({ user: { isOrgAdmin: true } });
+
+        route = {
+            ...route,
+            writeAccess: true
+        };
+
+        const wrapper = mount(componentWrapperIntl(
+            <CustomRoute exact route={route} Component={PokusComponent}/>,
+            store,
+            ['/path'])
+        );
+
+        expect(wrapper.find(PokusComponent)).toHaveLength(1);
+        expect(wrapper.find(RedirectNotAdmin)).toHaveLength(1);
+    });
+
+    it('renders RedirectNoId when redirectNoId set', () => {
+        useSource.useSource = jest.fn().mockImplementation(() => undefined);
+        RedirectNoId.default = () => <h1>Redirect no ID mock</h1>;
+
+        route = {
+            ...route,
+            redirectNoId: true
+        };
+
+        const wrapper = mount(componentWrapperIntl(
+            <CustomRoute exact route={route} Component={PokusComponent}/>,
+            undefined,
+            ['/path/'])
+        );
+
+        expect(wrapper.find(RedirectNoId.default)).toHaveLength(1);
+        expect(useSource.useSource).toHaveBeenCalled();
+    });
+});

--- a/src/test/components/redirectNoId/RedirectNoId.spec.js
+++ b/src/test/components/redirectNoId/RedirectNoId.spec.js
@@ -7,13 +7,14 @@ import { componentWrapperIntl } from '../../../Utilities/testsHelpers';
 import RedirectNoId from '../../../components/RedirectNoId/RedirectNoId';
 import * as actions from '../../../redux/sources/actions';
 import * as api from '../../../api/entities';
+import { routes } from '../../../Routes';
 
 describe('RedirectNoId', () => {
     let initialStore;
     let initialEntry;
     let mockStore;
 
-    const wasRedirectedToRoot = (wrapper) => wrapper.find(MemoryRouter).instance().history.location.pathname === '/';
+    const wasRedirectedToRoot = (wrapper) => wrapper.find(MemoryRouter).instance().history.location.pathname === routes.sources.path;
 
     beforeEach(() => {
         initialEntry = ['/remove/1'];

--- a/src/test/components/redirectNotAdmin/RedirectNotAdmin.spec.js
+++ b/src/test/components/redirectNotAdmin/RedirectNotAdmin.spec.js
@@ -6,13 +6,14 @@ import { act } from 'react-dom/test-utils';
 import { componentWrapperIntl } from '../../../Utilities/testsHelpers';
 import * as actions from '../../../redux/sources/actions';
 import RedirectNotAdmin from '../../../components/RedirectNotAdmin/RedirectNotAdmin';
+import { routes } from '../../../Routes';
 
 describe('RedirectNotAdmin', () => {
     let initialStore;
     let initialEntry;
     let mockStore;
 
-    const wasRedirectedToRoot = (wrapper) => wrapper.find(MemoryRouter).instance().history.location.pathname === '/';
+    const wasRedirectedToRoot = (wrapper) => wrapper.find(MemoryRouter).instance().history.location.pathname === routes.sources.path;
 
     beforeEach(() => {
         initialEntry = ['/remove/1'];

--- a/src/test/components/sourceEditForm/SourceEditModal.spec.js
+++ b/src/test/components/sourceEditForm/SourceEditModal.spec.js
@@ -9,7 +9,7 @@ import { Spinner } from '@redhat-cloud-services/frontend-components';
 
 import { componentWrapperIntl } from '../../../Utilities/testsHelpers';
 import SourceEditModal from '../../../components/SourceEditForm/SourceEditModal';
-import { paths } from '../../../Routes';
+import { routes } from '../../../Routes';
 import { applicationTypesData } from '../../applicationTypesData';
 import { sourceTypesData, OPENSHIFT_ID } from '../../sourceTypesData';
 import { sourcesDataGraphQl } from '../../sourcesData';
@@ -65,7 +65,7 @@ describe('SourceEditModal', () => {
 
         await act(async() => {
             wrapper = mount(componentWrapperIntl(
-                <Route path={paths.sourcesEdit} render={ (...args) => <SourceEditModal { ...args }/> } />,
+                <Route path={routes.sourcesEdit.path} render={ (...args) => <SourceEditModal { ...args }/> } />,
                 store,
                 initialEntry
             ));
@@ -100,7 +100,7 @@ describe('SourceEditModal', () => {
 
         await act(async() => {
             wrapper = mount(componentWrapperIntl(
-                <Route path={paths.sourcesEdit} render={ (...args) => <SourceEditModal { ...args }/> } />,
+                <Route path={routes.sourcesEdit.path} render={ (...args) => <SourceEditModal { ...args }/> } />,
                 store,
                 initialEntry
             ));
@@ -189,7 +189,7 @@ describe('SourceEditModal', () => {
         });
         wrapper.update();
 
-        expect(getCurrentAddress(wrapper)).toEqual(paths.sources);
+        expect(getCurrentAddress(wrapper)).toEqual(routes.sources.path);
     });
 
     it('calls onCancel via cancel button and returns to root', async () => {
@@ -200,7 +200,7 @@ describe('SourceEditModal', () => {
         });
         wrapper.update();
 
-        expect(getCurrentAddress(wrapper)).toEqual(paths.sources);
+        expect(getCurrentAddress(wrapper)).toEqual(routes.sources.path);
     });
 
     it('calls onRetry and resets edited fields', async () => {
@@ -243,7 +243,7 @@ describe('SourceEditModal', () => {
 
         await act(async() => {
             wrapper = mount(componentWrapperIntl(
-                <Route path={paths.sourcesEdit} render={ (...args) => <SourceEditModal { ...args }/> } />,
+                <Route path={routes.sourcesEdit.path} render={ (...args) => <SourceEditModal { ...args }/> } />,
                 store,
                 initialEntry
             ));
@@ -267,7 +267,7 @@ describe('SourceEditModal', () => {
 
         await act(async() => {
             wrapper = mount(componentWrapperIntl(
-                <Route path={paths.sourcesEdit} render={ (...args) => <SourceEditModal { ...args }/> } />,
+                <Route path={routes.sourcesEdit.path} render={ (...args) => <SourceEditModal { ...args }/> } />,
                 store,
                 initialEntry
             ));
@@ -281,6 +281,6 @@ describe('SourceEditModal', () => {
         });
         wrapper.update();
 
-        expect(getCurrentAddress(wrapper)).toEqual(paths.sources);
+        expect(getCurrentAddress(wrapper)).toEqual(routes.sources.path);
     });
 });

--- a/src/test/components/sourceEditForm/importedRedirect.spec.js
+++ b/src/test/components/sourceEditForm/importedRedirect.spec.js
@@ -1,6 +1,6 @@
 import { redirectWhenImported } from '../../../components/SourceEditForm/importedRedirect';
 import * as actions from '../../../redux/sources/actions';
-import { paths } from '../../../Routes';
+import { routes } from '../../../Routes';
 
 describe('redirectWhenImported', () => {
     const DISPATCH = jest.fn();
@@ -26,6 +26,6 @@ describe('redirectWhenImported', () => {
             'danger',
             EXPECT_DESCRIPTION,
         );
-        expect(HISTORY.push).toHaveBeenCalledWith(paths.sources);
+        expect(HISTORY.push).toHaveBeenCalledWith(routes.sources.path);
     });
 });

--- a/src/test/components/sourceEditForm/onSubmit.spec.js
+++ b/src/test/components/sourceEditForm/onSubmit.spec.js
@@ -1,6 +1,6 @@
 import { onSubmit } from '../../../components/SourceEditForm/onSubmit';
 import * as actions from '../../../redux/sources/actions';
-import { paths } from '../../../Routes';
+import { routes } from '../../../Routes';
 
 describe('editSourceModal - on submit', () => {
     let VALUES;
@@ -70,7 +70,7 @@ describe('editSourceModal - on submit', () => {
                 costManagement: EXPECTED_TRANSLATED_MESSAGE
             }
         );
-        expect(PUSH).toHaveBeenCalledWith(paths.sources);
+        expect(PUSH).toHaveBeenCalledWith(routes.sources.path);
         expect(actions.loadEntities).toHaveBeenCalled();
     });
 

--- a/src/test/components/undoButton/UndoButton.spec.js
+++ b/src/test/components/undoButton/UndoButton.spec.js
@@ -10,7 +10,7 @@ import ReducersProviders, { defaultSourcesState } from '../../../redux/sources/r
 
 import { componentWrapperIntl } from '../../../Utilities/testsHelpers';
 import { Button } from '@patternfly/react-core';
-import { paths } from '../../../Routes';
+import { routes } from '../../../Routes';
 import { MemoryRouter } from 'react-router-dom';
 import { addMessage } from '../../../redux/sources/actions';
 
@@ -48,7 +48,7 @@ describe('UndoButton', () => {
         wrapper.update();
     };
 
-    const wasRedirectedToWizard = (wrapper) => wrapper.find(MemoryRouter).instance().history.location.pathname === paths.sourcesNew;
+    const wasRedirectedToWizard = (wrapper) => wrapper.find(MemoryRouter).instance().history.location.pathname === routes.sourcesNew.path;
 
     it('renders correctly', () => {
         const wrapper = mount(componentWrapperIntl(<UndoButtonAdd {...initialProps} />, store));
@@ -59,7 +59,7 @@ describe('UndoButton', () => {
     it('should set values and redirect to the wizard path', () => {
         store.dispatch(addMessage(TITLE, VARIANT, DESCRIPTION, messageId));
 
-        const wrapper = mount(componentWrapperIntl(<UndoButtonAdd {...initialProps} />, store, [paths.sources]));
+        const wrapper = mount(componentWrapperIntl(<UndoButtonAdd {...initialProps} />, store, [routes.sources.path]));
 
         expect(store.getState().notifications).toHaveLength(1);
 
@@ -71,7 +71,7 @@ describe('UndoButton', () => {
     });
 
     it('should pass when no message', () => {
-        const wrapper = mount(componentWrapperIntl(<UndoButtonAdd {...initialProps} />, store, [paths.sources]));
+        const wrapper = mount(componentWrapperIntl(<UndoButtonAdd {...initialProps} />, store, [routes.sources.path]));
 
         clickOnButton(wrapper);
 
@@ -81,7 +81,7 @@ describe('UndoButton', () => {
     it('should set refresh the page when on wizard', () => {
         refresh.refreshPage = jest.fn();
 
-        const wrapper = mount(componentWrapperIntl(<UndoButtonAdd {...initialProps} />, store, [paths.sourcesNew]));
+        const wrapper = mount(componentWrapperIntl(<UndoButtonAdd {...initialProps} />, store, [routes.sourcesNew.path]));
 
         clickOnButton(wrapper);
 

--- a/src/test/pages/SourcesPage.spec.js
+++ b/src/test/pages/SourcesPage.spec.js
@@ -24,7 +24,7 @@ import * as api from '../../api/entities';
 import * as typesApi from '../../api/source_types';
 import EmptyStateTable from '../../components/SourcesSimpleView/EmptyStateTable';
 import PaginationLoader from '../../pages/SourcesPage/PaginationLoader';
-import { paths } from '../../Routes';
+import { routes } from '../../Routes';
 import * as helpers from '../../pages/SourcesPage/helpers';
 import UserReducer from '../../redux/user/reducer';
 import RedirectNotAdmin from '../../components/RedirectNotAdmin/RedirectNotAdmin';
@@ -148,7 +148,7 @@ describe('SourcesPage', () => {
         });
         wrapper.update();
 
-        expect(wrapper.find(MemoryRouter).instance().history.location.pathname).toEqual(paths.sourcesNew);
+        expect(wrapper.find(MemoryRouter).instance().history.location.pathname).toEqual(routes.sourcesNew.path);
         expect(wrapper.find(AddSourceWizard)).toHaveLength(1);
     });
 

--- a/src/test/pages/SourcesPage.spec.js
+++ b/src/test/pages/SourcesPage.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/display-name */
 import thunk from 'redux-thunk';
 import { notificationsMiddleware } from '@redhat-cloud-services/frontend-components-notifications';
 import { applyReducerHash } from '@redhat-cloud-services/frontend-components-utilities/files/ReducerRegistry';
@@ -438,8 +439,9 @@ describe('SourcesPage', () => {
     describe('routes', () => {
         let initialEntry;
 
+        const wasRedirectedToRoot = (wrapper) => wrapper.find(MemoryRouter).instance().history.location.pathname === routes.sources.path;
+
         it('renders remove', async () => {
-            // eslint-disable-next-line react/display-name
             SourceRemoveModal.default = () => <h1>remove modal mock</h1>;
             initialEntry = [`/remove/${SOURCE_ALL_APS_ID}`];
 
@@ -453,7 +455,6 @@ describe('SourcesPage', () => {
         });
 
         it('renders manageApps', async () => {
-            // eslint-disable-next-line react/display-name
             AddApplication.default = () => <h1>managing apps mock</h1>;
             initialEntry = [`/manage_apps/${SOURCE_ALL_APS_ID}`];
 
@@ -467,7 +468,6 @@ describe('SourcesPage', () => {
         });
 
         it('renders edit', async () => {
-            // eslint-disable-next-line react/display-name
             SourceEditModal.default = () => <h1>edit modal mock</h1>;
             initialEntry = [`/edit/${SOURCE_ALL_APS_ID}`];
 
@@ -478,6 +478,93 @@ describe('SourcesPage', () => {
 
             expect(wrapper.find(RedirectNotAdmin)).toHaveLength(1);
             expect(wrapper.find(SourceEditModal.default)).toHaveLength(1);
+        });
+
+        describe('id not found, redirect back to sources', () => {
+            const NONSENSE_ID = '&88{}#558';
+
+            beforeEach(() => {
+                api.doLoadSource = jest.fn().mockImplementation(() => Promise.resolve({ sources: [] }));
+            });
+
+            it('when remove', async () => {
+                SourceRemoveModal.default = () => <h1>remove modal mock</h1>;
+                initialEntry = [`/remove/${NONSENSE_ID}`];
+
+                await act(async() => {
+                    wrapper = mount(componentWrapperIntl(<SourcesPage { ...initialProps } />, store, initialEntry));
+                });
+                wrapper.update();
+
+                expect(wrapper.find(RedirectNotAdmin)).toHaveLength(0);
+                expect(wrapper.find(SourceRemoveModal.default)).toHaveLength(0);
+                expect(wasRedirectedToRoot(wrapper)).toEqual(true);
+            });
+
+            it('when manageApps', async () => {
+                AddApplication.default = () => <h1>managing apps mock</h1>;
+                initialEntry = [`/manage_apps/${NONSENSE_ID}`];
+
+                await act(async() => {
+                    wrapper = mount(componentWrapperIntl(<SourcesPage { ...initialProps } />, store, initialEntry));
+                });
+                wrapper.update();
+
+                expect(wrapper.find(RedirectNotAdmin)).toHaveLength(0);
+                expect(wrapper.find(AddApplication.default)).toHaveLength(0);
+                expect(wasRedirectedToRoot(wrapper)).toEqual(true);
+            });
+        });
+
+        describe('not org admin, redirect back to sources', () => {
+            beforeEach(() => {
+                store = createStore(
+                    combineReducers({
+                        sources: applyReducerHash(ReducersProviders, defaultSourcesState),
+                        user: applyReducerHash(UserReducer, { isOrgAdmin: false })
+                    }),
+                    applyMiddleware(...middlewares)
+                );
+            });
+
+            it('when remove', async () => {
+                SourceRemoveModal.default = () => <h1>remove modal mock</h1>;
+                initialEntry = [`/remove/${SOURCE_ALL_APS_ID}`];
+
+                await act(async() => {
+                    wrapper = mount(componentWrapperIntl(<SourcesPage { ...initialProps } />, store, initialEntry));
+                });
+                wrapper.update();
+
+                expect(wrapper.find(SourceRemoveModal.default)).toHaveLength(0);
+                expect(wasRedirectedToRoot(wrapper)).toEqual(true);
+            });
+
+            it('when manageApps', async () => {
+                AddApplication.default = () => <h1>managing apps mock</h1>;
+                initialEntry = [`/manage_apps/${SOURCE_ALL_APS_ID}`];
+
+                await act(async() => {
+                    wrapper = mount(componentWrapperIntl(<SourcesPage { ...initialProps } />, store, initialEntry));
+                });
+                wrapper.update();
+
+                expect(wrapper.find(AddApplication.default)).toHaveLength(0);
+                expect(wasRedirectedToRoot(wrapper)).toEqual(true);
+            });
+
+            it('when edit', async () => {
+                SourceEditModal.default = () => <h1>edit modal mock</h1>;
+                initialEntry = [`/edit/${SOURCE_ALL_APS_ID}`];
+
+                await act(async() => {
+                    wrapper = mount(componentWrapperIntl(<SourcesPage { ...initialProps } />, store, initialEntry));
+                });
+                wrapper.update();
+
+                expect(wrapper.find(SourceEditModal.default)).toHaveLength(0);
+                expect(wasRedirectedToRoot(wrapper)).toEqual(true);
+            });
         });
     });
 });

--- a/src/test/pages/SourcesPageAddRoute.spec.js
+++ b/src/test/pages/SourcesPageAddRoute.spec.js
@@ -1,0 +1,64 @@
+/* eslint-disable react/display-name */
+import thunk from 'redux-thunk';
+import { notificationsMiddleware } from '@redhat-cloud-services/frontend-components-notifications';
+import { applyReducerHash } from '@redhat-cloud-services/frontend-components-utilities/files/ReducerRegistry';
+import { createStore, combineReducers, applyMiddleware } from 'redux';
+import { act } from 'react-dom/test-utils';
+import { MemoryRouter } from 'react-router-dom';
+
+import { AddSourceWizard } from '@redhat-cloud-services/frontend-components-sources';
+
+import SourcesPage from '../../pages/SourcesPage';
+
+import { sourcesDataGraphQl } from '../sourcesData';
+import { sourceTypesData } from '../sourceTypesData';
+import { applicationTypesData } from '../applicationTypesData';
+
+import { componentWrapperIntl } from '../../Utilities/testsHelpers';
+
+import ReducersProviders, { defaultSourcesState } from '../../redux/sources/reducer';
+import * as api from '../../api/entities';
+import * as typesApi from '../../api/source_types';
+
+import { routes } from '../../Routes';
+import UserReducer from '../../redux/user/reducer';
+
+jest.mock('@redhat-cloud-services/frontend-components-sources', () => ({
+    __esModule: true,
+    AddSourceWizard: jest.fn().mockImplementation(() => <h2>AddSource mock</h2>)
+}));
+
+describe('SourcesPage - addSource route', () => {
+    const middlewares = [thunk, notificationsMiddleware()];
+    let store;
+    let wrapper;
+
+    const wasRedirectedToRoot = (wrapper) => wrapper.find(MemoryRouter).instance().history.location.pathname === routes.sources.path;
+
+    beforeEach(() => {
+        api.doLoadEntities = jest.fn().mockImplementation(() => Promise.resolve({ sources: sourcesDataGraphQl }));
+        api.doLoadCountOfSources = jest.fn().mockImplementation(() => Promise.resolve({ meta: { count: sourcesDataGraphQl.length } }));
+        api.doLoadAppTypes = jest.fn().mockImplementation(() => Promise.resolve(applicationTypesData));
+        typesApi.doLoadSourceTypes =  jest.fn().mockImplementation(() => Promise.resolve(sourceTypesData.data));
+
+        store = createStore(
+            combineReducers({
+                sources: applyReducerHash(ReducersProviders, defaultSourcesState),
+                user: applyReducerHash(UserReducer, { isOrgAdmin: false })
+            }),
+            applyMiddleware(...middlewares)
+        );
+    });
+
+    it('redirect when not org admin', async () => {
+        const initialEntry = [routes.sourcesNew.path];
+
+        await act(async() => {
+            wrapper = mount(componentWrapperIntl(<SourcesPage />, store, initialEntry));
+        });
+        wrapper.update();
+
+        expect(wrapper.find(AddSourceWizard)).toHaveLength(0);
+        expect(wasRedirectedToRoot(wrapper)).toEqual(true);
+    });
+});


### PR DESCRIPTION
Introduces one source of truth for all components' shared functionality
```jsx
export const routes = {
    sources: {
        path: '/'
    },
    sourcesNew: {
        path: '/new',
        writeAccess: true
    },
    sourcesEdit: {
        path: '/edit/:id',
        writeAccess: true
    },
    sourcesRemove: {
        path: '/remove/:id',
        redirectNoId: true,
        writeAccess: true
    },
    sourceManageApps: {
        path: '/manage_apps/:id',
        redirectNoId: true,
        writeAccess: true
    }
};
```


Then, CustomRoute component handle all these params.

```jsx
<CustomRoute exact route={routes.sourcesRemove} Component={SourceRemoveModal}/>
```