### PR TITLE
Set values on retry in addApplication wizard

### DIFF
--- a/src/api/doAttachApp.js
+++ b/src/api/doAttachApp.js
@@ -23,10 +23,9 @@ export const removeEmpty = (obj) => {
     return obj;
 };
 
-export const doAttachApp = async (values, formApi, authenticationInitialValues) => {
+export const doAttachApp = async (values, formApi, authenticationInitialValues, initialValues) => {
     const formState = formApi.getState();
 
-    const initialValues = formState.initialValues;
     const allFormValues = formState.values;
 
     const selectedAuthId = allFormValues.authentication ? allFormValues.authentication.id : undefined;

--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -62,8 +62,9 @@ export const graphQlAttributes = `
     updated_at,
     imported,
     availability_status,
+    source_ref,
     applications { application_type_id, id, availability_status_error, availability_status },
-    endpoints { id, scheme, host, port, path }
+    endpoints { id, scheme, host, port, path, receptor_node, role, certificate_authority, verify_ssl }
 `;
 
 export const doLoadEntities = ({ pageSize, pageNumber, sortBy, sortDirection, filterValue }) => getSourcesApi().postGraphQL({

--- a/src/components/AddApplication/AddApplication.js
+++ b/src/components/AddApplication/AddApplication.js
@@ -2,6 +2,8 @@ import React, { useReducer, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { useIntl } from 'react-intl';
+import merge from 'lodash/merge';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { loadEntities } from '../../redux/sources/actions';
 import SourcesFormRenderer from '../../Utilities/SourcesFormRenderer';
@@ -34,7 +36,8 @@ export const onSubmit = (values, formApi, authenticationInitialValues, dispatch,
     })
     .catch(error => setState({
         state: 'errored',
-        error
+        error,
+        values
     }));
 };
 
@@ -43,7 +46,8 @@ const initialState = {
     error: '',
     values: {},
     authenticationsValues: [],
-    sourceAppsLength: 0
+    sourceAppsLength: 0,
+    initialValues: {}
 };
 
 const reducer = (state, payload) => ({ ...state, ...payload });
@@ -84,11 +88,12 @@ const AddApplication = () => {
                     .listEndpointAuthentications(source.endpoints[0].id)
                     .then(({ data }) => setState({
                         authenticationsValues: data,
-                        values: {
+                        initialValues: {
                             source,
                             endpoint: source.endpoints[0],
                             url: endpointToUrl(source.endpoints[0]),
-                            application: selectedApp
+                            application: selectedApp,
+                            values: {}
                         }
                     }))
                     .then(() => {
@@ -100,7 +105,8 @@ const AddApplication = () => {
                     });
                 } else {
                     setState({
-                        values: { source, application: selectedApp }
+                        initialValues: { source, application: selectedApp },
+                        values: {}
                     });
                     if (state.state === 'loading') {
                         setState({
@@ -175,11 +181,13 @@ const AddApplication = () => {
         state.authenticationsValues,
         dispatch,
         setState,
-        state.values
+        state.initialValues
     );
 
     const hasAvailableApps = filteredAppTypes.length > 0;
     const onSubmitFinal = hasAvailableApps ? onSubmitWrapper : goToSources;
+
+    const finalValues = merge(cloneDeep(state.initialValues), state.values);
 
     return (
         <SourcesFormRenderer
@@ -187,7 +195,7 @@ const AddApplication = () => {
             showFormControls={false}
             onSubmit={onSubmitFinal}
             onCancel={goToSources}
-            initialValues={state.values}
+            initialValues={finalValues}
             subscription={{ values: true }}
             onStateUpdate={saveSelectedApp}
             clearedValue={null}

--- a/src/components/AddApplication/AddApplication.js
+++ b/src/components/AddApplication/AddApplication.js
@@ -23,10 +23,10 @@ import { doAttachApp } from '../../api/doAttachApp';
 let selectedApp = undefined; // this has to be not-state value, because it shouldn't re-render the component when changes
 const saveSelectedApp = ({ values: { application } }) => selectedApp = application;
 
-export const onSubmit = (values, formApi, authenticationInitialValues, dispatch, setState) => {
+export const onSubmit = (values, formApi, authenticationInitialValues, dispatch, setState, initialValues) => {
     setState({ state: 'submitting' });
 
-    return doAttachApp(values, formApi, authenticationInitialValues)
+    return doAttachApp(values, formApi, authenticationInitialValues, initialValues)
     .then(async () => {
         await dispatch(loadEntities());
         selectedApp = undefined;
@@ -174,7 +174,8 @@ const AddApplication = () => {
         formApi,
         state.authenticationsValues,
         dispatch,
-        setState
+        setState,
+        state.values
     );
 
     const hasAvailableApps = filteredAppTypes.length > 0;

--- a/src/test/api/doAttachApp.spec.js
+++ b/src/test/api/doAttachApp.spec.js
@@ -4,8 +4,7 @@ import * as cm from '@redhat-cloud-services/frontend-components-sources';
 
 const prepareFormApi = (values) => ({
     getState: () => ({
-        values,
-        initialValues: values
+        values
     })
 });
 
@@ -32,6 +31,7 @@ describe('doAttachApp', () => {
     let APP_ID;
     let ENDPOINT_ID;
     let RETURNED_ENDPOINT;
+    let INITIAL_VALUES;
 
     let mockPatchSourceSpy;
 
@@ -63,11 +63,12 @@ describe('doAttachApp', () => {
 
         SOURCE_ID = '23278326';
         VALUES = {};
-        FORM_API = prepareFormApi({
+        INITIAL_VALUES = {
             source: {
                 id: SOURCE_ID
             }
-        });
+        };
+        FORM_API = prepareFormApi(INITIAL_VALUES);
         AUTHENTICATION_INIT = [];
         APP_ID = '878776767';
         ENDPOINT_ID = '99998887776655';
@@ -88,7 +89,7 @@ describe('doAttachApp', () => {
         FORM_API = prepareFormApi({});
 
         try {
-            await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT);
+            await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT, INITIAL_VALUES);
         } catch (error) {
             expect(error).toEqual('Missing source id');
 
@@ -109,7 +110,7 @@ describe('doAttachApp', () => {
             }
         };
 
-        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT);
+        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT, INITIAL_VALUES);
 
         expect(mockPatchSourceSpy).not.toHaveBeenCalled();
         expect(sourceUpdate).not.toHaveBeenCalled();
@@ -127,7 +128,7 @@ describe('doAttachApp', () => {
             }
         };
 
-        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT);
+        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT, INITIAL_VALUES);
 
         expect(mockPatchSourceSpy).not.toHaveBeenCalled();
         expect(sourceUpdate).toHaveBeenCalledWith(SOURCE_ID, {
@@ -141,14 +142,16 @@ describe('doAttachApp', () => {
     });
 
     it('only source is changed and only modified (removed) values are sent to the endpoint', async () => {
-        FORM_API = prepareFormApi({
+        INITIAL_VALUES = {
             source: {
                 id: SOURCE_ID,
                 source_ref: '2323',
                 cat: 'dog',
                 original: 'old'
             }
-        });
+        };
+
+        FORM_API = prepareFormApi(INITIAL_VALUES);
 
         VALUES = {
             source: {
@@ -160,7 +163,7 @@ describe('doAttachApp', () => {
             }
         };
 
-        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT);
+        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT, INITIAL_VALUES);
 
         expect(mockPatchSourceSpy).not.toHaveBeenCalled();
         expect(sourceUpdate).toHaveBeenCalledWith(SOURCE_ID, {
@@ -176,7 +179,7 @@ describe('doAttachApp', () => {
     });
 
     it('only source is changed and only modified (removed) values are sent to the endpoint with super nesting', async () => {
-        FORM_API = prepareFormApi({
+        INITIAL_VALUES = {
             source: {
                 id: SOURCE_ID,
                 source_ref: '2323',
@@ -195,7 +198,9 @@ describe('doAttachApp', () => {
                     }
                 }
             }
-        });
+        };
+
+        FORM_API = prepareFormApi(INITIAL_VALUES);
 
         VALUES = {
             source: {
@@ -221,7 +226,7 @@ describe('doAttachApp', () => {
             }
         };
 
-        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT);
+        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT, INITIAL_VALUES);
 
         expect(mockPatchSourceSpy).not.toHaveBeenCalled();
         expect(sourceUpdate).toHaveBeenCalledWith(SOURCE_ID, {
@@ -247,14 +252,16 @@ describe('doAttachApp', () => {
     });
 
     it('only endpoint is changed', async () => {
-        FORM_API = prepareFormApi({
+        INITIAL_VALUES = {
             source: {
                 id: SOURCE_ID
             },
             endpoint: {
                 id: ENDPOINT_ID
             }
-        });
+        };
+
+        FORM_API = prepareFormApi(INITIAL_VALUES);
 
         VALUES = {
             endpoint: {
@@ -262,7 +269,7 @@ describe('doAttachApp', () => {
             }
         };
 
-        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT);
+        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT, INITIAL_VALUES);
 
         expect(mockPatchSourceSpy).not.toHaveBeenCalled();
         expect(sourceUpdate).not.toHaveBeenCalled();
@@ -279,14 +286,16 @@ describe('doAttachApp', () => {
     });
 
     it('only endpoint is changed - port is nonsense', async () => {
-        FORM_API = prepareFormApi({
+        INITIAL_VALUES = {
             source: {
                 id: SOURCE_ID
             },
             endpoint: {
                 id: ENDPOINT_ID
             }
-        });
+        };
+
+        FORM_API = prepareFormApi(INITIAL_VALUES);
 
         VALUES = {
             endpoint: {
@@ -294,7 +303,7 @@ describe('doAttachApp', () => {
             }
         };
 
-        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT);
+        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT, INITIAL_VALUES);
 
         expect(mockPatchSourceSpy).not.toHaveBeenCalled();
         expect(sourceUpdate).not.toHaveBeenCalled();
@@ -311,20 +320,22 @@ describe('doAttachApp', () => {
     });
 
     it('empty endpoint', async () => {
-        FORM_API = prepareFormApi({
+        INITIAL_VALUES = {
             source: {
                 id: SOURCE_ID
             },
             endpoint: {
                 id: ENDPOINT_ID
             }
-        });
+        };
+
+        FORM_API = prepareFormApi(INITIAL_VALUES);
 
         VALUES = {
             endpoint: { }
         };
 
-        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT);
+        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT, INITIAL_VALUES);
 
         expect(mockPatchSourceSpy).not.toHaveBeenCalled();
         expect(sourceUpdate).not.toHaveBeenCalled();
@@ -336,20 +347,22 @@ describe('doAttachApp', () => {
     });
 
     it('url is changed', async () => {
-        FORM_API = prepareFormApi({
+        INITIAL_VALUES = {
             source: {
                 id: SOURCE_ID
             },
             endpoint: {
                 id: ENDPOINT_ID
             }
-        });
+        };
+
+        FORM_API = prepareFormApi(INITIAL_VALUES);
 
         VALUES = {
             url: 'https://redhat.com:8989/mypage'
         };
 
-        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT);
+        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT, INITIAL_VALUES);
 
         expect(mockPatchSourceSpy).not.toHaveBeenCalled();
         expect(sourceUpdate).not.toHaveBeenCalled();
@@ -368,7 +381,7 @@ describe('doAttachApp', () => {
     it('only auth is changed', async () => {
         const AUTH_ID = '654789';
 
-        FORM_API = prepareFormApi({
+        INITIAL_VALUES = {
             source: {
                 id: SOURCE_ID
             },
@@ -378,7 +391,9 @@ describe('doAttachApp', () => {
             authentication: {
                 id: AUTH_ID
             }
-        });
+        };
+
+        FORM_API = prepareFormApi(INITIAL_VALUES);
 
         VALUES = {
             authentication: {
@@ -390,7 +405,7 @@ describe('doAttachApp', () => {
             id: AUTH_ID
         }];
 
-        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT);
+        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT, INITIAL_VALUES);
 
         expect(mockPatchSourceSpy).not.toHaveBeenCalled();
         expect(sourceUpdate).not.toHaveBeenCalled();
@@ -404,7 +419,7 @@ describe('doAttachApp', () => {
     it('only auth is changed and only modified (removed) values are sent to to the endpoint', async () => {
         const AUTH_ID = '654789';
 
-        FORM_API = prepareFormApi({
+        INITIAL_VALUES = {
             source: {
                 id: SOURCE_ID
             },
@@ -414,7 +429,9 @@ describe('doAttachApp', () => {
             authentication: {
                 id: AUTH_ID
             }
-        });
+        };
+
+        FORM_API = prepareFormApi(INITIAL_VALUES);
 
         VALUES = {
             authentication: {
@@ -430,7 +447,7 @@ describe('doAttachApp', () => {
             removed: 'this was removed'
         }];
 
-        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT);
+        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT, INITIAL_VALUES);
 
         expect(mockPatchSourceSpy).not.toHaveBeenCalled();
         expect(sourceUpdate).not.toHaveBeenCalled();
@@ -445,14 +462,16 @@ describe('doAttachApp', () => {
     });
 
     it('auth is created', async () => {
-        FORM_API = prepareFormApi({
+        INITIAL_VALUES = {
             source: {
                 id: SOURCE_ID
             },
             endpoint: {
                 id: ENDPOINT_ID
             }
-        });
+        };
+
+        FORM_API = prepareFormApi(INITIAL_VALUES);
 
         VALUES = {
             authentication: {
@@ -460,7 +479,7 @@ describe('doAttachApp', () => {
             }
         };
 
-        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT);
+        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT, INITIAL_VALUES);
 
         expect(mockPatchSourceSpy).not.toHaveBeenCalled();
         expect(sourceUpdate).not.toHaveBeenCalled();
@@ -480,7 +499,7 @@ describe('doAttachApp', () => {
             url: 'https://redhat.com:8989/mypage'
         };
 
-        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT);
+        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT, INITIAL_VALUES);
 
         expect(mockPatchSourceSpy).not.toHaveBeenCalled();
         expect(sourceUpdate).not.toHaveBeenCalled();
@@ -506,7 +525,7 @@ describe('doAttachApp', () => {
             }
         };
 
-        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT);
+        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT, INITIAL_VALUES);
 
         expect(mockPatchSourceSpy).not.toHaveBeenCalled();
         expect(sourceUpdate).not.toHaveBeenCalled();
@@ -535,7 +554,7 @@ describe('doAttachApp', () => {
             }
         };
 
-        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT);
+        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT, INITIAL_VALUES);
 
         expect(mockPatchSourceSpy).not.toHaveBeenCalled();
         expect(sourceUpdate).not.toHaveBeenCalled();
@@ -553,7 +572,7 @@ describe('doAttachApp', () => {
             nonsense: 'Z7SHADZUSAgd'
         };
 
-        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT);
+        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT, INITIAL_VALUES);
 
         expect(mockPatchSourceSpy).toHaveBeenCalledWith({
             id: SOURCE_ID,
@@ -576,7 +595,7 @@ describe('doAttachApp', () => {
             nonsense: 'Z7SHADZUSAgd'
         };
 
-        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT);
+        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT, INITIAL_VALUES);
 
         expect(mockPatchSourceSpy).toHaveBeenCalledWith({
             id: SOURCE_ID,
@@ -596,7 +615,7 @@ describe('doAttachApp', () => {
             nonsense: 'Z7SHADZUSAgd'
         };
 
-        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT);
+        await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT, INITIAL_VALUES);
 
         expect(mockPatchSourceSpy).toHaveBeenCalledWith({
             id: SOURCE_ID,

--- a/src/test/components/addApplication/AddApplication.spec.js
+++ b/src/test/components/addApplication/AddApplication.spec.js
@@ -176,15 +176,19 @@ describe('AddApplication', () => {
     });
 
     describe('imported source - not need to edit any value', () => {
+        let initialValues;
+        let source;
+
         beforeEach(() => {
+            source = {
+                id: SOURCE_NO_APS_ID,
+                source_type_id: OPENSHIFT_ID,
+                applications: [],
+                imported: 'cfme'
+            };
             store = mockStore({
                 sources: {
-                    entities: [{
-                        id: SOURCE_NO_APS_ID,
-                        source_type_id: OPENSHIFT_ID,
-                        applications: [],
-                        imported: 'cfme'
-                    }],
+                    entities: [source],
                     appTypes: applicationTypesData.data,
                     sourceTypes: sourceTypesData.data,
                     appTypesLoaded: true,
@@ -192,6 +196,7 @@ describe('AddApplication', () => {
                     loaded: 0
                 }
             });
+            initialValues = { application: undefined, source };
         });
 
         it('renders review', () => {
@@ -247,6 +252,7 @@ describe('AddApplication', () => {
                 formValues,
                 formApi,
                 authenticationValues,
+                initialValues
             );
             expect(wrapper.find(FinishedStep).length).toEqual(1);
         });
@@ -288,6 +294,7 @@ describe('AddApplication', () => {
                 formValues,
                 formApi,
                 authenticationValues,
+                initialValues
             );
             expect(wrapper.find(ErroredStepAttach).length).toEqual(1);
             expect(wrapper.find(EmptyStateBody).text().includes(ERROR_MESSAGE)).toEqual(true);


### PR DESCRIPTION
When click on retry, the add application wizard preserve set values

![retryaddapplication](https://user-images.githubusercontent.com/32869456/73661575-94963000-469a-11ea-8fa7-054d28711e08.gif)
