### PR TITLE
Show icons of source types in the table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6948,7 +6948,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6969,12 +6970,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6989,17 +6992,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7116,7 +7122,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7128,6 +7135,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7142,6 +7150,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7149,12 +7158,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7173,6 +7184,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7262,7 +7274,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7274,6 +7287,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7359,7 +7373,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7395,6 +7410,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7414,6 +7430,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7457,12 +7474,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/components/SourcesTable/SourcesTable.js
+++ b/src/components/SourcesTable/SourcesTable.js
@@ -32,6 +32,7 @@ const renderSources = (entities, columns, sourceTypes, appTypes) =>
 export const prepareColumnsCells = columns => columns.filter(column => column.title || column.hidden).map(column => ({
     title: column.title || '',
     value: column.value,
+    hidden: column.hidden,
     ...(column.sortable && { transforms: [sortable] })
 }));
 
@@ -165,7 +166,7 @@ const SourcesTable = () => {
             })}
             onSort={(_event, key, direction) => reduxDispatch(sortEntities(state.cells[key].value, direction))}
             sortBy={{
-                index: state.cells.map(cell => cell.value).indexOf(sortBy),
+                index: state.cells.map(cell => cell.hidden ? 'hidden' : cell.value).indexOf(sortBy),
                 direction: sortDirection
             }}
             rows={shownRows}

--- a/src/test/__mocks__/sourceTypesData.js
+++ b/src/test/__mocks__/sourceTypesData.js
@@ -177,6 +177,7 @@ export const sourceTypesData =
         },
         {
             created_at: '2019-04-05T17:54:38Z',
+            icon_url: '/tower.jpg',
             id: '3',
             name: 'ansible-tower',
             product_name: 'Ansible Tower',
@@ -268,6 +269,7 @@ export const sourceTypesData =
         },
         {
             created_at: '2019-07-16T13:52:12Z',
+            icon_url: 'ovirt.jpg',
             id: '5',
             name: 'ovirt',
             product_name: 'Red Hat Virtualization',
@@ -365,6 +367,7 @@ export const sourceTypesData =
             created_at: '2019-11-08T14:43:11Z',
             id: '9',
             name: 'satellite',
+            icon_url: 'satellite.jpg',
             product_name: 'Red Hat Satellite',
             schema: {
                 endpoint: {

--- a/src/test/components/sourcesTable/SourcesTable.test.js
+++ b/src/test/components/sourcesTable/SourcesTable.test.js
@@ -119,6 +119,7 @@ describe('SourcesTable', () => {
                 expect(wrapper.find(RowWrapper).first().props().className).toEqual(ROW_WRAPPER_CLASSNAME);
                 expect(wrapper.find(LongArrowAltDownIcon)).toHaveLength(1);
                 expect(wrapper.find(ArrowsAltVIcon)).toHaveLength(expectSortableColumns);
+                expect(wrapper.find('img')).toHaveLength(sourcesDataGraphQl.length);
                 done();
             });
         });

--- a/src/views/sourcesViewDefinition.js
+++ b/src/views/sourcesViewDefinition.js
@@ -8,7 +8,7 @@ export const sourcesColumns = (intl, notSortable = false) => ([{
     sortable: !notSortable
 }, {
     hidden: true,
-    value: 'source_type_icon',
+    value: 'source_type_id',
     formatter: 'sourceTypeIconFormatter'
 }, {
     title: intl.formatMessage({


### PR DESCRIPTION
Due to previous changes, icons in the table went missing :(

But they are back!

+ updated tests to not let it happen again