### PR TITLE
Make modals consistent

### DIFF
--- a/src/components/AddApplication/RemoveAppModal.js
+++ b/src/components/AddApplication/RemoveAppModal.js
@@ -6,10 +6,8 @@ import { useIntl, FormattedMessage } from 'react-intl';
 import { Text, TextVariants } from '@patternfly/react-core/dist/js/components/Text/Text';
 import { TextContent } from '@patternfly/react-core/dist/js/components/Text/TextContent';
 import { Button } from '@patternfly/react-core/dist/js/components/Button/Button';
-import { Split } from '@patternfly/react-core/dist/js/layouts/Split/Split';
-import { SplitItem } from '@patternfly/react-core/dist/js/layouts/Split/SplitItem';
-import { Stack } from '@patternfly/react-core/dist/js/layouts/Stack/Stack';
 import { Modal } from '@patternfly/react-core/dist/js/components/Modal/Modal';
+import { Title } from '@patternfly/react-core/dist/js/components/Title/Title';
 
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 
@@ -51,18 +49,32 @@ const RemoveAppModal = ({ app, onCancel }) => {
     return (
         <Modal
             className="ins-c-sources__dialog--warning"
-            title={`Remove ${app.display_name} application`}
             isOpen={true}
-            isSmall
             onClose={onCancel}
             isFooterLeftAligned
+            isSmall
+            title={
+                intl.formatMessage({
+                    id: 'sources.deleteAppTitle',
+                    defaultMessage: 'Remove application?',
+                })
+            }
+            header={
+                <Title size="2xl">
+                    <ExclamationTriangleIcon size="sm" className="ins-m-alert ins-c-source__delete-icon pf-u-mr-sm" />
+                    {intl.formatMessage({
+                        id: 'sources.deleteAppTitle',
+                        defaultMessage: 'Remove application?',
+                    })}
+                </Title>
+            }
             actions={[
                 <Button
                     id="deleteSubmit" key="submit" variant="danger" type="button" onClick={ onSubmit }
                 >
                     <FormattedMessage
                         id="sources.remove"
-                        defaultMessage="Remove"
+                        defaultMessage="Remove application"
                     />
                 </Button>,
                 <Button id="deleteCancel" key="cancel" variant="link" type="button" onClick={ onCancel }>
@@ -73,33 +85,26 @@ const RemoveAppModal = ({ app, onCancel }) => {
                 </Button>
             ]}
         >
-            <Split gutter="md">
-                <SplitItem><ExclamationTriangleIcon size="xl" className="ins-m-alert ins-c-source__delete-icon" /></SplitItem>
-                <SplitItem isFilled>
-                    <Stack gutter="md">
-                        <TextContent>
-                            <Text component={TextVariants.p}>
-                                <FormattedMessage
-                                    id="sources.deleteAppWarning"
-                                    defaultMessage={`Are you sure to remove { appName } from this source?`}
-                                    values={{
-                                        appName: app.display_name
-                                    }}
-                                />
-                            </Text>
-                            {dependentApps.length > 0 && <Text component={TextVariants.p}>
-                                <FormattedMessage
-                                    id="sources.deleteAppDetails"
-                                    defaultMessage={`This change will affect these applications: { apps }.`}
-                                    values={{
-                                        apps: dependentApps
-                                    }}
-                                />
-                            </Text>}
-                        </TextContent>
-                    </Stack>
-                </SplitItem>
-            </Split>
+            <TextContent>
+                <Text component={TextVariants.p}>
+                    <FormattedMessage
+                        id="sources.deleteAppWarning"
+                        defaultMessage={`Are you sure to remove { appName } from this source?`}
+                        values={{
+                            appName: <b>{app.display_name}</b>
+                        }}
+                    />
+                </Text>
+                {dependentApps.length > 0 && <Text component={TextVariants.p}>
+                    <FormattedMessage
+                        id="sources.deleteAppDetails"
+                        defaultMessage={`This change will affect these applications: { apps }.`}
+                        values={{
+                            apps: dependentApps
+                        }}
+                    />
+                </Text>}
+            </TextContent>
         </Modal>
     );
 };

--- a/src/components/SourceEditForm/parser/RemoveAuth.js
+++ b/src/components/SourceEditForm/parser/RemoveAuth.js
@@ -5,9 +5,7 @@ import { Modal } from '@patternfly/react-core/dist/js/components/Modal';
 import { Text, TextVariants } from '@patternfly/react-core/dist/js/components/Text/Text';
 import { TextContent } from '@patternfly/react-core/dist/js/components/Text/TextContent';
 import { Button } from '@patternfly/react-core/dist/js/components/Button/Button';
-import { Split } from '@patternfly/react-core/dist/js/layouts/Split/Split';
-import { SplitItem } from '@patternfly/react-core/dist/js/layouts/Split/SplitItem';
-import { Stack } from '@patternfly/react-core/dist/js/layouts/Stack/Stack';
+import { Title } from '@patternfly/react-core/dist/js/components/Title/Title';
 
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 
@@ -56,9 +54,13 @@ const RemoveAuth = ({ onClose, appNames, schemaAuth, auth }) => {
     if (hasAttachedApp) {
         body = (<FormattedMessage
             id="sources.removeAuthWarningApps"
-            defaultMessage="To remove this authentication you have to remove attached
+            defaultMessage="To remove {authname} authentication you have to remove attached
             {count, plural, one {application} other {applications}}: { appNames }."
-            values={{ appNames: appNames.join(', '), count: appNames.length }}
+            values={{
+                appNames: appNames.join(', '),
+                count: appNames.length,
+                authname: <b>{schemaAuth.name}</b>
+            }}
         />);
         actions = [<Button
             id="deleteCancel"
@@ -75,7 +77,8 @@ const RemoveAuth = ({ onClose, appNames, schemaAuth, auth }) => {
     } else {
         body = (<FormattedMessage
             id="sources.removeAuthWarning"
-            defaultMessage="Do you really want to remove this authentication?"
+            defaultMessage="Do you really want to remove {auth} authentication?"
+            values={{ auth: <b>{schemaAuth.name}</b> }}
         />);
         actions = [<Button
             id="deleteSubmit"
@@ -86,7 +89,7 @@ const RemoveAuth = ({ onClose, appNames, schemaAuth, auth }) => {
         >
             <FormattedMessage
                 id="sources.deleteConfirm"
-                defaultMessage="Delete this authentication"
+                defaultMessage="Remove authentication"
             />
         </Button>,
         <Button
@@ -98,7 +101,7 @@ const RemoveAuth = ({ onClose, appNames, schemaAuth, auth }) => {
         >
             <FormattedMessage
                 id="sources.deleteCancel"
-                defaultMessage="Do not delete this authentication"
+                defaultMessage="Cancel"
             />
         </Button>];
     }
@@ -111,25 +114,28 @@ const RemoveAuth = ({ onClose, appNames, schemaAuth, auth }) => {
             onClose={onClose}
             actions={actions}
             isSmall
-            title={intl.formatMessage(
-                { id: 'sources.deleteAuthTitle', defaultMessage: 'Delete { name }' },
-                { name: schemaAuth.name })
+            title={
+                intl.formatMessage({
+                    id: 'sources.deleteAuthTitle',
+                    defaultMessage: 'Remove authentication?',
+                })
+            }
+            header={
+                <Title size="2xl">
+                    <ExclamationTriangleIcon size="sm" className="ins-m-alert ins-c-source__delete-icon pf-u-mr-sm" />
+                    {intl.formatMessage({
+                        id: 'sources.deleteAppTitle',
+                        defaultMessage: 'Remove authentication?',
+                    })}
+                </Title>
             }
         >
-            <Split gutter="md">
-                <SplitItem>
-                    <ExclamationTriangleIcon size="xl" className="ins-m-alert ins-c-source__delete-icon" />
-                </SplitItem>
-                <SplitItem isFilled>
-                    <Stack gutter="md">
-                        <TextContent>
-                            <Text variant={TextVariants.p}>
-                                {body}
-                            </Text>
-                        </TextContent>
-                    </Stack>
-                </SplitItem>
-            </Split>
+
+            <TextContent>
+                <Text variant={TextVariants.p}>
+                    {body}
+                </Text>
+            </TextContent>
         </Modal>
     );
 };

--- a/src/test/components/addApplication/AddApplicationDescription.test.js
+++ b/src/test/components/addApplication/AddApplicationDescription.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { Text, Button, Title } from '@patternfly/react-core';
+import { Text, Button } from '@patternfly/react-core';
 import { Route } from 'react-router-dom';
 import { notificationsMiddleware } from '@redhat-cloud-services/frontend-components-notifications';
 import configureStore from 'redux-mock-store';
@@ -90,14 +90,10 @@ describe('AddApplicationDescription', () => {
             [replaceRouteId(routes.sourceManageApps.path, '406')]
         ));
 
-        const source = sourcesDataGraphQl.find((x) => x.id === '406');
-        const applicationType = applicationTypesData.data.find((x) => x.id === source.applications[0].application_type_id);
-
         wrapper.find(Button).first().simulate('click');
 
         wrapper.update();
         expect(wrapper.find(RemoveAppModal).length).toEqual(1);
-        expect(wrapper.find(Title).first().text().includes(applicationType.display_name)).toEqual(true);
     });
 
     it('show remove app modal and close it', () => {

--- a/src/test/components/addApplication/RemoveAppModal.test.js
+++ b/src/test/components/addApplication/RemoveAppModal.test.js
@@ -69,7 +69,7 @@ describe('RemoveAppModal', () => {
         expect(wrapper.find(Modal).length).toEqual(1);
         expect(wrapper.find(Button).length).toEqual(3); // modal cancel, remove, cancel
         expect(wrapper.find(FormattedMessage).length).toEqual(3);
-        expect(wrapper.find(Button).at(1).text()).toEqual('Remove');
+        expect(wrapper.find(Button).at(1).text()).toEqual('Remove application');
         expect(wrapper.find(Button).last().text()).toEqual('Cancel');
     });
 

--- a/src/test/components/sourceEditForm/parser/removeAuth.test.js
+++ b/src/test/components/sourceEditForm/parser/removeAuth.test.js
@@ -50,10 +50,10 @@ describe('RemoveAuth', () => {
             );
 
             expect(wrapper.find(Modal)).toHaveLength(1);
-            expect(wrapper.find(Modal).props().title).toEqual('Delete some name');
+            expect(wrapper.find(Modal).props().title).toEqual('Remove authentication?');
             expect(wrapper.find(ExclamationTriangleIcon)).toHaveLength(1);
             expect(wrapper.find(Button)).toHaveLength(2);
-            expect(wrapper.find(Text).text()).toEqual('To remove this authentication you have to remove attached application: Catalog.');
+            expect(wrapper.find(Text).text()).toEqual('To remove some name authentication you have to remove attached application: Catalog.');
         });
 
         it('renders correctly - multiple apps', () => {
@@ -71,10 +71,10 @@ describe('RemoveAuth', () => {
             );
 
             expect(wrapper.find(Modal)).toHaveLength(1);
-            expect(wrapper.find(Modal).props().title).toEqual('Delete some name');
+            expect(wrapper.find(Modal).props().title).toEqual('Remove authentication?');
             expect(wrapper.find(ExclamationTriangleIcon)).toHaveLength(1);
             expect(wrapper.find(Button)).toHaveLength(2);
-            expect(wrapper.find(Text).text()).toEqual('To remove this authentication you have to remove attached applications: Catalog, Cost Management.');
+            expect(wrapper.find(Text).text()).toEqual('To remove some name authentication you have to remove attached applications: Catalog, Cost Management.');
         });
 
         it('close on icon/button', () => {
@@ -113,10 +113,10 @@ describe('RemoveAuth', () => {
             );
 
             expect(wrapper.find(Modal)).toHaveLength(1);
-            expect(wrapper.find(Modal).props().title).toEqual('Delete some name');
+            expect(wrapper.find(Modal).props().title).toEqual('Remove authentication?');
             expect(wrapper.find(ExclamationTriangleIcon)).toHaveLength(1);
             expect(wrapper.find(Button)).toHaveLength(3);
-            expect(wrapper.find(Text).text()).toEqual('Do you really want to remove this authentication?');
+            expect(wrapper.find(Text).text()).toEqual('Do you really want to remove some name authentication?');
         });
 
         it('calls submit succesfuly', async () => {


### PR DESCRIPTION
Because #345 chaged the layout of the remove modal, I propose to propagate these changes to all modals to make everything look consistent.

**Remove app modal (Manage Apps > Remove application)**

Before

![image](https://user-images.githubusercontent.com/32869456/82043951-c1e87600-96ac-11ea-9f6c-2aded4d7a1f2.png)

After

![image](https://user-images.githubusercontent.com/32869456/82044201-33c0bf80-96ad-11ea-96e9-b8e4bfcf5ebe.png)


**Remove auth modal (Edit source with no applications > Trash icon for authentication)**

Before

![image](https://user-images.githubusercontent.com/32869456/82044085-fa884f80-96ac-11ea-814f-c96d7aedd938.png)


After

![image](https://user-images.githubusercontent.com/32869456/82043975-cca30b00-96ac-11ea-8714-c818bda10446.png)


