### PR TITLE
Use PF spinner for loading of the table

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -11,17 +11,10 @@
   flex: 1
 }
 
-/* styling for sources placeholder table */
-.sources-placeholder-table {
-  background: white;
-  width: 100%;
-  border-top: 1px solid rgb(204,204,204);
-  border-bottom: 1px solid rgb(204,204,204);
-  border-collapse: collapse;
-  td {
-    display: block;
-    padding: 10px;
-  }
+.ins-c-sources__sources-placeholder-loader {
+  margin: 0px;
+  padding: 0px;
+  min-height: 500px;
 }
 
 .ins-c-sources__dialog--warning {

--- a/src/components/SourcesSimpleView/loaders.js
+++ b/src/components/SourcesSimpleView/loaders.js
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types';
 import { RowWrapper } from '@patternfly/react-table';
 import { RowLoader } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
 import { COLUMN_COUNT } from '../../views/sourcesViewDefinition';
+import { Spinner } from '@patternfly/react-core/dist/js/components/Spinner';
+import { Bullseye } from '@patternfly/react-core/dist/js/layouts/Bullseye';
 
 export const PlaceHolderTable = () => (
-    <table className="sources-placeholder-table pf-m-compact ins-entity-table">
-        <tbody>
-            {new Array(12).fill(null).map((_, idx) => <tr key={idx}><td><RowLoader /></td></tr>)}
-        </tbody>
-    </table>
+    <Bullseye className="ins-c-sources__sources-placeholder-loader">
+        <Spinner size="xl"/>
+    </Bullseye>
 );
 
 export const RowWrapperLoader = ({ row: { isDeleting, ...row }, ...initialProps }) => (isDeleting ?

--- a/src/test/components/SourcesSimpleView/SourcesSimpleView.spec.js
+++ b/src/test/components/SourcesSimpleView/SourcesSimpleView.spec.js
@@ -6,6 +6,8 @@ import { Table, TableHeader, TableBody, RowWrapper, sortable, ActionsColumn } fr
 import { MemoryRouter } from 'react-router-dom';
 import { RowLoader } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
 import { act } from 'react-dom/test-utils';
+import ArrowsAltVIcon from '@patternfly/react-icons/dist/js/icons/arrows-alt-v-icon';
+import LongArrowAltDownIcon from '@patternfly/react-icons/dist/js/icons/long-arrow-alt-down-icon';
 
 import SourcesSimpleView, { insertEditAction, actionResolver, prepareColumnsCells } from '../../../components/SourcesSimpleView/SourcesSimpleView';
 import { PlaceHolderTable, RowWrapperLoader } from '../../../components/SourcesSimpleView/loaders';
@@ -20,6 +22,7 @@ import * as actions from '../../../redux/sources/actions';
 import * as API from '../../../api/entities';
 import { replaceRouteId, routes } from '../../../Routes';
 import { defaultSourcesState } from '../../../redux/sources/reducer';
+import { sourcesColumns } from '../../../views/sourcesViewDefinition';
 
 describe('SourcesSimpleView', () => {
     const middlewares = [thunk, notificationsMiddleware()];
@@ -55,6 +58,8 @@ describe('SourcesSimpleView', () => {
         const wrapper = mount(componentWrapperIntl(<SourcesSimpleView { ...initialProps } />, store));
 
         expect(wrapper.find(PlaceHolderTable)).toHaveLength(1);
+        expect(wrapper.find(ArrowsAltVIcon)).toHaveLength(0);
+        expect(wrapper.find(LongArrowAltDownIcon)).toHaveLength(0);
     });
 
     it('renders removing row', (done) => {
@@ -99,6 +104,9 @@ describe('SourcesSimpleView', () => {
         const store = mockStore(initialState);
         const wrapper = mount(componentWrapperIntl(<SourcesSimpleView { ...initialProps } />, store));
 
+        const activeSortingIcon = 1;
+        const expectSortableColumns = sourcesColumns({ formatMessage: () => {} }).filter(x => x.sortable).length - activeSortingIcon;
+
         setTimeout(() => {
             setTimeout(() => {
                 wrapper.update();
@@ -109,6 +117,8 @@ describe('SourcesSimpleView', () => {
                 expect(wrapper.find(RowWrapper)).toHaveLength(sourcesDataGraphQl.length);
                 expect(wrapper.find(ActionsColumn)).toHaveLength(sourcesDataGraphQl.length);
                 expect(wrapper.find(RowWrapper).first().props().className).toEqual(ROW_WRAPPER_CLASSNAME);
+                expect(wrapper.find(LongArrowAltDownIcon)).toHaveLength(1);
+                expect(wrapper.find(ArrowsAltVIcon)).toHaveLength(expectSortableColumns);
                 done();
             });
         });
@@ -170,6 +180,7 @@ describe('SourcesSimpleView', () => {
         expect(wrapper.find(TableHeader)).toHaveLength(1);
         expect(wrapper.find(TableBody)).toHaveLength(1);
         expect(wrapper.find(ActionsColumn)).toHaveLength(0);
+        expect(wrapper.find(ArrowsAltVIcon)).toHaveLength(0);
     });
 
     it('re-renders when entities changed', async () => {

--- a/src/test/components/SourcesSimpleView/SourcesSimpleView.spec.js
+++ b/src/test/components/SourcesSimpleView/SourcesSimpleView.spec.js
@@ -19,6 +19,7 @@ import { componentWrapperIntl } from '../../../Utilities/testsHelpers';
 import * as actions from '../../../redux/sources/actions';
 import * as API from '../../../api/entities';
 import { replaceRouteId, routes } from '../../../Routes';
+import { defaultSourcesState } from '../../../redux/sources/reducer';
 
 describe('SourcesSimpleView', () => {
     const middlewares = [thunk, notificationsMiddleware()];
@@ -31,14 +32,7 @@ describe('SourcesSimpleView', () => {
         initialProps = {};
         mockStore = configureStore(middlewares);
         initialState = {
-            sources: {
-                loaded: 0,
-                rows: [],
-                entities: [],
-                numberOfEntities: 0,
-                pageNumber: 1,
-                pageSize: 10
-            },
+            sources: defaultSourcesState,
             user: {
                 isOrgAdmin: true
             }
@@ -60,7 +54,6 @@ describe('SourcesSimpleView', () => {
         const store = mockStore(initialState);
         const wrapper = mount(componentWrapperIntl(<SourcesSimpleView { ...initialProps } />, store));
 
-        expect(wrapper.find(Table)).toHaveLength(0);
         expect(wrapper.find(PlaceHolderTable)).toHaveLength(1);
     });
 

--- a/src/test/components/SourcesSimpleView/loaders.spec.js
+++ b/src/test/components/SourcesSimpleView/loaders.spec.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { RowWrapper } from '@patternfly/react-table';
 import { RowLoader } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
+import { Spinner } from '@patternfly/react-core/dist/js/components/Spinner';
+import { Bullseye } from '@patternfly/react-core/dist/js/layouts/Bullseye';
 
 import { PlaceHolderTable, RowWrapperLoader } from '../../../components/SourcesSimpleView/loaders';
 import { COLUMN_COUNT } from '../../../views/sourcesViewDefinition';
@@ -11,8 +13,8 @@ describe('loaders', () => {
         it('renders correctly', () => {
             const wrapper = mount(<PlaceHolderTable />);
 
-            expect(wrapper.find('table').length).toEqual(1);
-            expect(wrapper.find(RowLoader).length).toEqual(12);
+            expect(wrapper.find(Spinner)).toHaveLength(1);
+            expect(wrapper.find(Bullseye)).toHaveLength(1);
         });
     });
 

--- a/src/test/pages/SourcesPage.spec.js
+++ b/src/test/pages/SourcesPage.spec.js
@@ -8,7 +8,6 @@ import { act } from 'react-dom/test-utils';
 import { Chip, Select, Pagination, Button } from '@patternfly/react-core';
 import { MemoryRouter, Link } from 'react-router-dom';
 import { AddSourceWizard } from '@redhat-cloud-services/frontend-components-sources';
-import { RowLoader } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
 
 import SourcesPage from '../../pages/SourcesPage';
 import SourcesEmptyState from '../../components/SourcesEmptyState';
@@ -33,6 +32,8 @@ import * as AddApplication from '../../components/AddApplication/AddApplication'
 import * as SourceEditModal from '../../components/SourceEditForm/SourceEditModal';
 import * as SourceRemoveModal from '../../components/SourceRemoveModal';
 import * as urlQuery from '../../Utilities/urlQuery';
+import { PlaceHolderTable } from '../../components/SourcesSimpleView/loaders';
+import { Table } from '@patternfly/react-table';
 
 describe('SourcesPage', () => {
     const middlewares = [thunk, notificationsMiddleware()];
@@ -255,14 +256,11 @@ describe('SourcesPage', () => {
             wrapper = mount(componentWrapperIntl(<SourcesPage { ...initialProps } />, store));
         });
 
-        const paginationLoadersCount = 2;
-        const rowLoadersCount = 12;
-
-        expect(wrapper.find(RowLoader)).toHaveLength(rowLoadersCount);
-        expect(wrapper.find(PaginationLoader)).toHaveLength(paginationLoadersCount);
+        expect(wrapper.find(PlaceHolderTable)).toHaveLength(1);
+        expect(wrapper.find(Table)).toHaveLength(1);
         wrapper.update();
-        expect(wrapper.find(RowLoader)).toHaveLength(0);
-        expect(wrapper.find(PaginationLoader)).toHaveLength(0);
+        expect(wrapper.find(PlaceHolderTable)).toHaveLength(0);
+        expect(wrapper.find(Table)).toHaveLength(1);
     });
 
     describe('filtering', () => {


### PR DESCRIPTION
Follows PF 4's guidelines for loading

https://www.patternfly.org/v4/documentation/core/demos/table/loading-state-demo
https://www.patternfly.org/v4/design-guidelines/usage-and-behavior/data-loading

**Before**

![before](https://user-images.githubusercontent.com/32869456/73950312-028d6200-48fc-11ea-8d0e-a4770db9e745.gif)


**After** 

![after](https://user-images.githubusercontent.com/32869456/73950319-04efbc00-48fc-11ea-959a-c14c05ce347e.gif)