### PR TITLE
Copy code from utils to achieve smaller size

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "@redhat-cloud-services/frontend-components-notifications": "1.0.1",
     "@redhat-cloud-services/frontend-components-sources": "1.0.2",
     "@redhat-cloud-services/frontend-components-utilities": "1.0.0",
+    "@sentry/minimal": "5.12.0",
+    "axios": "0.19.2",
     "deep-object-diff": "^1.1.0",
     "lodash": "^4.17.15",
     "react": "^16.12.0",
@@ -33,7 +35,8 @@
       "src/**/*.{js,jsx}",
       "!src/**/stories/*",
       "!src/entry.js",
-      "!src/entry-dev.js"
+      "!src/entry-dev.js",
+      "!src/frontend-components-copies/*"
     ],
     "setupFiles": [
       "<rootDir>/config/setupTests.js"

--- a/src/App.js
+++ b/src/App.js
@@ -3,13 +3,13 @@ import { NotificationsPortal } from '@redhat-cloud-services/frontend-components-
 import { Main } from '@redhat-cloud-services/frontend-components/components/Main';
 import { IntlProvider } from 'react-intl';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { getBaseName } from '@redhat-cloud-services/frontend-components-utilities/files/helpers';
 
 import Routes from './Routes';
 import './App.scss';
 
 import ErrorBoundary from './components/ErrorBoundary';
 import PermissionsChecker from './components/PermissionsChecker';
+import { getBaseName } from './frontend-components-copies/getBaseName';
 
 const App = () => {
     useEffect(() => {

--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -1,5 +1,6 @@
 /* eslint-disable max-len */
-import axiosInstanceInsights from '@redhat-cloud-services/frontend-components-utilities/files/interceptors';
+import axios from 'axios';
+import * as interceptors from '../frontend-components-copies/interceptors';
 
 import { SOURCES_API_BASE } from './constants';
 
@@ -11,6 +12,12 @@ export const graphQlErrorInterceptor = response => {
     return response;
 };
 
+const axiosInstanceInsights = axios.create();
+axiosInstanceInsights.interceptors.request.use(interceptors.authInterceptor);
+axiosInstanceInsights.interceptors.response.use(interceptors.responseDataInterceptor);
+axiosInstanceInsights.interceptors.response.use(null, interceptors.interceptor401);
+axiosInstanceInsights.interceptors.response.use(null, interceptors.interceptor500);
+axiosInstanceInsights.interceptors.response.use(null, interceptors.errorInterceptor);
 axiosInstanceInsights.interceptors.response.use(graphQlErrorInterceptor);
 
 export { axiosInstanceInsights as axiosInstance };

--- a/src/frontend-components-copies/getBaseName.js
+++ b/src/frontend-components-copies/getBaseName.js
@@ -1,0 +1,15 @@
+export const getBaseName = (pathname, level = 2) => {
+    let release = '/';
+    const pathName = pathname.replace(/(#|\?).*/, '').split('/');
+
+    pathName.shift();
+
+    if (pathName[0] === 'beta') {
+        pathName.shift();
+        release = `/beta/`;
+    }
+
+    return [...new Array(level)].reduce((acc, _curr, key) => {
+        return `${acc}${pathName[key] || ''}${key < (level - 1) ? '/' : ''}`;
+    }, release);
+};

--- a/src/frontend-components-copies/interceptors.js
+++ b/src/frontend-components-copies/interceptors.js
@@ -1,0 +1,52 @@
+import axios from 'axios';
+import { configureScope, captureException } from '@sentry/minimal';
+
+export async function authInterceptor(config) {
+    await window.insights.chrome.auth.getUser();
+    return config;
+}
+
+export function responseDataInterceptor(response) {
+    if (response.data) {
+        return response.data;
+    }
+
+    return response;
+}
+
+export function interceptor401(error) {
+    if (error.response && error.response.status === 401) {
+        window.insights.chrome.auth.logout();
+        return false;
+    }
+
+    throw error;
+}
+
+export function interceptor500(error) {
+    if (error.response && error.response.status >= 500 && error.response.status < 600) {
+        configureScope((scope) => {
+            scope.setTag('request_id', error.response.req_id);
+        });
+    }
+
+    throw error;
+}
+
+export function errorInterceptor(err) {
+    if (!axios.isCancel(err)) {
+        try {
+            const errObject = { ...err };
+            if (errObject.response && errObject.response.data) {
+                throw errObject.response.data;
+            }
+
+            throw err;
+        }
+        catch (customError) {
+            const sentryId = captureException(customError);
+            customError.sentryId = sentryId;
+            throw customError;
+        }
+    }
+}


### PR DESCRIPTION
Exports from frontend components are too large, so I just copied interceptors and the one helper method I am using. App is now 130 KB smaller.

@Hyperkid123 @karelhala 

**Before**

![image](https://user-images.githubusercontent.com/32869456/74453720-12202400-4e83-11ea-8f11-2cefd462e6b8.png)
![image](https://user-images.githubusercontent.com/32869456/74453738-1c422280-4e83-11ea-96be-5213f2d78fcc.png)


**After**

![image](https://user-images.githubusercontent.com/32869456/74453759-2401c700-4e83-11ea-9431-c17d300b5319.png)
![image](https://user-images.githubusercontent.com/32869456/74453776-2a903e80-4e83-11ea-822d-31c5b210e5ba.png)