### PR TITLE
Remove logger from production version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7501,7 +7501,8 @@
     "deep-diff": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
-      "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
+      "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ=",
+      "dev": true
     },
     "deep-equal": {
       "version": "1.0.1",
@@ -12754,7 +12755,8 @@
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
     },
     "lodash.isregexp": {
       "version": "4.0.1",
@@ -15735,6 +15737,7 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
       "integrity": "sha1-91VZZvMJjzyIYExEnPC69XeCdL8=",
+      "dev": true,
       "requires": {
         "deep-diff": "^0.3.5"
       }
@@ -15743,6 +15746,7 @@
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.4.tgz",
       "integrity": "sha512-xmcA0O/tjCLXhh9Fuiq6pMrJCwFRaouA8436zcikdIpYWWCjU76CRk+i2bHx8EeiSiMGnB85/lZdU3wIJVXHTA==",
+      "dev": true,
       "requires": {
         "lodash.isplainobject": "^4.0.6"
       }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
     "react-redux": "^7.1.3",
     "react-router-dom": "^5.1.2",
     "redux": "^4.0.5",
-    "redux-logger": "^3.0.6",
-    "redux-mock-store": "^1.5.4",
     "redux-promise-middleware": "^6.1.2",
     "redux-thunk": "^2.3.0"
   },
@@ -81,6 +79,8 @@
     "node-fetch": "^2.6.0",
     "node-sass": "^4.13.1",
     "npm-run-all": "^4.1.3",
+    "redux-logger": "^3.0.6",
+    "redux-mock-store": "^1.5.4",
     "sass-loader": "^7.3.1",
     "source-map-loader": "^0.2.3",
     "style-loader": "^0.21.0",

--- a/src/Utilities/getDevStore.js
+++ b/src/Utilities/getDevStore.js
@@ -1,0 +1,4 @@
+import { logger } from 'redux-logger';
+import { getStore } from './store';
+
+export const getDevStore = () => getStore([logger]);

--- a/src/Utilities/store.js
+++ b/src/Utilities/store.js
@@ -1,6 +1,5 @@
 import ReducerRegistry, { applyReducerHash } from '@redhat-cloud-services/frontend-components-utilities/files/ReducerRegistry';
 import { notifications, notificationsMiddleware } from '@redhat-cloud-services/frontend-components-notifications';
-import logger from 'redux-logger';
 import thunk from 'redux-thunk';
 import promise from 'redux-promise-middleware';
 
@@ -19,17 +18,14 @@ export const urlQueryMiddleware = store => next => action => {
     next(action);
 };
 
-export const getStore = (includeLogger) => {
+export const getStore = (addMiddlewares = []) => {
     const middlewares = [
         thunk,
         notificationsMiddleware({ errorTitleKey: 'error.title', errorDescriptionKey: 'error.detail' }),
         promise,
-        urlQueryMiddleware
+        urlQueryMiddleware,
+        ...addMiddlewares
     ];
-
-    if (includeLogger) {
-        middlewares.push(logger);
-    }
 
     const registry = new ReducerRegistry({}, middlewares);
 
@@ -40,5 +36,4 @@ export const getStore = (includeLogger) => {
     return registry.getStore();
 };
 
-export const getDevStore = () => getStore(true);
-export const getProdStore = () => getStore(false);
+export const getProdStore = () => getStore();

--- a/src/entries-dev.js
+++ b/src/entries-dev.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import App from './App';
-import { getProdStore } from './Utilities/store';
+import { getDevStore } from './Utilities/getDevStore';
 
-export const ProdEntry = () => (<Provider store={getProdStore()}>
+export const DevEntry = () => (<Provider store={getDevStore()}>
     <App />
 </Provider>);

--- a/src/entry-dev.js
+++ b/src/entry-dev.js
@@ -1,5 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { DevEntry } from './entries';
+import { DevEntry } from './entries-dev';
 
 ReactDOM.render(<DevEntry />, document.getElementById('root'));

--- a/src/test/entries.spec.js
+++ b/src/test/entries.spec.js
@@ -1,16 +1,17 @@
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 
-import { DevEntry, ProdEntry } from '../entries';
+import { ProdEntry } from '../entries';
+import { DevEntry } from '../entries-dev';
 import * as app from '../App';
 import * as stores from '../Utilities/store';
-
+import * as getDevStore from '../Utilities/getDevStore';
+;
 describe('entries test', () => {
     let store;
-
     beforeEach(() => {
         store = configureStore()({});
-        stores.getDevStore = jest.fn().mockImplementation(() => store);
+        getDevStore.getDevStore = jest.fn().mockImplementation(() => store);
         stores.getProdStore = jest.fn().mockImplementation(() => store);
 
         // eslint-disable-next-line react/display-name
@@ -22,7 +23,7 @@ describe('entries test', () => {
 
         expect(wrapper.find(Provider)).toHaveLength(1);
         expect(wrapper.find('h1')).toHaveLength(1);
-        expect(stores.getDevStore).toHaveBeenCalled();
+        expect(getDevStore.getDevStore).toHaveBeenCalled();
         expect(stores.getProdStore).not.toHaveBeenCalled();
     });
 
@@ -31,7 +32,7 @@ describe('entries test', () => {
 
         expect(wrapper.find(Provider)).toHaveLength(1);
         expect(wrapper.find('h1')).toHaveLength(1);
-        expect(stores.getDevStore).not.toHaveBeenCalled();
+        expect(getDevStore.getDevStore).not.toHaveBeenCalled();
         expect(stores.getProdStore).toHaveBeenCalled();
     });
 });

--- a/src/test/utilities/store.spec.js
+++ b/src/test/utilities/store.spec.js
@@ -1,8 +1,9 @@
-import { getDevStore, getProdStore, urlQueryMiddleware } from '../../Utilities/store';
+import { getProdStore, urlQueryMiddleware } from '../../Utilities/store';
 import { defaultSourcesState } from '../../redux/sources/reducer';
 import { defaultUserState } from '../../redux/user/reducer';
 import * as queries from '../../Utilities/urlQuery';
 import { ACTION_TYPES } from '../../redux/sources/actions-types';
+import { getDevStore } from '../../Utilities/getDevStore';
 
 describe('store creator', () => {
     const EXPECTED_DEFAULT_STATE = {


### PR DESCRIPTION
This saves 9 KB of parsed space.

**Before**

![image](https://user-images.githubusercontent.com/32869456/74435603-16d5df80-4e65-11ea-9c79-1c14e264e66c.png)

**After**

![image](https://user-images.githubusercontent.com/32869456/74435620-205f4780-4e65-11ea-8fc0-7508e0b25bf1.png)
