### PR TITLE
Remove modal in modal situations

### DIFF
--- a/src/components/AddApplication/AddApplicationDescription.js
+++ b/src/components/AddApplication/AddApplicationDescription.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
 
@@ -10,7 +11,7 @@ import RemoveAppModal from './RemoveAppModal';
 import ApplicationList from '../ApplicationsList/ApplicationList';
 import { useSource } from '../../hooks/useSource';
 
-const AddApplicationDescription = () => {
+const AddApplicationDescription = ({ container }) => {
     const [removingApp, setApplicationToRemove] = useState({});
 
     const sourceTypes = useSelector(({ sources }) => sources.sourceTypes);
@@ -23,7 +24,14 @@ const AddApplicationDescription = () => {
         <React.Fragment>
             {removingApp.id && <RemoveAppModal
                 app={removingApp}
-                onCancel={() => setApplicationToRemove({})}
+                onCancel={() => {
+                    if (container) {
+                        container.hidden = false;
+                    }
+
+                    return setApplicationToRemove({});
+                }}
+                container={container}
             />}
             <TextContent>
                 <Grid gutter="md">
@@ -74,6 +82,10 @@ const AddApplicationDescription = () => {
             </TextContent>
         </React.Fragment>
     );
+};
+
+AddApplicationDescription.propTypes = {
+    container: PropTypes.instanceOf(Element)
 };
 
 export default AddApplicationDescription;

--- a/src/components/AddApplication/AddApplicationSchema.js
+++ b/src/components/AddApplication/AddApplicationSchema.js
@@ -295,7 +295,8 @@ const fields = (
                             {
                                 component: 'description',
                                 name: 'description',
-                                Content: AddApplicationDescription
+                                Content: AddApplicationDescription,
+                                container
                             },
                             applicationSelection,
                             {

--- a/src/components/AddApplication/RemoveAppModal.js
+++ b/src/components/AddApplication/RemoveAppModal.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector, useDispatch } from 'react-redux';
 import { useIntl, FormattedMessage } from 'react-intl';
@@ -14,13 +14,19 @@ import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/excla
 import { removeApplication } from '../../redux/sources/actions';
 import { useSource } from '../../hooks/useSource';
 
-const RemoveAppModal = ({ app, onCancel }) => {
+const RemoveAppModal = ({ app, onCancel, container }) => {
     const intl = useIntl();
 
     const appTypes = useSelector(({ sources }) => sources.appTypes);
     const source = useSource();
 
     const dispatch = useDispatch();
+
+    useEffect(() => {
+        if (container) {
+            container.hidden = true;
+        }
+    }, []);
 
     const dependentApps = app.dependent_applications.map(appName => {
         const appType = appTypes.find(({ name }) => name === appName);
@@ -116,7 +122,8 @@ RemoveAppModal.propTypes = {
         dependent_applications: PropTypes.arrayOf(PropTypes.string),
         sourceAppsNames: PropTypes.arrayOf(PropTypes.string)
     }).isRequired,
-    onCancel: PropTypes.func.isRequired
+    onCancel: PropTypes.func.isRequired,
+    container: PropTypes.instanceOf(Element)
 };
 
 export default RemoveAppModal;

--- a/src/components/SourceEditForm/SourceEditModal.js
+++ b/src/components/SourceEditForm/SourceEditModal.js
@@ -18,6 +18,7 @@ import { useSource } from '../../hooks/useSource';
 import { useIsLoaded } from '../../hooks/useIsLoaded';
 import reducer, { initialState } from './reducer';
 import sourceEditContext from './sourceEditContext';
+import RemoveAuth from './parser/RemoveAuth';
 
 const SourceEditModal = () => {
     const [state, setState] = useReducer(reducer, initialState);
@@ -90,42 +91,45 @@ const SourceEditModal = () => {
     }
 
     return (
-        <Modal
-            title={intl.formatMessage({
-                id: 'sources.editSource',
-                defaultMessage: 'Edit source.'
-            })}
-            header={<Header />}
-            isOpen={true}
-            isLarge
-            onClose={returnToSources}
-        >
+        <React.Fragment>
             <sourceEditContext.Provider value={{ setState, source }}>
-                <SourcesFormRenderer
-                    onCancel={returnToSources}
-                    schema={schema}
-                    onSubmit={
-                        (values, formApi) =>
-                            onSubmit(values, formApi.getState().dirtyFields, dispatch, source, intl, history.push)
-                    }
-                    FormTemplate={(props) => (<FormTemplate
-                        {...props}
-                        formWrapperProps={{
-                            isHorizontal: true
-                        }}
-                        canReset
-                        disableSubmit={['submitting']}
-                        submitLabel={intl.formatMessage({
-                            id: 'sources.save',
-                            defaultMessage: 'Save'
-                        })}
-                    />)}
-                    clearedValue={null}
-                    onReset={() => setState({ type: 'reset' })}
-                    initialValues={initialValues}
-                />
+                {state.isAuthRemoving && <RemoveAuth {...state.isAuthRemoving}/>}
+                <Modal
+                    title={intl.formatMessage({
+                        id: 'sources.editSource',
+                        defaultMessage: 'Edit source.'
+                    })}
+                    header={<Header />}
+                    isOpen={!state.isAuthRemoving}
+                    isLarge
+                    onClose={returnToSources}
+                >
+                    <SourcesFormRenderer
+                        onCancel={returnToSources}
+                        schema={schema}
+                        onSubmit={
+                            (values, formApi) =>
+                                onSubmit(values, formApi.getState().dirtyFields, dispatch, source, intl, history.push)
+                        }
+                        FormTemplate={(props) => (<FormTemplate
+                            {...props}
+                            formWrapperProps={{
+                                isHorizontal: true
+                            }}
+                            canReset
+                            disableSubmit={['submitting']}
+                            submitLabel={intl.formatMessage({
+                                id: 'sources.save',
+                                defaultMessage: 'Save'
+                            })}
+                        />)}
+                        clearedValue={null}
+                        onReset={() => setState({ type: 'reset' })}
+                        initialValues={initialValues}
+                    />
+                </Modal>
             </sourceEditContext.Provider>
-        </Modal>
+        </React.Fragment>
     );
 };
 

--- a/src/components/SourceEditForm/parser/AuthenticationManagement.js
+++ b/src/components/SourceEditForm/parser/AuthenticationManagement.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 
 import { Button } from '@patternfly/react-core/dist/js/components/Button';
@@ -8,13 +8,11 @@ import { TextContent } from '@patternfly/react-core/dist/js/components/Text/Text
 import { Text, TextVariants } from '@patternfly/react-core/dist/js/components/Text/Text';
 import TrashIcon from '@patternfly/react-icons/dist/js/icons/trash-icon';
 
-import RemoveAuth from './RemoveAuth';
 import sourceEditContext from '../sourceEditContext';
 import { FormattedMessage } from 'react-intl';
 
 const AuthenticationManagement = ({ schemaAuth, auth, appTypes, isDeleting }) => {
-    const { source } = useContext(sourceEditContext);
-    const [isRemoving, setRemove] = useState(false);
+    const { source, setState } = useContext(sourceEditContext);
 
     const attachedAppTypes = source.source.applications.filter(
         ({ authentications }) => authentications.find(({ id }) => id === auth.id)
@@ -24,45 +22,46 @@ const AuthenticationManagement = ({ schemaAuth, auth, appTypes, isDeleting }) =>
         ({ application_type_id }) => application_type_id ? appTypes.find(({ id }) => id === application_type_id) : undefined
     ).filter(Boolean).map(app => app.display_name);
 
+    const setAuthRemoving = () => setState({
+        type: 'setAuthRemoving',
+        removingAuth: {
+            auth,
+            appNames,
+            schemaAuth
+        }
+    });
+
     return (
-        <React.Fragment>
-            {isRemoving && <RemoveAuth
-                auth={auth}
-                onClose={() => setRemove(false)}
-                appNames={ appNames }
-                schemaAuth={schemaAuth}/>
-            }
-            <GridItem sm={12}>
-                <Title size="xl">{schemaAuth.name}&nbsp;
-                    {!isDeleting &&
-                    <Button variant="plain" aria-label="Remove authentication" onClick={() => setRemove(!isRemoving)}>
+        <GridItem sm={12}>
+            <Title size="xl">{schemaAuth.name}&nbsp;
+                {!isDeleting &&
+                    <Button variant="plain" aria-label="Remove authentication" onClick={setAuthRemoving}>
                         <TrashIcon />
                     </Button>
-                    }
-                </Title>
-                <TextContent>
-                    <Text component={TextVariants.small} className="pf-u-mb-0">
-                        <FormattedMessage
-                            id="sources.removeAuthDescription"
-                            defaultMessage="id: {authid} { appNames}"
-                            values={{
-                                authid: auth.id,
-                                appNames: appNames.length > 0 ?
-                                    <FormattedMessage
-                                        id="sources.removeAuthWithApps"
-                                        defaultMessage="used by {appNames}"
-                                        values={{ appNames: appNames.join(', ') }}
-                                    />
-                                    : <FormattedMessage
-                                        id="sources.removeAuthNoApps"
-                                        defaultMessage="not used by any app"
-                                    />
-                            }}
-                        />&nbsp;
-                    </Text>
-                </TextContent>
-            </GridItem>
-        </React.Fragment>
+                }
+            </Title>
+            <TextContent>
+                <Text component={TextVariants.small} className="pf-u-mb-0">
+                    <FormattedMessage
+                        id="sources.removeAuthDescription"
+                        defaultMessage="id: {authid} { appNames}"
+                        values={{
+                            authid: auth.id,
+                            appNames: appNames.length > 0 ?
+                                <FormattedMessage
+                                    id="sources.removeAuthWithApps"
+                                    defaultMessage="used by {appNames}"
+                                    values={{ appNames: appNames.join(', ') }}
+                                />
+                                : <FormattedMessage
+                                    id="sources.removeAuthNoApps"
+                                    defaultMessage="not used by any app"
+                                />
+                        }}
+                    />
+                </Text>
+            </TextContent>
+        </GridItem>
     );
 };
 

--- a/src/components/SourceEditForm/parser/RemoveAuth.js
+++ b/src/components/SourceEditForm/parser/RemoveAuth.js
@@ -17,7 +17,7 @@ import { addMessage } from '../../../redux/sources/actions';
 import { doDeleteAuthentication } from '../../../api/entities';
 import { handleError } from '@redhat-cloud-services/frontend-components-sources';
 
-const RemoveAuth = ({ onClose, appNames, schemaAuth, auth }) => {
+const RemoveAuth = ({ appNames, schemaAuth, auth }) => {
     const hasAttachedApp = appNames.length > 0;
     let body;
     let actions;
@@ -26,6 +26,8 @@ const RemoveAuth = ({ onClose, appNames, schemaAuth, auth }) => {
     const intl = useIntl();
 
     const { setState } = useContext(sourceEditContext);
+
+    const onClose = () => setState({ type: 'closeAuthRemoving' });
 
     const onRemove = () => {
         setState({ type: 'removeAuthPending', authId: auth.id });
@@ -141,7 +143,6 @@ const RemoveAuth = ({ onClose, appNames, schemaAuth, auth }) => {
 };
 
 RemoveAuth.propTypes = {
-    onClose: PropTypes.func.isRequired,
     appNames: PropTypes.arrayOf(PropTypes.string),
     schemaAuth: PropTypes.shape({
         name: PropTypes.string.isRequired

--- a/src/components/SourceEditForm/reducer.js
+++ b/src/components/SourceEditForm/reducer.js
@@ -7,10 +7,11 @@ export const initialState = {
     source: undefined,
     initialValues: {},
     sourceType: undefined,
-    schema: undefined
+    schema: undefined,
+    isAuthRemoving: null
 };
 
-const reducer = (state, { type, source, name, sourceType, setEdit, appTypes, authId }) => {
+const reducer = (state, { type, source, name, sourceType, setEdit, appTypes, authId, removingAuth }) => {
     switch (type) {
         case 'createForm':
             return {
@@ -46,6 +47,7 @@ const reducer = (state, { type, source, name, sourceType, setEdit, appTypes, aut
         case 'removeAuthPending':
             return {
                 ...state,
+                isAuthRemoving: null,
                 source: {
                     ...state.source,
                     authentications: state.source.authentications.map((auth) => auth.id === authId ? {
@@ -70,6 +72,16 @@ const reducer = (state, { type, source, name, sourceType, setEdit, appTypes, aut
                     ...state.source,
                     authentications: state.source.authentications.filter((auth) => auth.id !== authId)
                 }
+            };
+        case 'setAuthRemoving':
+            return {
+                ...state,
+                isAuthRemoving: removingAuth
+            };
+        case 'closeAuthRemoving':
+            return {
+                ...state,
+                isAuthRemoving: null
             };
         default:
             return state;

--- a/src/test/components/addApplication/AddApplicationDescription.test.js
+++ b/src/test/components/addApplication/AddApplicationDescription.test.js
@@ -21,8 +21,12 @@ describe('AddApplicationDescription', () => {
     let initialEntry;
     const middlewares = [thunk, notificationsMiddleware()];
     let mockStore;
+    let initialProps;
 
     beforeEach(() => {
+        initialProps = {
+            container: document.createElement('div')
+        };
         initialEntry = [replaceRouteId(routes.sourceManageApps.path, '23')];
         mockStore = configureStore(middlewares);
         store = mockStore({
@@ -36,7 +40,7 @@ describe('AddApplicationDescription', () => {
 
     it('renders correctly', () => {
         const wrapper = mount(componentWrapperIntl(
-            <Route path={routes.sourceManageApps.path} render={ (...args) => <AddApplicationDescription { ...args }/> } />,
+            <Route path={routes.sourceManageApps.path} render={ (...args) => <AddApplicationDescription {...initialProps} { ...args }/> } />,
             store,
             initialEntry
         ));
@@ -49,11 +53,12 @@ describe('AddApplicationDescription', () => {
         expect(wrapper.find(ApplicationList).length).toEqual(0);
         expect(wrapper.find(FormattedMessage).last().text()).toEqual('No applications');
         expect(wrapper.find(Button).length).toEqual(0);
+        expect(initialProps.container.hidden).toEqual(false);
     });
 
     it('renders correctly with application', () => {
         const wrapper = mount(componentWrapperIntl(
-            <Route path={routes.sourceManageApps.path} render={ (...args) => <AddApplicationDescription { ...args }/> } />,
+            <Route path={routes.sourceManageApps.path} render={ (...args) => <AddApplicationDescription {...initialProps} { ...args }/> } />,
             store,
             [replaceRouteId(routes.sourceManageApps.path, '406')]
         ));
@@ -69,7 +74,7 @@ describe('AddApplicationDescription', () => {
 
     it('renders correctly with applications', () => {
         const wrapper = mount(componentWrapperIntl(
-            <Route path={routes.sourceManageApps.path} render={ (...args) => <AddApplicationDescription { ...args }/> } />,
+            <Route path={routes.sourceManageApps.path} render={ (...args) => <AddApplicationDescription {...initialProps} { ...args }/> } />,
             store,
             [replaceRouteId(routes.sourceManageApps.path, '408')]
         ));
@@ -83,22 +88,9 @@ describe('AddApplicationDescription', () => {
         expect(wrapper.find(Button).length).toEqual(3);
     });
 
-    it('show remove app modal', () => {
-        const wrapper = mount(componentWrapperIntl(
-            <Route path={routes.sourceManageApps.path} render={ (...args) => <AddApplicationDescription { ...args }/> } />,
-            store,
-            [replaceRouteId(routes.sourceManageApps.path, '406')]
-        ));
-
-        wrapper.find(Button).first().simulate('click');
-
-        wrapper.update();
-        expect(wrapper.find(RemoveAppModal).length).toEqual(1);
-    });
-
     it('show remove app modal and close it', () => {
         const wrapper = mount(componentWrapperIntl(
-            <Route path={routes.sourceManageApps.path} render={ (...args) => <AddApplicationDescription { ...args }/> } />,
+            <Route path={routes.sourceManageApps.path} render={ (...args) => <AddApplicationDescription {...initialProps} { ...args }/> } />,
             store,
             [replaceRouteId(routes.sourceManageApps.path, '406')]
         ));
@@ -108,10 +100,12 @@ describe('AddApplicationDescription', () => {
         wrapper.find(Button).first().simulate('click');
         wrapper.update();
         expect(wrapper.find(RemoveAppModal).length).toEqual(1);
+        expect(initialProps.container.hidden).toEqual(true);
 
         wrapper.find(Button).at(0).simulate('click');
         wrapper.update();
         expect(wrapper.find(RemoveAppModal).length).toEqual(0);
+        expect(initialProps.container.hidden).toEqual(false);
     });
 
     it('renders correctly when SourceType does not exist', () => {
@@ -125,7 +119,7 @@ describe('AddApplicationDescription', () => {
         });
 
         const wrapper = mount(componentWrapperIntl(
-            <Route path={routes.sourceManageApps.path} render={ (...args) => <AddApplicationDescription { ...args }/> } />,
+            <Route path={routes.sourceManageApps.path} render={ (...args) => <AddApplicationDescription {...initialProps} { ...args }/> } />,
             store,
             initialEntry
         ));

--- a/src/test/components/addApplication/RemoveAppModal.test.js
+++ b/src/test/components/addApplication/RemoveAppModal.test.js
@@ -4,6 +4,7 @@ import { Modal, Button, Text } from '@patternfly/react-core';
 import configureStore from 'redux-mock-store';
 import { FormattedMessage } from 'react-intl';
 import { Route } from 'react-router-dom';
+import { act } from 'react-dom/test-utils';
 
 import RemoveAppModal from '../../../components/AddApplication/RemoveAppModal';
 import * as actions from '../../../redux/sources/actions';
@@ -50,7 +51,8 @@ describe('RemoveAppModal', () => {
                 display_name: 'Catalog',
                 dependent_applications: []
             },
-            onCancel: spyOnCancel
+            onCancel: spyOnCancel,
+            container: document.createElement('div')
         };
         initialEntry = [replaceRouteId(routes.sourceManageApps.path, SOURCE_ID)];
     });
@@ -123,6 +125,23 @@ describe('RemoveAppModal', () => {
         expect(wrapper.find(Text)).toHaveLength(1);
         expect(wrapper.find(Text).last().html().includes(APP1_DISPLAY_NAME)).toEqual(false);
         expect(wrapper.find(Text).last().html().includes(APP2_DISPLAY_NAME)).toEqual(false);
+    });
+
+    it('hides container on render', async () => {
+        let wrapper;
+
+        expect(initialProps.container.hidden).toEqual(false);
+
+        await act(async () => {
+            wrapper = mount(componentWrapperIntl(
+                <Route path={routes.sourceManageApps.path} render={ (...args) =>  <RemoveAppModal {...args} {...initialProps}/> } />,
+                store,
+                initialEntry
+            ));
+        });
+        wrapper.update();
+
+        expect(initialProps.container.hidden).toEqual(true);
     });
 
     it('calls cancel', () => {

--- a/src/test/components/sourceEditForm/SourceEditModal.test.js
+++ b/src/test/components/sourceEditForm/SourceEditModal.test.js
@@ -326,6 +326,7 @@ describe('SourceEditModal', () => {
             expect(wrapper.find(AuthenticationManagement)).toHaveLength(1);
             expect(wrapper.find(Title).last().text()).toEqual('Token ');
             expect(wrapper.find(RemoveAuthPlaceholder)).toHaveLength(0);
+            expect(wrapper.find(Modal)).toHaveLength(1);
 
             await act(async() => {
                 const removeButton = wrapper.find(Button).at(1);
@@ -336,6 +337,9 @@ describe('SourceEditModal', () => {
             api.doDeleteAuthentication = jest.fn().mockImplementation(() => new Promise((res) => setTimeout(() => res('OK'), 1)));
 
             expect(api.doDeleteAuthentication).not.toHaveBeenCalled();
+            expect(wrapper.find(Modal)).toHaveLength(2);
+            expect(wrapper.find(Modal).first().props().isOpen).toEqual(true);
+            expect(wrapper.find(Modal).last().props().isOpen).toEqual(false);
 
             jest.useFakeTimers();
             await act(async() => {
@@ -345,6 +349,8 @@ describe('SourceEditModal', () => {
             wrapper.update();
             expect(api.doDeleteAuthentication).toHaveBeenCalledWith('authid');
             expect(wrapper.find(RemoveAuthPlaceholder)).toHaveLength(1);
+            expect(wrapper.find(Modal)).toHaveLength(1);
+            expect(wrapper.find(Modal).props().isOpen).toEqual(true);
 
             await act(async() => {
                 jest.advanceTimersByTime(1000);

--- a/src/test/components/sourceEditForm/parser/authenticationManagement.test.js
+++ b/src/test/components/sourceEditForm/parser/authenticationManagement.test.js
@@ -45,7 +45,7 @@ describe('AuhtenticationManagement', () => {
         expect(wrapper.find(RemoveAuth)).toHaveLength(0);
         expect(wrapper.find(Button)).toHaveLength(1);
         expect(wrapper.find(Title).text()).toEqual('some name ');
-        expect(wrapper.find(Text).text()).toEqual('id: authid not used by any app ');
+        expect(wrapper.find(Text).text()).toEqual('id: authid not used by any app');
     });
 
     it('renders correctly with assigned app', () => {
@@ -71,7 +71,7 @@ describe('AuhtenticationManagement', () => {
         expect(wrapper.find(RemoveAuth)).toHaveLength(0);
         expect(wrapper.find(Button)).toHaveLength(1);
         expect(wrapper.find(Title).text()).toEqual('some name ');
-        expect(wrapper.find(Text).text()).toEqual('id: authid used by Cost Management ');
+        expect(wrapper.find(Text).text()).toEqual('id: authid used by Cost Management');
     });
 
     it('renders correctly with assigned multiple apps', () => {
@@ -107,7 +107,7 @@ describe('AuhtenticationManagement', () => {
         expect(wrapper.find(RemoveAuth)).toHaveLength(0);
         expect(wrapper.find(Button)).toHaveLength(1);
         expect(wrapper.find(Title).text()).toEqual('some name ');
-        expect(wrapper.find(Text).text()).toEqual('id: authid used by Cost Management, Topological Inventory ');
+        expect(wrapper.find(Text).text()).toEqual('id: authid used by Cost Management, Topological Inventory');
     });
 
     it('renders deleting', () => {
@@ -127,12 +127,14 @@ describe('AuhtenticationManagement', () => {
         expect(wrapper.find(RemoveAuth)).toHaveLength(0);
         expect(wrapper.find(Button)).toHaveLength(0);
         expect(wrapper.find(Title).text()).toEqual('some name ');
-        expect(wrapper.find(Text).text()).toEqual('id: authid not used by any app ');
+        expect(wrapper.find(Text).text()).toEqual('id: authid not used by any app');
     });
 
     it('renders remove modal', () => {
+        const setState = jest.fn();
+
         const wrapper = mount(componentWrapperIntl(
-            <sourceEditContext.Provider value={{ source }}>
+            <sourceEditContext.Provider value={{ source, setState }}>
                 <AuthenticationManagement {...initialProps }/>
             </sourceEditContext.Provider>
         ),
@@ -142,11 +144,14 @@ describe('AuhtenticationManagement', () => {
         expect(wrapper.find(RemoveAuth)).toHaveLength(0);
         wrapper.find(Button).simulate('click');
         wrapper.update();
-        expect(wrapper.find(RemoveAuth)).toHaveLength(1);
-        expect(wrapper.find(RemoveAuth).props().auth).toEqual(initialProps.auth);
 
-        wrapper.find(Button).first().simulate('click');
-        wrapper.update();
-        expect(wrapper.find(RemoveAuth)).toHaveLength(0);
+        expect(setState).toHaveBeenCalledWith({
+            type: 'setAuthRemoving',
+            removingAuth: {
+                auth: initialProps.auth,
+                appNames: [],
+                schemaAuth: initialProps.schemaAuth
+            }
+        });
     });
 });

--- a/src/test/components/sourceEditForm/parser/removeAuth.test.js
+++ b/src/test/components/sourceEditForm/parser/removeAuth.test.js
@@ -15,18 +15,15 @@ import * as actions from '../../../../redux/sources/actions';
 describe('RemoveAuth', () => {
     let initialProps;
     let setState;
-    let onClose;
 
     const middlewares = [thunk, notificationsMiddleware()];
     let mockStore;
     let store;
 
     beforeEach(() => {
-        onClose = jest.fn();
         initialProps = {
             schemaAuth: { name: 'some name' },
             auth: { id: 'authid' },
-            onClose,
             appNames: []
         };
         setState = jest.fn();
@@ -91,14 +88,14 @@ describe('RemoveAuth', () => {
             store
             );
 
-            expect(onClose).not.toHaveBeenCalled();
+            expect(setState).not.toHaveBeenCalled();
 
             wrapper.find(Button).first().simulate('click');
-            expect(onClose).toHaveBeenCalled();
-            onClose.mockClear();
+            expect(setState).toHaveBeenCalledWith({ type: 'closeAuthRemoving' });
+            setState.mockClear();
 
             wrapper.find(Button).last().simulate('click');
-            expect(onClose).toHaveBeenCalled();
+            expect(setState).toHaveBeenCalledWith({ type: 'closeAuthRemoving' });
         });
     });
 
@@ -181,14 +178,14 @@ describe('RemoveAuth', () => {
             store
             );
 
-            expect(onClose).not.toHaveBeenCalled();
+            expect(setState).not.toHaveBeenCalled();
 
             wrapper.find(Button).first().simulate('click');
-            expect(onClose).toHaveBeenCalled();
-            onClose.mockClear();
+            expect(setState).toHaveBeenCalledWith({ type: 'closeAuthRemoving' });
+            setState.mockClear();
 
             wrapper.find(Button).last().simulate('click');
-            expect(onClose).toHaveBeenCalled();
+            expect(setState).toHaveBeenCalledWith({ type: 'closeAuthRemoving' });
         });
     });
 });


### PR DESCRIPTION
Add wizard changes introduced 'no modal in modal' policy

- [x] Manage applications > Remove application
- [x] Edit source > Remove authentication

**Auth removal**

Before

![removeauthbefore](https://user-images.githubusercontent.com/32869456/83129899-c9ad0f00-a0dd-11ea-86eb-cd13f43df8f6.gif)

After

![removeauthafter](https://user-images.githubusercontent.com/32869456/83129908-cca7ff80-a0dd-11ea-8892-77a4cee5f5e9.gif)

**App remove**

Before

![removeappbefore](https://user-images.githubusercontent.com/32869456/83129920-d03b8680-a0dd-11ea-900f-e41d7a783f48.gif)

After

![removeappmodalafter](https://user-images.githubusercontent.com/32869456/83129941-d6316780-a0dd-11ea-97fd-73b273be3f0a.gif)