### PR TITLE
Allow to select the autentication when adding app

### DIFF
--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -100,12 +100,10 @@ export const graphQlAttributes = `
     created_at,
     source_type_id,
     name,
-    uid,
-    updated_at,
     imported,
     availability_status,
     source_ref,
-    applications { application_type_id, id, availability_status_error, availability_status },
+    applications { application_type_id, id, availability_status_error, availability_status, authentications { id } },
     endpoints { id, scheme, host, port, path, receptor_node, role, certificate_authority, verify_ssl, availability_status_error, availability_status, authentications { authtype, availability_status, availability_status_error } }
 `;
 

--- a/src/components/AddApplication/AddApplication.js
+++ b/src/components/AddApplication/AddApplication.js
@@ -98,8 +98,8 @@ const AddApplication = () => {
                             endpoint: source.endpoints[0],
                             url: endpointToUrl(source.endpoints[0]),
                             application: selectedApp,
-                            values: {}
-                        }
+                        },
+                        values: {}
                     }))
                     .then(() => {
                         if (state.state === 'loading') {

--- a/src/components/AddApplication/AddApplicationSchema.js
+++ b/src/components/AddApplication/AddApplicationSchema.js
@@ -85,8 +85,12 @@ const selectAuthenticationStep = ({ source, authenticationValues, sourceType, ap
                 const appTypeId = app ? app.application_type_id : '';
                 const appType = appTypeId ? applicationTypes.find(({ id }) => id === appTypeId) : '';
 
+                const includeUsername = values.username ? `-${values.username}` : '';
+                const includeAppName = appType ? `-${appType.display_name}` : `-unused-${values.id}`;
+                const label = `${supportedAuthTypeName}${includeUsername}${includeAppName}`;
+
                 return {
-                    label: `${supportedAuthTypeName}-${appType ? `-${appType.display_name}` : `unused-${values.id}`}`,
+                    label,
                     value: values.id,
                 };
             });

--- a/src/components/AddApplication/AddApplicationSchema.js
+++ b/src/components/AddApplication/AddApplicationSchema.js
@@ -55,8 +55,6 @@ export const hasAlreadySupportedAuthType = (authValues = [], appType, sourceType
     authValues.find(({ authtype }) => authtype === get(appType, `supported_authentication_types.${sourceTypeName}[0]`));
 
 const selectAuthenticationStep = ({ source, authenticationValues, sourceType, applicationTypes, modifiedValues }) => {
-    console.log(source);
-
     const nextStep = ({ values: { application } }) => {
         const app = application ? application : {};
         const appId = app.application_type_id ? app.application_type_id : '';
@@ -151,15 +149,12 @@ const fields = (applications = [], intl, sourceTypes, applicationTypes, authenti
 
         applicationTypes.forEach(appType => {
             if (appType.supported_source_types.includes(sourceType.name)) {
-                const doNotRequirePasswords = hasAlreadySupportedAuthType(authenticationValues, appType, sourceType.name);
-
                 authenticationFields.push(
                     schemaBuilder.createSpecificAuthTypeSelection(
                         sourceType,
                         appType,
                         appendEndpoint,
                         false,
-                        doNotRequirePasswords
                     )
                 );
             }
@@ -171,8 +166,6 @@ const fields = (applications = [], intl, sourceTypes, applicationTypes, authenti
                     const appAdditionalSteps = schemaBuilder.getAdditionalSteps(sourceType.name, auth.type, appType.name);
 
                     if (appAdditionalSteps.length > 0) {
-                        const doNotRequirePasswords = hasAlreadySupportedAuthType(authenticationValues, appType, sourceType.name);
-
                         authenticationFields.push(
                             ...schemaBuilder.createAdditionalSteps(
                                 appAdditionalSteps,
@@ -181,7 +174,6 @@ const fields = (applications = [], intl, sourceTypes, applicationTypes, authenti
                                 hasEndpointStep,
                                 auth.fields,
                                 appType.name,
-                                doNotRequirePasswords
                             )
                         );
                     }

--- a/src/components/AddApplication/AuthTypeCleaner.js
+++ b/src/components/AddApplication/AuthTypeCleaner.js
@@ -1,0 +1,29 @@
+import { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import get from 'lodash/get';
+
+export const AuthTypeCleaner = ({ formOptions, modifiedValues }) => {
+    const selectedAppId = get(formOptions.getState().values, 'application.application_type_id', '');
+
+    const [initialValue] = useState(selectedAppId);
+
+    useEffect(() => {
+        if (initialValue !== selectedAppId) {
+            const values = modifiedValues && modifiedValues.authentication ? modifiedValues.authentication : undefined;
+            formOptions.batch(() => {
+                formOptions.change('authentication', values);
+                formOptions.change('selectedAuthentication', undefined);
+            });
+        }
+    }, [selectedAppId]);
+
+    return null;
+};
+
+AuthTypeCleaner.propTypes = {
+    formOptions: PropTypes.shape({
+        getState: PropTypes.func.isRequired,
+        change: PropTypes.func.isRequired
+    }).isRequired,
+    modifiedValues: PropTypes.object
+};

--- a/src/components/AddApplication/AuthTypeCleaner.js
+++ b/src/components/AddApplication/AuthTypeCleaner.js
@@ -5,7 +5,7 @@ import get from 'lodash/get';
 export const AuthTypeCleaner = ({ formOptions, modifiedValues }) => {
     const selectedAppId = get(formOptions.getState().values, 'application.application_type_id', '');
 
-    const [initialValue] = useState(selectedAppId);
+    const [initialValue, setInitialValue] = useState(selectedAppId);
 
     useEffect(() => {
         if (initialValue !== selectedAppId) {
@@ -14,6 +14,7 @@ export const AuthTypeCleaner = ({ formOptions, modifiedValues }) => {
                 formOptions.change('authentication', values);
                 formOptions.change('selectedAuthentication', undefined);
             });
+            setInitialValue(undefined);
         }
     }, [selectedAppId]);
 

--- a/src/components/AddApplication/AuthTypeSetter.js
+++ b/src/components/AddApplication/AuthTypeSetter.js
@@ -1,74 +1,42 @@
 import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { useSelector, shallowEqual } from 'react-redux';
-import { useSource } from '../../hooks/useSource';
-import get from 'lodash/get';
 import merge from 'lodash/merge';
 import cloneDeep from 'lodash/cloneDeep';
 
-export const checkAuthTypeMemo = () => {
-    let previousAuthType;
-
-    return (newAuthType) => {
-        if (previousAuthType === newAuthType) {
-            return false;
-        }
-
-        previousAuthType = newAuthType;
-        return true;
-    };
-};
-
 export const innerSetter = ({
-    sourceTypes,
-    source,
-    appTypes,
     formOptions,
-    checkAuthType,
+    modifiedValues,
     authenticationValues,
-    modifiedValues
+    selectedAuthentication
 }) => {
-    const sourceType = sourceTypes.find(({ id }) => id === source.source_type_id);
+    if (selectedAuthentication === 'new') {
+        const authentication = authenticationValues.find(({ id }) => id === selectedAuthentication);
 
-    const formValues = formOptions.getState();
-
-    const application = appTypes.find(
-        ({ id }) => id === get(formValues, 'values.application.application_type_id', undefined)
-    );
-    const supported_auth_type = get(application, `supported_authentication_types[${sourceType.name}][0]`, '');
-
-    if (checkAuthType(supported_auth_type)) {
-        formOptions.change('supported_auth_type', supported_auth_type);
-
-        const hasAuthenticationAlready = authenticationValues.find(({ authtype }) => authtype === supported_auth_type);
-
-        if (hasAuthenticationAlready) {
-            if (modifiedValues && modifiedValues.authentication) {
-                const newAuthenticationValues = merge(cloneDeep(hasAuthenticationAlready), modifiedValues.authentication);
-                formOptions.change('authentication', newAuthenticationValues);
-            } else {
-                formOptions.change('authentication', hasAuthenticationAlready);
-            }
+        if (modifiedValues && modifiedValues.authentication) {
+            const newAuthenticationValues = merge(cloneDeep(authentication), modifiedValues.authentication);
+            formOptions.change('authentication', newAuthenticationValues);
         } else {
-            if (modifiedValues && modifiedValues.authentication) {
-                formOptions.change('authentication', modifiedValues.authentication);
-            } else {
-                formOptions.change('authentication', undefined);
-            }
+            formOptions.change('authentication', authentication);
+        }
+    } else {
+        if (modifiedValues && modifiedValues.authentication) {
+            formOptions.change('authentication', modifiedValues.authentication);
+        } else {
+            formOptions.change('authentication', undefined);
         }
     }
 };
 
 export const AuthTypeSetter = ({ formOptions, authenticationValues, modifiedValues }) => {
-    const [checkAuthType] = useState(() => checkAuthTypeMemo());
+    const selectedAuthentication = formOptions.getState().values.selectedAuthentication;
 
-    const { appTypes, sourceTypes } = useSelector(({ sources }) => sources, shallowEqual);
-
-    const source = useSource();
+    const [initialValue] = useState(selectedAuthentication);
 
     useEffect(() => {
-        innerSetter({ sourceTypes, checkAuthType, formOptions, authenticationValues, appTypes, source, modifiedValues });
-    });
+        if (initialValue !== selectedAuthentication) {
+            innerSetter({ formOptions, authenticationValues, modifiedValues, selectedAuthentication });
+        }
+    }, [selectedAuthentication]);
 
     return null;
 };

--- a/src/components/AddApplication/AuthTypeSetter.js
+++ b/src/components/AddApplication/AuthTypeSetter.js
@@ -30,11 +30,12 @@ export const innerSetter = ({
 export const AuthTypeSetter = ({ formOptions, authenticationValues, modifiedValues }) => {
     const selectedAuthentication = formOptions.getState().values.selectedAuthentication;
 
-    const [initialValue] = useState(selectedAuthentication);
+    const [initialValue, setInitialValue] = useState(selectedAuthentication);
 
     useEffect(() => {
         if (initialValue !== selectedAuthentication) {
             innerSetter({ formOptions, authenticationValues, modifiedValues, selectedAuthentication });
+            setInitialValue(undefined);
         }
     }, [selectedAuthentication]);
 

--- a/src/components/AddApplication/AuthTypeSetter.js
+++ b/src/components/AddApplication/AuthTypeSetter.js
@@ -9,7 +9,7 @@ export const innerSetter = ({
     authenticationValues,
     selectedAuthentication
 }) => {
-    if (selectedAuthentication === 'new') {
+    if (selectedAuthentication !== 'new') {
         const authentication = authenticationValues.find(({ id }) => id === selectedAuthentication);
 
         if (modifiedValues && modifiedValues.authentication) {

--- a/src/test/__mocks__/sourceTypesData.js
+++ b/src/test/__mocks__/sourceTypesData.js
@@ -424,3 +424,6 @@ export const ANSIBLE_TOWER_ID = '3';
 export const OPENSHIFT_INDEX = 0;
 export const AMAZON_INDEX = 1;
 export const ANSIBLE_TOWER_INDEX = 2;
+
+export const OPENSHIFT = sourceTypesData.data[OPENSHIFT_INDEX];
+export const AMAZON = sourceTypesData.data[AMAZON_INDEX];

--- a/src/test/components/addApplication/AuthTypeCleaner.test.js
+++ b/src/test/components/addApplication/AuthTypeCleaner.test.js
@@ -1,0 +1,206 @@
+import { mount } from 'enzyme';
+import { AuthTypeCleaner } from '../../../components/AddApplication/AuthTypeCleaner';
+
+describe('AuthTypeCleaner', () => {
+    let initialProps;
+    let formOptions;
+    let changeSpy;
+
+    class Wrapper extends React.Component {
+        render() {
+            return (
+                <AuthTypeCleaner {...this.props} />
+            );
+        }
+    }
+
+    beforeEach(() => {
+        changeSpy = jest.fn().mockImplementation();
+
+        formOptions = {
+            batch: jest.fn().mockImplementation(fn => fn()),
+            getState: jest.fn().mockImplementation(() => ({ values: {} })),
+            change: changeSpy
+        };
+
+        initialProps = {
+            formOptions,
+        };
+    });
+
+    it('change authentication when selected app is changed', () => {
+        const wrapper = mount(<Wrapper {...initialProps} />);
+
+        expect(changeSpy).not.toHaveBeenCalled();
+        changeSpy.mockClear();
+
+        wrapper.setProps({
+            formOptions: {
+                ...formOptions,
+                getState: jest.fn().mockImplementation(() => ({
+                    values: {
+                        application: {
+                            application_type_id: 'cosi'
+                        }
+                    }
+                })),
+            }
+        });
+
+        expect(changeSpy.mock.calls[0][0]).toEqual('authentication');
+        expect(changeSpy.mock.calls[0][1]).toEqual(undefined);
+
+        expect(changeSpy.mock.calls[1][0]).toEqual('selectedAuthentication');
+        expect(changeSpy.mock.calls[1][1]).toEqual(undefined);
+
+        expect(changeSpy.mock.calls.length).toEqual(2);
+        changeSpy.mockClear();
+
+        wrapper.setProps({
+            formOptions: {
+                ...formOptions,
+                getState: jest.fn().mockImplementation(() => ({
+                    values: {
+                        application: {
+                            application_type_id: undefined
+                        }
+                    }
+                })),
+            }
+        });
+
+        expect(changeSpy.mock.calls[0][0]).toEqual('authentication');
+        expect(changeSpy.mock.calls[0][1]).toEqual(undefined);
+
+        expect(changeSpy.mock.calls[1][0]).toEqual('selectedAuthentication');
+        expect(changeSpy.mock.calls[1][1]).toEqual(undefined);
+
+        expect(changeSpy.mock.calls.length).toEqual(2);
+        changeSpy.mockClear();
+    });
+
+    it('do not reset when selectedApplication is defined on initialRender', () => {
+        formOptions = {
+            ...formOptions,
+            getState: jest.fn().mockImplementation(() => ({
+                values: {
+                    application: {
+                        application_type_id: 'cosi'
+                    }
+                }
+            })),
+        };
+
+        const wrapper = mount(<Wrapper {...initialProps} />);
+
+        expect(changeSpy).not.toHaveBeenCalled();
+        changeSpy.mockClear();
+
+        wrapper.setProps({
+            formOptions: {
+                ...formOptions,
+                getState: jest.fn().mockImplementation(() => ({
+                    values: {
+                        application: {
+                            application_type_id: 'cosi2'
+                        }
+                    }
+                })),
+            }
+        });
+
+        expect(changeSpy.mock.calls[0][0]).toEqual('authentication');
+        expect(changeSpy.mock.calls[0][1]).toEqual(undefined);
+
+        expect(changeSpy.mock.calls[1][0]).toEqual('selectedAuthentication');
+        expect(changeSpy.mock.calls[1][1]).toEqual(undefined);
+
+        expect(changeSpy.mock.calls.length).toEqual(2);
+        changeSpy.mockClear();
+
+        wrapper.setProps({
+            formOptions: {
+                ...formOptions,
+                getState: jest.fn().mockImplementation(() => ({
+                    values: {
+                        application: {
+                            application_type_id: 'cosi'
+                        }
+                    }
+                })),
+            }
+        });
+
+        expect(changeSpy.mock.calls[0][0]).toEqual('authentication');
+        expect(changeSpy.mock.calls[0][1]).toEqual(undefined);
+
+        expect(changeSpy.mock.calls[1][0]).toEqual('selectedAuthentication');
+        expect(changeSpy.mock.calls[1][1]).toEqual(undefined);
+
+        expect(changeSpy.mock.calls.length).toEqual(2);
+        changeSpy.mockClear();
+    });
+
+    it('change authentication when selectedAuthentication is changed with modified values', () => {
+        const modifiedValues = {
+            nested: true,
+            authentication: {
+                password: '123456'
+            }
+        };
+
+        initialProps = {
+            ...initialProps,
+            modifiedValues
+        };
+
+        const wrapper = mount(<Wrapper {...initialProps} />);
+
+        expect(changeSpy).not.toHaveBeenCalled();
+        changeSpy.mockClear();
+
+        wrapper.setProps({
+            formOptions: {
+                ...formOptions,
+                getState: jest.fn().mockImplementation(() => ({
+                    values: {
+                        application: {
+                            application_type_id: 'cosi'
+                        }
+                    }
+                })),
+            }
+        });
+
+        expect(changeSpy.mock.calls[0][0]).toEqual('authentication');
+        expect(changeSpy.mock.calls[0][1]).toEqual(modifiedValues.authentication);
+
+        expect(changeSpy.mock.calls[1][0]).toEqual('selectedAuthentication');
+        expect(changeSpy.mock.calls[1][1]).toEqual(undefined);
+
+        expect(changeSpy.mock.calls.length).toEqual(2);
+        changeSpy.mockClear();
+
+        wrapper.setProps({
+            formOptions: {
+                ...formOptions,
+                getState: jest.fn().mockImplementation(() => ({
+                    values: {
+                        application: {
+                            application_type_id: undefined
+                        }
+                    }
+                })),
+            }
+        });
+
+        expect(changeSpy.mock.calls[0][0]).toEqual('authentication');
+        expect(changeSpy.mock.calls[0][1]).toEqual(modifiedValues.authentication);
+
+        expect(changeSpy.mock.calls[1][0]).toEqual('selectedAuthentication');
+        expect(changeSpy.mock.calls[1][1]).toEqual(undefined);
+
+        expect(changeSpy.mock.calls.length).toEqual(2);
+        changeSpy.mockClear();
+    });
+});


### PR DESCRIPTION
- Allows to use already existing authentication (multiple authentication of the same type) when adding an app 
- when there is no available authentication, nothing changed

![chooseauthentication](https://user-images.githubusercontent.com/32869456/78238327-bd8d4280-74dc-11ea-944c-d78697897c2d.gif)

TODO:
- [x] change dontRequirePassword to better solution https://github.com/RedHatInsights/frontend-components/pull/428
- [x] remove authentication when changed app type
- [x] show which applications are using the authentications
- [x] tests