### PR TITLE
Update availability status formatter

### DIFF
--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import axiosInstanceInsights from '@redhat-cloud-services/frontend-components-utilities/files/interceptors';
 import { DefaultApi as SourcesDefaultApi } from '@redhat-cloud-services/sources-client';
 
@@ -64,7 +65,7 @@ export const graphQlAttributes = `
     availability_status,
     source_ref,
     applications { application_type_id, id, availability_status_error, availability_status },
-    endpoints { id, scheme, host, port, path, receptor_node, role, certificate_authority, verify_ssl }
+    endpoints { id, scheme, host, port, path, receptor_node, role, certificate_authority, verify_ssl, availability_status_error, availability_status, authentications { authtype, availability_status, availability_status_error } }
 `;
 
 export const doLoadEntities = ({ pageSize, pageNumber, sortBy, sortDirection, filterValue }) => getSourcesApi().postGraphQL({

--- a/src/components/SourcesSimpleView/formatters.js
+++ b/src/components/SourcesSimpleView/formatters.js
@@ -155,7 +155,7 @@ export const getStatusText = (status) => ({
     defaultMessage="Unknown"
 />);
 
-const UnknownError = () => (<FormattedMessage
+export const UnknownError = () => (<FormattedMessage
     id="sources.unknownError"
     defaultMessage="unavailable"
 />);
@@ -208,7 +208,7 @@ export const formatAvailibilityErrors = (appTypes, errors) => (<React.Fragment>
     />}
 </React.Fragment>);
 
-export const getStatusTooltipText = (status, appTypes, errors) => ({
+export const getStatusTooltipText = (status, appTypes, errors = {}) => ({
     [UNAVAILABLE]: <React.Fragment>
         <FormattedMessage
             id="sources.appStatusPartiallyOK"
@@ -241,6 +241,7 @@ export const getAllErrors = (
 ) => {
     let errors = {};
     let statusesCount = 0;
+    let errorsCount = 0;
 
     if (availability_status === UNAVAILABLE) {
         errors = {
@@ -248,6 +249,7 @@ export const getAllErrors = (
             source: availability_status_error || <UnknownError />
         };
         statusesCount++;
+        errorsCount++;
     } else if (availability_status === AVAILABLE) {
         statusesCount++;
     }
@@ -262,41 +264,40 @@ export const getAllErrors = (
                 ]
             };
             statusesCount++;
+            errorsCount++;
         } else if (app.availability_status === AVAILABLE) {
             statusesCount++;
         }
     });
 
-    if (endpoint) {
-        if (endpoint.availability_status === UNAVAILABLE) {
-            errors = {
-                ...errors,
-                endpoint: endpoint.availability_status_error || <UnknownError />
-            };
-            statusesCount++;
-        } else if (endpoint.availability_status === AVAILABLE) {
-            statusesCount++;
-        }
-
-        if (endpoint.authentications) {
-            endpoint.authentications.map((auth) => {
-                if (auth.availability_status === UNAVAILABLE) {
-                    errors = {
-                        ...errors,
-                        authentications: [
-                            ...(errors.authentications ? errors.authentications : []),
-                            { type: auth.authtype, error: auth.availability_status_error || <UnknownError /> }
-                        ]
-                    };
-                    statusesCount++;
-                } else if (auth.availability_status === AVAILABLE) {
-                    statusesCount++;
-                }
-            });
-        }
+    if (endpoint.availability_status === UNAVAILABLE) {
+        errors = {
+            ...errors,
+            endpoint: endpoint.availability_status_error || <UnknownError />
+        };
+        statusesCount++;
+        errorsCount++;
+    } else if (endpoint.availability_status === AVAILABLE) {
+        statusesCount++;
     }
 
-    const errorsCount = Object.keys(errors).length;
+    if (endpoint.authentications) {
+        endpoint.authentications.map((auth) => {
+            if (auth.availability_status === UNAVAILABLE) {
+                errors = {
+                    ...errors,
+                    authentications: [
+                        ...(errors.authentications ? errors.authentications : []),
+                        { type: auth.authtype, error: auth.availability_status_error || <UnknownError /> }
+                    ]
+                };
+                statusesCount++;
+                errorsCount++;
+            } else if (auth.availability_status === AVAILABLE) {
+                statusesCount++;
+            }
+        });
+    }
 
     return {
         errors,

--- a/src/components/SourcesSimpleView/formatters.js
+++ b/src/components/SourcesSimpleView/formatters.js
@@ -126,22 +126,27 @@ export const importedFormatter = (value) => {
     </Badge>);
 };
 
+export const AVAILABLE = 'available';
+export const UNAVAILABLE = 'unavailable';
+export const UNKNOWN = 'unknown';
+export const PARTIALLY_UNAVAILABLE = 'partially_available';
+
 export const getStatusIcon = (status) => ({
-    unavailable: <TimesCircleIcon className="ins-c-sources__availability-not-ok"/>,
-    available: <CheckCircleIcon className="ins-c-sources__availability-ok"/>,
-    partially_available: <ExclamationTriangleIcon className="ins-c-sources__availability-partially"/>
+    [UNAVAILABLE]: <TimesCircleIcon className="ins-c-sources__availability-not-ok"/>,
+    [AVAILABLE]: <CheckCircleIcon className="ins-c-sources__availability-ok"/>,
+    [PARTIALLY_UNAVAILABLE]: <ExclamationTriangleIcon className="ins-c-sources__availability-partially"/>
 }[status] || <QuestionCircleIcon className="ins-c-sources__availability-unknown"/>);
 
 export const getStatusText = (status) => ({
-    unavailable: <FormattedMessage
+    [UNAVAILABLE]: <FormattedMessage
         id="sources.unavailable"
         defaultMessage="Unavailable"
     />,
-    available: <FormattedMessage
+    [AVAILABLE]: <FormattedMessage
         id="sources.ok"
         defaultMessage="OK"
     />,
-    partially_available: <FormattedMessage
+    [PARTIALLY_UNAVAILABLE]: <FormattedMessage
         id="sources.partiallyAvailable"
         defaultMessage="Partially available"
     />
@@ -150,90 +155,170 @@ export const getStatusText = (status) => ({
     defaultMessage="Unknown"
 />);
 
-export const formatAvailibilityErrors = (source, appTypes) => {
-    if (source.applications && source.applications.length > 0) {
-        if (!source.applications.some(({ availability_status }) => availability_status === 'unavailable')) {
-            return (<FormattedMessage
-                id="sources.unknownError"
-                defaultMessage="Unknown error"
-            />);
-        }
+const UnknownError = () => (<FormattedMessage
+    id="sources.unknownError"
+    defaultMessage="unavailable"
+/>);
 
-        return source.applications.map(
-            ({ application_type_id, availability_status_error, availability_status }, index) => {
-                if (availability_status === 'unavailable') {
-                    const application = appTypes.find(({ id }) => id === application_type_id);
-                    const applicationName = application ? application.display_name : '';
-
-                    if (availability_status_error) {
-                        return `${availability_status_error} \n ${applicationName ? `(${applicationName})` : ''}`;
-                    }
-
-                    return (<FormattedMessage
-                        key={availability_status_error || index}
-                        id="sources.unknownAppError"
-                        defaultMessage="Unknown application error ({ appName }) "
-                        values={{ appName: applicationName }}
-                    />);
-                }
-            }
-        );
-    }
-
-    return (<FormattedMessage
-        key="availability_status_error"
-        id="sources.unknownAppError"
-        defaultMessage="Unknown source error."
-    />);
-};
-
-export const getStatusTooltipText = (status, source, appTypes) => ({
-    unavailable: <React.Fragment>
+export const formatAvailibilityErrors = (appTypes, errors) => (<React.Fragment>
+    {errors.source && <React.Fragment>
         <FormattedMessage
-            id="sources.appStatusPartiallyOK"
-            defaultMessage="We found these errors:"
+            id="sources.sourceError"
+            defaultMessage="Source's status: { error }"
+            values={{ error: errors.source  }}
         />
         <br />
-        {formatAvailibilityErrors(source, appTypes)}
+    </React.Fragment>}
+    {errors.endpoint && <React.Fragment>
+        <FormattedMessage
+            id="sources.endpointError"
+            defaultMessage="Endpoint error: { error }"
+            values={{ error: errors.endpoint }}
+        />
+        <br />
+    </React.Fragment>}
+    {errors.authentications && <FormattedMessage
+        id="sources.authErrors"
+        defaultMessage="Authentication {count, plural, one {status} other {statuses}} : { errors }"
+        values={{
+            count: errors.authentications.length,
+            errors: errors.authentications.map(({ error, type }) => (<React.Fragment key={type}>
+                <FormattedMessage
+                    id="sources.errorAuthTemplate"
+                    defaultMessage="{ type }: { error }"
+                    values={{ error, type  }}
+                />
+                <br />
+            </React.Fragment>))  }}
+    />}
+    {errors.applications && <FormattedMessage
+        id="sources.appErrors"
+        defaultMessage="Application {count, plural, one {status} other {statutes}}: { errors }"
+        values={{
+            count: errors.applications.length,
+            errors: errors.applications.map(({ error, id }) => (<React.Fragment key={id}>
+                <FormattedMessage
+                    id="sources.errorAppTemplate"
+                    defaultMessage="{ app }: { error }"
+                    values={{ error, app: appTypes.find((app) => app.id === id)?.display_name || id }}
+                />
+                <br />
+            </React.Fragment>))
+        }}
+    />}
+</React.Fragment>);
+
+export const getStatusTooltipText = (status, appTypes, errors) => ({
+    [UNAVAILABLE]: <React.Fragment>
+        <FormattedMessage
+            id="sources.appStatusPartiallyOK"
+            defaultMessage="We found {count, plural, one {this error} other {these errors}}."
+            values={{ count: Object.keys(errors).length }}
+        />
+        <hr />
+        {formatAvailibilityErrors(appTypes, errors)}
     </React.Fragment>,
-    available: <FormattedMessage
+    [AVAILABLE]: <FormattedMessage
         id="sources.appStatusOK"
-        defaultMessage="Everything works fine - all applications are connected."
+        defaultMessage="Everything works fine."
     />,
-    partially_available: <React.Fragment>
+    [PARTIALLY_UNAVAILABLE]: <React.Fragment>
         <FormattedMessage
             id="sources.appStatusPartiallyOK"
-            defaultMessage="We found these errors:"
+            defaultMessage="We found {count, plural, one {this error} other {these errors}}."
+            values={{ count: Object.keys(errors).length }}
         />
-        <br />
-        {formatAvailibilityErrors(source, appTypes)}
+        <hr />
+        {formatAvailibilityErrors(appTypes, errors)}
     </React.Fragment>
 }[status] || <FormattedMessage
     id="sources.appStatusUnknown"
     defaultMessage="Status has not been verified."
 />);
 
-export const availabilityFormatter = (status, source, { appTypes }) => {
-    const noApps = !source.applications || source.applications.length === 0;
+export const getAllErrors = (
+    { availability_status, availability_status_error, applications = [], endpoint = { authentications: [] } }
+) => {
+    let errors = {};
+    let statusesCount = 0;
 
-    const statusContent = noApps ? '--' : (<React.Fragment>
-        {getStatusIcon(status)}&nbsp;
-        {getStatusText(status)}
-    </React.Fragment>);
+    if (availability_status === UNAVAILABLE) {
+        errors = {
+            ...errors,
+            source: availability_status_error || <UnknownError />
+        };
+        statusesCount++;
+    } else if (availability_status === AVAILABLE) {
+        statusesCount++;
+    }
 
-    const tooltipText = noApps ? (<FormattedMessage
-        id="sources.noAppConnected"
-        defaultMessage="No application connected."
-    />) : getStatusTooltipText(status, source, appTypes);
+    applications.map((app) => {
+        if (app.availability_status === UNAVAILABLE) {
+            errors = {
+                ...errors,
+                applications: [
+                    ...(errors.applications ? errors.applications : []),
+                    { id: app.application_type_id, error: app.availability_status_error || <UnknownError /> }
+                ]
+            };
+            statusesCount++;
+        } else if (app.availability_status === AVAILABLE) {
+            statusesCount++;
+        }
+    });
+
+    if (endpoint) {
+        if (endpoint.availability_status === UNAVAILABLE) {
+            errors = {
+                ...errors,
+                endpoint: endpoint.availability_status_error || <UnknownError />
+            };
+            statusesCount++;
+        } else if (endpoint.availability_status === AVAILABLE) {
+            statusesCount++;
+        }
+
+        if (endpoint.authentications) {
+            endpoint.authentications.map((auth) => {
+                if (auth.availability_status === UNAVAILABLE) {
+                    errors = {
+                        ...errors,
+                        authentications: [
+                            ...(errors.authentications ? errors.authentications : []),
+                            { type: auth.authtype, error: auth.availability_status_error || <UnknownError /> }
+                        ]
+                    };
+                    statusesCount++;
+                } else if (auth.availability_status === AVAILABLE) {
+                    statusesCount++;
+                }
+            });
+        }
+    }
+
+    const errorsCount = Object.keys(errors).length;
+
+    return {
+        errors,
+        status: errorsCount === 0  ?
+            statusesCount === 0 ? UNKNOWN : AVAILABLE
+            : errorsCount === statusesCount ? UNAVAILABLE : PARTIALLY_UNAVAILABLE
+    };
+};
+
+export const availabilityFormatter = (_status, source, { appTypes }) => {
+    const meta = getAllErrors(source);
+    const status = meta.status;
 
     return (<TextContent className="clickable">
         <Text key={status} component={ TextVariants.p }>
             <Popover
                 aria-label={`${status} popover`}
-                bodyContent={<h1>{tooltipText}</h1>}
+                bodyContent={<h1>{getStatusTooltipText(status, appTypes, meta.errors)}</h1>}
             >
                 <span>
-                    {statusContent}
+                    {getStatusIcon(status)}&nbsp;
+                    {getStatusText(status)}
                 </span>
             </Popover>
         </Text>

--- a/src/views/sourcesViewDefinition.js
+++ b/src/views/sourcesViewDefinition.js
@@ -42,8 +42,7 @@ export const sourcesColumns = (intl, notSortable = false) => ([{
         defaultMessage: 'Status'
     }),
     value: 'availability_status',
-    formatter: 'availabilityFormatter',
-    sortable: !notSortable
+    formatter: 'availabilityFormatter'
 }]);
 
 const KEBAB_COLUMN = 1;


### PR DESCRIPTION
closes https://github.com/RedHatInsights/sources-ui/issues/198

- checks all possible availability statuses
  - `nills` are ignored
  - if all are available, source is available
  - if all are unavailable, source is unavailable and errors are shown
  - if at least one of them is unavailable and others are available, source is partially available and the error(s) is shown
  - if there is no available/available and everything is nill, then status is uknown
- removes `--` status


![statuses](https://user-images.githubusercontent.com/32869456/74221595-c74fb200-4cb2-11ea-8d56-e1377de28b0f.gif)
