### PR TITLE
Sync url with app's state

### DIFF
--- a/src/Utilities/store.js
+++ b/src/Utilities/store.js
@@ -6,12 +6,25 @@ import promise from 'redux-promise-middleware';
 
 import SourcesReducer, { defaultSourcesState } from '../redux/sources/reducer';
 import UserReducer, { defaultUserState } from '../redux/user/reducer';
+import { updateQuery } from './urlQuery';
+import { ACTION_TYPES } from '../redux/sources/actions-types';
+
+export const urlQueryMiddleware = store => next => action => {
+    const sources = store.getState().sources;
+
+    if (sources.loaded && action.type === ACTION_TYPES.LOAD_ENTITIES_FULFILLED) {
+        updateQuery(sources);
+    }
+
+    next(action);
+};
 
 export const getStore = (includeLogger) => {
     const middlewares = [
         thunk,
         notificationsMiddleware({ errorTitleKey: 'error.title', errorDescriptionKey: 'error.detail' }),
-        promise
+        promise,
+        urlQueryMiddleware
     ];
 
     if (includeLogger) {

--- a/src/Utilities/store.js
+++ b/src/Utilities/store.js
@@ -12,8 +12,8 @@ import { ACTION_TYPES } from '../redux/sources/actions-types';
 export const urlQueryMiddleware = store => next => action => {
     const sources = store.getState().sources;
 
-    if (sources.loaded && action.type === ACTION_TYPES.LOAD_ENTITIES_FULFILLED) {
-        updateQuery(sources);
+    if (action.type === ACTION_TYPES.LOAD_ENTITIES_PENDING) {
+        updateQuery({ ...sources, ...action.options });
     }
 
     next(action);

--- a/src/Utilities/store.js
+++ b/src/Utilities/store.js
@@ -10,9 +10,9 @@ import { updateQuery } from './urlQuery';
 import { ACTION_TYPES } from '../redux/sources/actions-types';
 
 export const urlQueryMiddleware = store => next => action => {
-    const sources = store.getState().sources;
-
     if (action.type === ACTION_TYPES.LOAD_ENTITIES_PENDING) {
+        const sources = store.getState().sources;
+
         updateQuery({ ...sources, ...action.options });
     }
 

--- a/src/Utilities/urlQuery.js
+++ b/src/Utilities/urlQuery.js
@@ -1,0 +1,97 @@
+import { restFilterGenerator } from '../api/entities';
+import { sourcesColumns } from '../views/sourcesViewDefinition';
+
+export const updateQuery = ({ sortBy, sortDirection, pageNumber, pageSize, filterValue }) => {
+    const sortQuery = `sort_by[]=${sortBy}:${sortDirection}`;
+
+    const paginationQuery = `limit=${pageSize}&offset=${(pageNumber - 1) * pageSize}`;
+
+    const filterQuery = restFilterGenerator(filterValue);
+
+    const query = `?${sortQuery}&${paginationQuery}${filterQuery ? `&${filterQuery}` : ''}`;
+
+    const fullHref = decodeURIComponent(`${window.location.pathname}${query}`);
+
+    if (location.href !== fullHref) {
+        return history.replaceState('', '', fullHref);
+    }
+
+    return null;
+};
+
+export const parseQuery = () => {
+    let fetchOptions = {};
+
+    const urlParams = new URLSearchParams(window.location.search);
+
+    const sortByRaw = urlParams.get('sort_by[]');
+
+    let sortBy;
+    let sortDirection;
+
+    if (sortByRaw) {
+        sortBy = sortByRaw.split(':')[0];
+        sortDirection = sortByRaw.split(':')[1];
+
+        sortBy = sourcesColumns({ formatMessage: () => '' })
+        .filter(({ sortable }) => sortable)
+        .map(({ value }) => value)
+        .includes(sortBy) ? sortBy : 'created_at';
+        sortDirection = ['desc', 'asc'].includes(sortDirection) ? sortDirection : 'desc';
+    }
+
+    if (sortBy && sortDirection) {
+        fetchOptions = {
+            sortBy,
+            sortDirection
+        };
+    }
+
+    const pageSize = urlParams.get('limit');
+    const offset = urlParams.get('offset');
+
+    let pageNumber;
+
+    if (offset && pageSize) {
+        pageNumber = ((offset / pageSize) + 1);
+        if (isNaN(pageNumber)) {
+            pageNumber = undefined;
+        }
+    }
+
+    if (pageSize && pageNumber) {
+        fetchOptions = {
+            ...fetchOptions,
+            pageNumber: parseInt(pageNumber, 10),
+            pageSize: parseInt(pageSize, 10)
+        };
+    }
+
+    let filterValue = {};
+
+    const name = urlParams.get('filter[name][contains_i]');
+
+    if (name) {
+        filterValue = { name };
+    }
+
+    const sourceTypes = urlParams.getAll('filter[source_type_id][]');
+
+    if (sourceTypes.length > 0) {
+        filterValue = {
+            ...filterValue,
+            source_type_id: sourceTypes
+        };
+    }
+
+    const hasSomeFilterValue = Object.entries(filterValue).map(([_key, value]) => value).filter(Boolean).length > 0;
+
+    if (hasSomeFilterValue) {
+        fetchOptions = {
+            ...fetchOptions,
+            filterValue
+        };
+    }
+
+    return fetchOptions;
+};

--- a/src/pages/SourcesPage.js
+++ b/src/pages/SourcesPage.js
@@ -60,7 +60,6 @@ const SourcesPage = () => {
         fetchingError,
         addSourceInitialValues,
         sourceTypes,
-        entities,
         paginationClicked,
         appTypesLoaded,
         sourceTypesLoaded
@@ -77,7 +76,7 @@ const SourcesPage = () => {
 
     useEffect(() => {
         if (checkEmptyState) {
-            setShowEmptyState(numberOfEntities === 0 && !hasSomeFilter);
+            setShowEmptyState(loaded && numberOfEntities === 0 && !hasSomeFilter);
             updateQuery(sources);
         }
     }, [location, checkEmptyState]);
@@ -86,11 +85,13 @@ const SourcesPage = () => {
         if (filter !== filterValue.name) {
             setFilterValue(filterValue.name);
         }
+    }, [filterValue.name]);
 
-        if (checkEmptyState) {
+    useEffect(() => {
+        if (checkEmptyState && loaded) {
             setShowEmptyState(numberOfEntities === 0 && !hasSomeFilter);
         }
-    }, [filterValue]);
+    }, [filterValue, loaded]);
 
     const onSetPage = (_e, page) => dispatch(pageAndSize(page, pageSize));
 
@@ -98,8 +99,8 @@ const SourcesPage = () => {
 
     const maximumPageNumber = Math.ceil(numberOfEntities / pageSize);
 
-    if (entities.length > 0 && loaded && pageNumber > Math.max(maximumPageNumber, 1)) {
-        onSetPage(maximumPageNumber);
+    if (loaded && numberOfEntities > 0 && pageNumber > Math.max(maximumPageNumber, 1)) {
+        onSetPage({}, maximumPageNumber);
     }
 
     const paginationConfig = {

--- a/src/test/utilities/store.spec.js
+++ b/src/test/utilities/store.spec.js
@@ -1,6 +1,8 @@
-import { getDevStore, getProdStore } from '../../Utilities/store';
+import { getDevStore, getProdStore, urlQueryMiddleware } from '../../Utilities/store';
 import { defaultSourcesState } from '../../redux/sources/reducer';
 import { defaultUserState } from '../../redux/user/reducer';
+import * as queries from '../../Utilities/urlQuery';
+import { ACTION_TYPES } from '../../redux/sources/actions-types';
 
 describe('store creator', () => {
     const EXPECTED_DEFAULT_STATE = {
@@ -19,5 +21,76 @@ describe('store creator', () => {
         const store = getProdStore();
 
         expect(store.getState()).toEqual(EXPECTED_DEFAULT_STATE);
+    });
+
+    describe('url middleware', () => {
+        let store;
+        let next;
+        let action;
+        let sources;
+
+        beforeEach(() => {
+            next = jest.fn();
+            queries.updateQuery = jest.fn();
+        });
+
+        it('calls update url when app is loaded and type is load_entities_fulfilled', () => {
+            sources = {
+                pageSize: 1,
+                pageNumber: 125,
+                loaded: true
+            };
+
+            action = {
+                type: ACTION_TYPES.LOAD_ENTITIES_FULFILLED
+            };
+
+            store = {
+                getState: () => ({ sources })
+            };
+
+            urlQueryMiddleware(store)(next)(action);
+
+            expect(next).toHaveBeenCalledWith(action);
+            expect(queries.updateQuery).toHaveBeenCalledWith(sources);
+        });
+
+        it('does not call update url when app is not loaded and type is load_entities_fulfilled', () => {
+            sources = {
+                loaded: false
+            };
+
+            action = {
+                type: ACTION_TYPES.LOAD_ENTITIES_FULFILLED
+            };
+
+            store = {
+                getState: () => ({ sources })
+            };
+
+            urlQueryMiddleware(store)(next)(action);
+
+            expect(next).toHaveBeenCalledWith(action);
+            expect(queries.updateQuery).not.toHaveBeenCalledWith(sources);
+        });
+
+        it('does not call update url when app is loaded and type is not load_entities_fulfilled', () => {
+            sources = {
+                loaded: false
+            };
+
+            action = {
+                type: ACTION_TYPES.LOAD_ENTITIES_PENDING
+            };
+
+            store = {
+                getState: () => ({ sources })
+            };
+
+            urlQueryMiddleware(store)(next)(action);
+
+            expect(next).toHaveBeenCalledWith(action);
+            expect(queries.updateQuery).not.toHaveBeenCalledWith(sources);
+        });
     });
 });

--- a/src/test/utilities/store.spec.js
+++ b/src/test/utilities/store.spec.js
@@ -28,21 +28,29 @@ describe('store creator', () => {
         let next;
         let action;
         let sources;
+        let options;
 
         beforeEach(() => {
             next = jest.fn();
             queries.updateQuery = jest.fn();
-        });
-
-        it('calls update url when app is loaded and type is load_entities_fulfilled', () => {
             sources = {
                 pageSize: 1,
                 pageNumber: 125,
                 loaded: true
             };
+        });
+
+        it('calls update url when load_entities_pending', () => {
+            options = {
+                pageSize: 2,
+                filterValue: {
+                    name: 'johny smith'
+                }
+            };
 
             action = {
-                type: ACTION_TYPES.LOAD_ENTITIES_FULFILLED
+                type: ACTION_TYPES.LOAD_ENTITIES_PENDING,
+                options
             };
 
             store = {
@@ -51,36 +59,18 @@ describe('store creator', () => {
 
             urlQueryMiddleware(store)(next)(action);
 
-            expect(next).toHaveBeenCalledWith(action);
-            expect(queries.updateQuery).toHaveBeenCalledWith(sources);
-        });
-
-        it('does not call update url when app is not loaded and type is load_entities_fulfilled', () => {
-            sources = {
-                loaded: false
+            const combinedState = {
+                ...sources,
+                ...options
             };
 
+            expect(next).toHaveBeenCalledWith(action);
+            expect(queries.updateQuery).toHaveBeenCalledWith(combinedState);
+        });
+
+        it('does not call update url when action is not load_entities_pending', () => {
             action = {
                 type: ACTION_TYPES.LOAD_ENTITIES_FULFILLED
-            };
-
-            store = {
-                getState: () => ({ sources })
-            };
-
-            urlQueryMiddleware(store)(next)(action);
-
-            expect(next).toHaveBeenCalledWith(action);
-            expect(queries.updateQuery).not.toHaveBeenCalledWith(sources);
-        });
-
-        it('does not call update url when app is loaded and type is not load_entities_fulfilled', () => {
-            sources = {
-                loaded: false
-            };
-
-            action = {
-                type: ACTION_TYPES.LOAD_ENTITIES_PENDING
             };
 
             store = {

--- a/src/test/utilities/urlQuery.spec.js
+++ b/src/test/utilities/urlQuery.spec.js
@@ -1,0 +1,237 @@
+import { parseQuery, updateQuery } from '../../Utilities/urlQuery';
+
+describe('urlQuery helpers', () => {
+    let tmpLocation;
+
+    beforeEach(() => {
+        tmpLocation = Object.assign({}, window.location);
+
+        delete window.location;
+
+        window.location = {};
+    });
+
+    afterEach(() => {
+        window.location = tmpLocation;
+    });
+
+    describe('updateQuery', () => {
+        let spy;
+        let params;
+        let expectedQuery;
+
+        let tmpHistory;
+
+        beforeEach(() => {
+            tmpHistory = Object.assign({}, window.history);
+
+            spy = jest.fn();
+
+            delete window.history;
+
+            window.history = {
+                replaceState: spy
+            };
+
+            window.location.pathname = 'sources';
+
+            params = {
+                sortBy: 'name',
+                sortDirection: 'asc',
+                pageNumber: '12',
+                pageSize: '50',
+                filterValue: {
+                    name: 'pepa',
+                    source_type_id: ['125', '542', '1']
+                }
+            };
+
+            expectedQuery = 'sources?sort_by[]=name:asc&limit=50&offset=550&filter[name][contains_i]=pepa&filter[source_type_id][]=125&filter[source_type_id][]=542&filter[source_type_id][]=1';
+        });
+
+        afterEach(() => {
+            window.history = tmpHistory;
+        });
+
+        it('updates query when is different', () => {
+            updateQuery(params);
+
+            expect(spy).toHaveBeenCalledWith('', '', decodeURIComponent(expectedQuery));
+        });
+
+        it('do not update query when it is the same', () => {
+            window.location.href = expectedQuery;
+
+            updateQuery(params);
+
+            expect(spy).not.toHaveBeenCalled();
+        });
+
+        it('empty filterValue', () => {
+            params = {
+                ...params,
+                filterValue: {}
+            };
+
+            expectedQuery = 'sources?sort_by[]=name:asc&limit=50&offset=550';
+
+            updateQuery(params);
+
+            expect(spy).toHaveBeenCalledWith('', '', decodeURIComponent(expectedQuery));
+        });
+    });
+
+    describe('parseQuery', () => {
+        it('handles empty search', () => {
+            window.location.search = '';
+
+            const result = parseQuery();
+
+            expect(result).toEqual({});
+        });
+
+        describe('sort by', () => {
+            it('handles sort by', () => {
+                window.location.search = '?sort_by[]=name';
+
+                const result = parseQuery();
+
+                expect(result).toEqual({
+                    sortBy: 'name',
+                    sortDirection: 'desc'
+                });
+            });
+
+            it('handles sort by with asc', () => {
+                window.location.search = '?sort_by[]=name:asc';
+
+                const result = parseQuery();
+
+                expect(result).toEqual({
+                    sortBy: 'name',
+                    sortDirection: 'asc'
+                });
+            });
+
+            it('handles sort by with nonsense direction', () => {
+                window.location.search = '?sort_by[]=name:ascii';
+
+                const result = parseQuery();
+
+                expect(result).toEqual({
+                    sortBy: 'name',
+                    sortDirection: 'desc'
+                });
+            });
+
+            it('handles unpermitted sort by by setting default state', () => {
+                window.location.search = '?sort_by[]=nonsense';
+
+                const result = parseQuery();
+
+                expect(result).toEqual({
+                    sortBy: 'created_at',
+                    sortDirection: 'desc'
+                });
+            });
+        });
+
+        describe('pagination', () => {
+            it('handles pagination', () => {
+                window.location.search = '?limit=50&offset=0';
+
+                const result = parseQuery();
+
+                expect(result).toEqual({
+                    pageNumber: 1,
+                    pageSize: 50
+                });
+            });
+
+            it('handles pagination', () => {
+                window.location.search = '?limit=50&offset=50';
+
+                const result = parseQuery();
+
+                expect(result).toEqual({
+                    pageNumber: 2,
+                    pageSize: 50
+                });
+            });
+
+            it('handles pagination 200/50 = 4', () => {
+                window.location.search = '?limit=50&offset=200';
+
+                const result = parseQuery();
+
+                expect(result).toEqual({
+                    pageNumber: 5,
+                    pageSize: 50
+                });
+            });
+
+            it('handles pagination 200/4 = 50', () => {
+                window.location.search = '?limit=4&offset=200';
+
+                const result = parseQuery();
+
+                expect(result).toEqual({
+                    pageNumber: 51,
+                    pageSize: 4
+                });
+            });
+
+            it('handles pagination when there are notnumbers', () => {
+                window.location.search = '?limit=aword&offset=50';
+
+                const result = parseQuery();
+
+                expect(result).toEqual({});
+            });
+        });
+
+        describe('filterValue', () => {
+            it('handles name filtering', () => {
+                window.location.search = '?filter[name][contains_i]=hledamjmeno';
+
+                const result = parseQuery();
+
+                expect(result).toEqual({
+                    filterValue: {
+                        name: 'hledamjmeno'
+                    }
+                });
+            });
+
+            it('handles sourceType filtering', () => {
+                window.location.search = '?filter[source_type_id][]=3&filter[source_type_id][]=2';
+
+                const result = parseQuery();
+
+                expect(result).toEqual({
+                    filterValue: {
+                        source_type_id: ['3', '2']
+                    }
+                });
+            });
+        });
+
+        it('combined query', () => {
+            window.location.search =
+            '?sort_by[]=name:asc&limit=50&offset=200&filter[name][contains_i]=hledamjmeno&filter[source_type_id][]=3&filter[source_type_id][]=2';
+
+            const result = parseQuery();
+
+            expect(result).toEqual({
+                sortBy: 'name',
+                sortDirection: 'asc',
+                pageNumber: 5,
+                pageSize: 50,
+                filterValue: {
+                    name: 'hledamjmeno',
+                    source_type_id: ['3', '2']
+                }
+            });
+        });
+    });
+});


### PR DESCRIPTION
This will allow users to share their states of the app ('look, on this page you can see...')

+ when we have the API support for filtering by subcollections, other apps would be able to have 'Show me Cost Management sources' links there

* the URL is updated when `pathname` is changed
* on initial mount of the app, it reads the state from the URL
* when `LOAD_ENTITIES_FULFILLED` happens
* format of the URL query is THE SAME as for the API

All input when mounting is controlled, there should be no way how to break the app.

![urlsync](https://user-images.githubusercontent.com/32869456/73531047-f005bb00-4419-11ea-918b-4d0f55842059.gif)
