### PR TITLE
Use code splitting for routes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,8 @@
 {
-    "presets": ['@babel/preset-env', '@babel/preset-react'],
+    "presets": ["@babel/preset-env", "@babel/preset-react"],
     "plugins": [
         "@babel/plugin-transform-runtime",
         "@babel/plugin-syntax-dynamic-import",
-        "@babel/plugin-proposal-class-properties",
-	    "dynamic-import-node"
+        "@babel/plugin-proposal-class-properties"
     ]
 }

--- a/config/base.webpack.config.js
+++ b/config/base.webpack.config.js
@@ -8,26 +8,16 @@ const webpackConfig = {
     mode: process.env.NODE_ENV === 'production' ? 'production' : 'development',
     devtool: false,
     optimization: {
-        minimize: process.env.NODE_ENV === 'production',
-        splitChunks: {
-            cacheGroups: {
-                vendors: false,
-                commons: {
-                    test: /[\\/]node_modules[\\/]/,
-                    name: 'vendor',
-                    chunks: 'initial'
-                }
-            }
-        }
+        minimize: process.env.NODE_ENV === 'production'
     },
     entry: {
         App: config.paths.entry
     },
     output: {
         filename: 'js/[name].js',
+        chunkFilename: 'js/[name].js',
         path: config.paths.public,
-        publicPath: config.paths.publicPath,
-        chunkFilename: 'js/[name].js'
+        publicPath: config.paths.publicPath
     },
     module: {
         rules: [{

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^8.2.3",
     "babel-loader": "^8.0.6",
-    "babel-plugin-dynamic-import-node": "^2.3.0",
     "babel-polyfill": "^6.26.0",
     "connect-history-api-fallback": "^1.5.0",
     "css-loader": "^2.1.1",

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -2,7 +2,7 @@ import React, { Suspense, lazy } from 'react';
 import { Route } from 'react-router-dom';
 import ContentLoader from 'react-content-loader';
 
-const SourcesPage = lazy(() => import('./pages/SourcesPage'));
+const SourcesPage = lazy(() => import(/* webpackChunkName: "sourcePage" */ './pages/SourcesPage'));
 
 const Loader = () => (
     <ContentLoader>


### PR DESCRIPTION
Use code splitting for routes.

Initial download size went from 2.5 MB to 1.5 MB.

**Before**

![Screenshot from 2020-02-11 16-59-18](https://user-images.githubusercontent.com/32869456/74314494-cd5a9700-4d75-11ea-86e2-196684da22ce.png)

**After**

![Screenshot from 2020-02-12 08-57-30](https://user-images.githubusercontent.com/32869456/74314481-c7fd4c80-4d75-11ea-82f4-5f6260de03ca.png)
