### PR TITLE
Refactor to remove update errors, refactor editForm to use context

### DIFF
--- a/src/components/EditField/EditFieldWrapper.js
+++ b/src/components/EditField/EditFieldWrapper.js
@@ -1,0 +1,34 @@
+import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
+
+import RendererContext from '@data-driven-forms/react-form-renderer/dist/cjs/renderer-context';
+import componentTypes from '@data-driven-forms/react-form-renderer/dist/cjs/component-types';
+
+import sourceEditContext from '../SourceEditForm/sourceEditContext';
+import EditField from './EditField';
+
+export const NOT_CHANGING_COMPONENTS = [componentTypes.CHECKBOX, componentTypes.SWITCH];
+
+const EditFieldWrapper = ({ originalComponent, isEditable = true, ...props }) => {
+    let Component = EditField;
+    let clearProps = {};
+
+    const { componentMapper } = useContext(RendererContext);
+    const { editing } = useContext(sourceEditContext);
+
+    if (editing[props.name] || NOT_CHANGING_COMPONENTS.includes(originalComponent)) {
+        Component = componentMapper[originalComponent];
+    } else if (isEditable) {
+        clearProps = { isEditable: true };
+    }
+
+    return <Component {...props} {...clearProps}/>;
+};
+
+EditFieldWrapper.propTypes = {
+    originalComponent: PropTypes.string,
+    name: PropTypes.string,
+    isEditable: PropTypes.bool
+};
+
+export default EditFieldWrapper;

--- a/src/components/RedirectNoId/RedirectNoId.js
+++ b/src/components/RedirectNoId/RedirectNoId.js
@@ -23,23 +23,23 @@ const RedirectNoId = () => {
         if (loaded && appTypesLoaded && sourceTypesLoaded) {
             doLoadSource(id).then(({ sources: [source] }) => dispatch(addHiddenSource(source)))
             .then(() => {
+                dispatch(addMessage(
+                    intl.formatMessage({
+                        id: 'sources.sourceNotFoundTitle',
+                        defaultMessage: 'Requested source was not found'
+                    }),
+                    'danger',
+                    intl.formatMessage({
+                        id: 'sources.sourceNotFoundTitleDescription',
+                        defaultMessage: 'Source with { id } was not found. Try it again later.'
+                    }, { id })
+                ));
                 setIsApplicationLoaded(true);
             });
         }
     }, [loaded, appTypesLoaded, sourceTypesLoaded]);
 
     if (applicationIsLoaded) {
-        dispatch(addMessage(
-            intl.formatMessage({
-                id: 'sources.sourceNotFoundTitle',
-                defaultMessage: 'Requested source was not found'
-            }),
-            'danger',
-            intl.formatMessage({
-                id: 'sources.sourceNotFoundTitleDescription',
-                defaultMessage: 'Source with { id } was not found. Try it again later.'
-            }, { id })
-        ));
         return <Redirect to={routes.sources.path} />;
     }
 

--- a/src/components/RedirectNotAdmin/RedirectNotAdmin.js
+++ b/src/components/RedirectNotAdmin/RedirectNotAdmin.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { Redirect } from 'react-router-dom';
 import { useIntl } from 'react-intl';
@@ -14,21 +14,26 @@ const RedirectNotAdmin = () => {
 
     const dispatch = useDispatch();
 
-    if (isOrgAdmin === false) {
-        const title = intl.formatMessage({
-            id: 'sources.insufficietnPerms',
-            defaultMessage: 'Insufficient permissions'
-        });
-        const description = intl.formatMessage({
-            id: 'sources.notAdminButton',
-            defaultMessage: 'You do not have permission to perform this action.'
-        });
+    useEffect(() => {
+        if (isOrgAdmin === false) {
+            const title = intl.formatMessage({
+                id: 'sources.insufficietnPerms',
+                defaultMessage: 'Insufficient permissions'
+            });
+            const description = intl.formatMessage({
+                id: 'sources.notAdminButton',
+                defaultMessage: 'You do not have permission to perform this action.'
+            });
 
-        dispatch(addMessage(
-            title,
-            'danger',
-            description
-        ));
+            dispatch(addMessage(
+                title,
+                'danger',
+                description
+            ));
+        }
+    }, []);
+
+    if (isOrgAdmin === false) {
         return <Redirect to={routes.sources.path} />;
     }
 

--- a/src/components/SourceEditForm/SourceEditModal.js
+++ b/src/components/SourceEditForm/SourceEditModal.js
@@ -51,21 +51,13 @@ const SourceEditModal = () => {
         }
     }, [sourceRedux, isLoaded]);
 
-    const setEdit = (name) => setState({ type: 'setEdit', name });
-
     useEffect(() => {
         if (source && appTypesLoaded && sourceTypesLoaded) {
             const sourceType = sourceTypes.find(({ id }) => id === source.source.source_type_id);
 
-            setState({ type: 'createForm', sourceType, source, setEdit, appTypes });
+            setState({ type: 'createForm', sourceType, source, appTypes });
         }
     }, [appTypesLoaded, source, sourceTypesLoaded]);
-
-    useEffect(() => {
-        if (source && !loading) {
-            setState({ type: 'refreshSchema', setEdit, appTypes });
-        }
-    }, [editing]);
 
     const isLoading = !appTypesLoaded || !sourceTypesLoaded || loading;
 
@@ -92,7 +84,7 @@ const SourceEditModal = () => {
 
     return (
         <React.Fragment>
-            <sourceEditContext.Provider value={{ setState, source }}>
+            <sourceEditContext.Provider value={{ setState, source, editing }}>
                 {state.isAuthRemoving && <RemoveAuth {...state.isAuthRemoving}/>}
                 <Modal
                     title={intl.formatMessage({

--- a/src/components/SourceEditForm/parser/application.js
+++ b/src/components/SourceEditForm/parser/application.js
@@ -37,7 +37,7 @@ export const getEnhancedCMField = (sourceType, name, authenticationsTypes) => {
     return field ? field : {};
 };
 
-export const appendClusterIdentifier = (editing, setEdit, sourceType) =>
+export const appendClusterIdentifier = (sourceType) =>
     sourceType.name === 'openshift' ? [{
         name: 'source.source_ref',
         label: <FormattedMessage
@@ -45,16 +45,14 @@ export const appendClusterIdentifier = (editing, setEdit, sourceType) =>
             defaultMessage="Cluster identifier"
         />,
         isRequired: true,
-        ...(editing['source.source_ref'] ? {} : { setEdit }),
         validate: [{ type: validatorTypes.REQUIRED }],
-        component: editing['source.source_ref'] ? componentTypes.TEXT_FIELD : EDIT_FIELD_NAME
+        originalComponent: componentTypes.TEXT_FIELD,
+        component: EDIT_FIELD_NAME
     }] : [];
 
 export const costManagementFields = (
     applications = [],
     sourceType,
-    editing,
-    setEdit,
     appTypes,
     source
 ) => {
@@ -84,8 +82,8 @@ export const costManagementFields = (
         title: costManagementApp.display_name,
         name: costManagementApp.display_name,
         fields: [
-            ...modifyFields(enhandcedFields, editing, setEdit),
-            ...appendClusterIdentifier(editing, setEdit, sourceType)
+            ...modifyFields(enhandcedFields),
+            ...appendClusterIdentifier(sourceType)
         ]
     });
 };
@@ -93,16 +91,12 @@ export const costManagementFields = (
 export const applicationsFields = (
     applications,
     sourceType,
-    editing,
-    setEdit,
     appTypes,
     source
 ) => ([
     costManagementFields(
         applications,
         sourceType,
-        editing,
-        setEdit,
         appTypes,
         source
     )

--- a/src/components/SourceEditForm/parser/authentication.js
+++ b/src/components/SourceEditForm/parser/authentication.js
@@ -4,10 +4,10 @@ import { componentTypes, validatorTypes } from '@data-driven-forms/react-form-re
 import { hardcodedSchemas } from '@redhat-cloud-services/frontend-components-sources';
 import { FormattedMessage } from 'react-intl';
 
-import { EDIT_FIELD_NAME } from '../../EditField/EditField';
 import { unsupportedAuthTypeField } from './unsupportedAuthType';
 import AuthenticationManagement from './AuthenticationManagement';
 import RemoveAuthPlaceholder from './RemoveAuthPlaceholder';
+import { modifyFields } from './helpers';
 
 export const createAuthFieldName = (fieldName, id) => `authentications.a${id}.${fieldName.replace('authentication.', '')}`;
 
@@ -22,19 +22,13 @@ export const getEnhancedAuthField = (sourceType, authtype, name) =>
 export const getAdditionalAuthSteps = (sourceType, authtype) =>
     get(hardcodedSchemas, [sourceType, 'authentication', authtype, 'generic', 'includeStepKeyFields'], []);
 
-export const modifyAuthSchemas = (fields, id, editing, setEdit) => fields.map((field) => {
+export const modifyAuthSchemas = (fields, id) => fields.map((field) => {
     const editedName = field.name.startsWith('authentication') ? createAuthFieldName(field.name, id) : field.name;
-    const isEditing = editing[editedName];
 
     const finalField = ({
         ...field,
         name: editedName,
-        component: isEditing ? field.component : EDIT_FIELD_NAME
     });
-
-    if (!isEditing) {
-        finalField.setEdit = setEdit;
-    }
 
     const isPassword = getLastPartOfName(finalField.name) === 'password';
 
@@ -53,7 +47,7 @@ export const modifyAuthSchemas = (fields, id, editing, setEdit) => fields.map((f
     return finalField;
 });
 
-export const authenticationFields = (authentications, sourceType, editing, setEdit, appTypes) => {
+export const authenticationFields = (authentications, sourceType, appTypes) => {
     if (!authentications || authentications.length === 0 || !sourceType.schema || !sourceType.schema.authentication) {
         return [];
     }
@@ -91,7 +85,7 @@ export const authenticationFields = (authentications, sourceType, editing, setEd
                     component: 'description',
                     name: `${auth.id}-remove-spinner`,
                     Content: RemoveAuthPlaceholder
-                } : modifyAuthSchemas(enhancedFields, auth.id, editing, setEdit)
+                } : modifyFields(modifyAuthSchemas(enhancedFields, auth.id))
             ]
         });
     });

--- a/src/components/SourceEditForm/parser/endpoint.js
+++ b/src/components/SourceEditForm/parser/endpoint.js
@@ -8,7 +8,7 @@ import { modifyFields } from './helpers';
 export const getEnhancedEndpointField = (sourceType, name) =>
     get(hardcodedSchemas, [sourceType, 'endpoint', name], {});
 
-export const endpointFields = (sourceType, editing, setEdit) => {
+export const endpointFields = (sourceType) => {
     if (!sourceType.schema || !sourceType.schema.endpoint || sourceType.schema.endpoint.hidden) {
         return undefined;
     }
@@ -27,6 +27,6 @@ export const endpointFields = (sourceType, editing, setEdit) => {
             defaultMessage="Endpoint"
         />,
         name: 'endpoint',
-        fields: modifyFields(enhancedFields, editing, setEdit)
+        fields: modifyFields(enhancedFields)
     });
 };

--- a/src/components/SourceEditForm/parser/genericInfo.js
+++ b/src/components/SourceEditForm/parser/genericInfo.js
@@ -6,15 +6,15 @@ import validatorTypes from '@data-driven-forms/react-form-renderer/dist/cjs/vali
 
 import { EDIT_FIELD_NAME } from '../../EditField/EditField';
 
-export const genericInfo = (editing, setEdit, sourceId) => ([
+export const genericInfo = (sourceId) => ([
     {
         name: 'source.name',
         label: <FormattedMessage
             id="sources.sourceName"
             defaultMessage="Source name"
         />,
-        component: editing['source.name'] ? componentTypes.TEXT_FIELD : EDIT_FIELD_NAME,
-        ...(editing['source.name'] ? {} : { setEdit }),
+        originalComponent: componentTypes.TEXT_FIELD,
+        component: EDIT_FIELD_NAME,
         validate: [
             (value) => asyncValidator(value, sourceId),
             { type: validatorTypes.REQUIRED }
@@ -27,6 +27,7 @@ export const genericInfo = (editing, setEdit, sourceId) => ([
             defaultMessage="Source type"
         />,
         isReadOnly: true,
-        component: EDIT_FIELD_NAME
+        component: EDIT_FIELD_NAME,
+        isEditable: false
     }
 ]);

--- a/src/components/SourceEditForm/parser/helpers.js
+++ b/src/components/SourceEditForm/parser/helpers.js
@@ -1,19 +1,7 @@
 import { EDIT_FIELD_NAME } from '../../EditField/EditField';
-import { componentTypes } from '@data-driven-forms/react-form-renderer';
 
-export const NOT_CHANGING_COMPONENTS = [componentTypes.CHECKBOX, componentTypes.SWITCH];
-
-export const modifyFields = (fields, editing, setEdit) => fields.map((field) => {
-    const isEditing = editing[field.name];
-
-    const finalField = ({
-        ...field,
-        component: isEditing || NOT_CHANGING_COMPONENTS.includes(field.component)  ? field.component : EDIT_FIELD_NAME
-    });
-
-    if (!isEditing && !NOT_CHANGING_COMPONENTS.includes(field.component)) {
-        finalField.setEdit = setEdit;
-    }
-
-    return finalField;
-});
+export const modifyFields = (fields) => fields.map((field) => ({
+    ...field,
+    originalComponent: field.component,
+    component: EDIT_FIELD_NAME
+}));

--- a/src/components/SourceEditForm/parser/parseSourceToSchema.js
+++ b/src/components/SourceEditForm/parser/parseSourceToSchema.js
@@ -3,11 +3,11 @@ import { authenticationFields } from './authentication';
 import { endpointFields } from './endpoint';
 import { applicationsFields } from './application';
 
-export const parseSourceToSchema = (source, editing, setEdit, sourceType, appTypes) => ({
+export const parseSourceToSchema = (source, sourceType, appTypes) => ({
     fields: [
-        ...genericInfo(editing, setEdit, source.source.id),
-        ...authenticationFields(source.authentications, sourceType, editing, setEdit, appTypes),
-        ...applicationsFields(source.applications, sourceType, editing, setEdit, appTypes, source),
-        source.endpoints && source.endpoints.length > 0 ? endpointFields(sourceType, editing, setEdit) : false
+        ...genericInfo(source.source.id),
+        ...authenticationFields(source.authentications, sourceType, appTypes),
+        ...applicationsFields(source.applications, sourceType, appTypes, source),
+        source.endpoints && source.endpoints.length > 0 ? endpointFields(sourceType) : false
     ].filter(Boolean)
 });

--- a/src/components/SourceEditForm/reducer.js
+++ b/src/components/SourceEditForm/reducer.js
@@ -11,20 +11,15 @@ export const initialState = {
     isAuthRemoving: null
 };
 
-const reducer = (state, { type, source, name, sourceType, setEdit, appTypes, authId, removingAuth }) => {
+const reducer = (state, { type, source, name, sourceType, appTypes, authId, removingAuth }) => {
     switch (type) {
         case 'createForm':
             return {
                 ...state,
                 sourceType,
                 initialValues: prepareInitialValues(state.source, sourceType.product_name),
-                schema: parseSourceToSchema(state.source, state.editing, setEdit, sourceType, appTypes),
+                schema: parseSourceToSchema(state.source, sourceType, appTypes),
                 loading: false
-            };
-        case 'refreshSchema':
-            return {
-                ...state,
-                schema: parseSourceToSchema(state.source, state.editing, setEdit, state.sourceType, appTypes)
             };
         case 'setSource':
             return {

--- a/src/test/components/editField/editField.test.js
+++ b/src/test/components/editField/editField.test.js
@@ -1,13 +1,15 @@
 import { FormGroup } from '@patternfly/react-core';
 import { PencilAltIcon } from '@patternfly/react-icons';
 import FormTemplate from '@data-driven-forms/pf4-component-mapper/dist/cjs/form-template';
-import FormRenderer from '@data-driven-forms/react-form-renderer/dist/cjs/form-renderer';
-import validatorTypes from '@data-driven-forms/react-form-renderer/dist/cjs/validator-types';
+import FormRendererOriginal from '@data-driven-forms/react-form-renderer/dist/cjs/form-renderer';
 
 import EditField, { EDIT_FIELD_NAME } from '../../../components/EditField/EditField';
+import sourceEditContext from '../../../components/SourceEditForm/sourceEditContext';
 
 describe('Edit field', () => {
     let initialProps;
+    let setState;
+    let FormRenderer;
 
     const NAME = 'name1234';
     const VALUE = 'password';
@@ -30,6 +32,13 @@ describe('Edit field', () => {
                 }]
             }
         };
+
+        setState = jest.fn();
+
+        // eslint-disable-next-line react/display-name
+        FormRenderer = (props) => (<sourceEditContext.Provider value={{ setState }}>
+            <FormRendererOriginal {...props} />
+        </sourceEditContext.Provider>);
     });
 
     it('renders correctly', () => {
@@ -38,28 +47,6 @@ describe('Edit field', () => {
         expect(wrapper.find(FormGroup)).toHaveLength(1);
         expect(wrapper.find('span')).toHaveLength(1);
         expect(wrapper.find(PencilAltIcon)).toHaveLength(0);
-    });
-
-    it('renders correctly with error', () => {
-        const ERROR = 'errror';
-
-        initialProps = {
-            ...initialProps,
-            schema: {
-                fields: [{
-                    ...initialProps.schema.fields[0],
-                    validate: [{ type: validatorTypes.REQUIRED, message: ERROR }]
-                }]
-            }
-        };
-
-        const wrapper = mount(<FormRenderer {...initialProps} />);
-
-        wrapper.find('form').simulate('submit');
-        wrapper.update();
-
-        expect(wrapper.find(FormGroup).props().isValid).toEqual(false);
-        expect(wrapper.find(FormGroup).props().helperTextInvalid).toEqual(ERROR);
     });
 
     it('renders correctly with value', () => {
@@ -76,32 +63,6 @@ describe('Edit field', () => {
         expect(wrapper.find(PencilAltIcon)).toHaveLength(0);
     });
 
-    it('renders correctly true', () => {
-        initialProps = {
-            ...initialProps,
-            initialValues: {
-                [NAME]: true
-            }
-        };
-
-        const wrapper = mount(<FormRenderer {...initialProps} />);
-
-        expect(wrapper.find('span').text()).toEqual('True');
-    });
-
-    it('renders correctly false', () => {
-        initialProps = {
-            ...initialProps,
-            initialValues: {
-                [NAME]: false
-            }
-        };
-
-        const wrapper = mount(<FormRenderer {...initialProps} />);
-
-        expect(wrapper.find('span').text()).toEqual('False');
-    });
-
     it('renders empty - Click to add', () => {
         initialProps = {
             ...initialProps,
@@ -111,7 +72,7 @@ describe('Edit field', () => {
             schema: {
                 fields: [{
                     ...initialProps.schema.fields[0],
-                    setEdit: jest.fn()
+                    isEditable: true
                 }]
             }
         };
@@ -130,8 +91,8 @@ describe('Edit field', () => {
             schema: {
                 fields: [{
                     ...initialProps.schema.fields[0],
-                    setEdit: jest.fn(),
-                    type: 'password'
+                    type: 'password',
+                    isEditable: true
                 }]
             }
         };
@@ -160,7 +121,7 @@ describe('Edit field', () => {
             schema: {
                 fields: [{
                     ...initialProps.schema.fields[0],
-                    setEdit: jest.fn()
+                    isEditable: true
                 }]
             }
         };
@@ -171,14 +132,12 @@ describe('Edit field', () => {
     });
 
     it('calls setEdit with field name', () => {
-        const setEdit = jest.fn();
-
         initialProps = {
             ...initialProps,
             schema: {
                 fields: [{
                     ...initialProps.schema.fields[0],
-                    setEdit,
+                    isEditable: true
                 }]
             }
         };
@@ -187,18 +146,16 @@ describe('Edit field', () => {
 
         wrapper.find(FormGroup).simulate('click');
 
-        expect(setEdit).toHaveBeenCalledWith(NAME);
+        expect(setState).toHaveBeenCalledWith({ type: 'setEdit', name: NAME });
     });
 
     it('calls setEdit with field name by pressing space', () => {
-        const setEdit = jest.fn();
-
         initialProps = {
             ...initialProps,
             schema: {
                 fields: [{
                     ...initialProps.schema.fields[0],
-                    setEdit,
+                    isEditable: true,
                 }]
             }
         };
@@ -212,19 +169,17 @@ describe('Edit field', () => {
 
         wrapper.find(FormGroup).simulate('keypress', event);
 
-        expect(setEdit).toHaveBeenCalledWith(NAME);
+        expect(setState).toHaveBeenCalledWith({ type: 'setEdit', name: NAME });
         expect(event.preventDefault).toHaveBeenCalled();
     });
 
     it('do not call setEdit with field name by pressing different key than space', () => {
-        const setEdit = jest.fn();
-
         initialProps = {
             ...initialProps,
             schema: {
                 fields: [{
                     ...initialProps.schema.fields[0],
-                    setEdit,
+                    isEditable: true,
                 }]
             }
         };
@@ -238,7 +193,7 @@ describe('Edit field', () => {
 
         wrapper.find(FormGroup).simulate('keypress', event);
 
-        expect(setEdit).not.toHaveBeenCalled();
+        expect(setState).not.toHaveBeenCalled();
         expect(event.preventDefault).not.toHaveBeenCalled();
     });
 
@@ -248,6 +203,7 @@ describe('Edit field', () => {
             schema: {
                 fields: [{
                     ...initialProps.schema.fields[0],
+                    isEditable: false
                 }]
             }
         };

--- a/src/test/components/editField/editFieldWrapper.test.js
+++ b/src/test/components/editField/editFieldWrapper.test.js
@@ -1,0 +1,111 @@
+import FormRenderer from '@data-driven-forms/react-form-renderer/dist/cjs/form-renderer';
+import FormTemplate from '@data-driven-forms/pf4-component-mapper/dist/cjs/form-template';
+import componentTypes from '@data-driven-forms/react-form-renderer/dist/cjs/component-types';
+import componentMapper from '@data-driven-forms/pf4-component-mapper/dist/cjs/component-mapper';
+
+import sourceEditContext from '../../../components/SourceEditForm/sourceEditContext';
+import EditFieldWrapper from '../../../components/EditField/EditFieldWrapper';
+import EditField, { EDIT_FIELD_NAME } from '../../../components/EditField/EditField';
+
+describe('Edit field wrapper', () => {
+    const ComponentWrapper = ({ editing = {}, ...props }) => (<sourceEditContext.Provider value={{ editing, setState: jest.fn() }}>
+        <FormRenderer {...props} />
+    </sourceEditContext.Provider>);
+
+    let initialProps;
+    let schema;
+
+    beforeEach(() => {
+        initialProps = {
+            onSubmit: jest.fn(),
+            FormTemplate,
+            componentMapper: {
+                ...componentMapper,
+                [EDIT_FIELD_NAME]: EditFieldWrapper
+            }
+        };
+    });
+
+    it('renders edit component', () => {
+        schema = {
+            fields: [{
+                component: EDIT_FIELD_NAME,
+                originalComponent: componentTypes.TEXT_FIELD,
+                name: 'text-field',
+                label: 'text-field-label'
+            }]
+        };
+
+        const wrapper = mount(<ComponentWrapper {...initialProps} schema={schema} />);
+
+        expect(wrapper.find(EditField)).toHaveLength(1);
+        expect(wrapper.find(EditField).props().isEditable).toEqual(true);
+        expect(wrapper.find(componentMapper[componentTypes.TEXT_FIELD])).toHaveLength(0);
+    });
+
+    it('renders uneditable component', () => {
+        schema = {
+            fields: [{
+                component: EDIT_FIELD_NAME,
+                originalComponent: componentTypes.TEXT_FIELD,
+                name: 'text-field',
+                label: 'text-field-label',
+                isEditable: false
+            }]
+        };
+
+        const wrapper = mount(<ComponentWrapper {...initialProps} schema={schema} />);
+
+        expect(wrapper.find(EditField)).toHaveLength(1);
+        expect(wrapper.find(EditField).props().isEditable).toEqual(undefined);
+        expect(wrapper.find(componentMapper[componentTypes.TEXT_FIELD])).toHaveLength(0);
+    });
+
+    it('renders switch component', () => {
+        schema = {
+            fields: [{
+                component: EDIT_FIELD_NAME,
+                originalComponent: componentTypes.SWITCH,
+                name: 'switch',
+                label: 'switch',
+            }]
+        };
+
+        const wrapper = mount(<ComponentWrapper {...initialProps} schema={schema} />);
+
+        expect(wrapper.find(EditField)).toHaveLength(0);
+        expect(wrapper.find(componentMapper[componentTypes.SWITCH])).toHaveLength(1);
+    });
+
+    it('renders checkbox component', () => {
+        schema = {
+            fields: [{
+                component: EDIT_FIELD_NAME,
+                originalComponent: componentTypes.CHECKBOX,
+                name: 'checkbox',
+                label: 'checkbox',
+            }]
+        };
+
+        const wrapper = mount(<ComponentWrapper {...initialProps} schema={schema} />);
+
+        expect(wrapper.find(EditField)).toHaveLength(0);
+        expect(wrapper.find(componentMapper[componentTypes.CHECKBOX])).toHaveLength(1);
+    });
+
+    it('renders component when editing', () => {
+        schema = {
+            fields: [{
+                component: EDIT_FIELD_NAME,
+                originalComponent: componentTypes.TEXT_FIELD,
+                name: 'text-field',
+                label: 'text-field-label',
+            }]
+        };
+
+        const wrapper = mount(<ComponentWrapper {...initialProps} schema={schema} editing={{ 'text-field': true }}/>);
+
+        expect(wrapper.find(EditField)).toHaveLength(0);
+        expect(wrapper.find(componentMapper[componentTypes.TEXT_FIELD])).toHaveLength(1);
+    });
+});

--- a/src/test/components/sourceEditForm/parser/application.test.js
+++ b/src/test/components/sourceEditForm/parser/application.test.js
@@ -41,15 +41,11 @@ describe('application edit form parser', () => {
         const FIELDS = [...BILLING_SOURCE_FIELDS, { name: 'field2' }];
 
         let APPLICATIONS;
-        let EDITING;
-        let SET_EDIT;
         let SOURCE_TYPE;
         let SOURCE;
 
         beforeEach(() => {
             APPLICATIONS = [{ application_type_id: COSTMANAGEMENT_APP.id }];
-            EDITING = {};
-            SET_EDIT = jest.fn();
             SOURCE_TYPE = {
                 name: 'aws',
                 schema: {
@@ -63,10 +59,6 @@ describe('application edit form parser', () => {
             SOURCE = { authentications: [{ authtype: 'arn' }] };
         });
 
-        afterEach(() => {
-            SET_EDIT.mockReset();
-        });
-
         it('return undefined if cm app does not exist', () => {
             const EXPECTED_RESULT = undefined;
 
@@ -74,8 +66,6 @@ describe('application edit form parser', () => {
 
             const result = costManagementFields(
                 APPLICATIONS,
-                EDITING,
-                SET_EDIT,
                 SOURCE_TYPE,
                 APPLICATION_TYPES_WITHOUT_CM,
                 SOURCE,
@@ -91,8 +81,6 @@ describe('application edit form parser', () => {
 
             const result = costManagementFields(
                 UNDEF_APPLICATIONS,
-                EDITING,
-                SET_EDIT,
                 SOURCE_TYPE,
                 APP_TYPES,
                 SOURCE,
@@ -108,8 +96,6 @@ describe('application edit form parser', () => {
 
             const result = costManagementFields(
                 APPLICATION_WITHOUT_CM,
-                EDITING,
-                SET_EDIT,
                 SOURCE_TYPE,
                 APP_TYPES,
                 SOURCE,
@@ -123,14 +109,12 @@ describe('application edit form parser', () => {
                 component: componentTypes.SUB_FORM,
                 title: COSTMANAGEMENT_APP.display_name,
                 name: COSTMANAGEMENT_APP.display_name,
-                fields: modifyFields(BILLING_SOURCE_FIELDS, EDITING, SET_EDIT)
+                fields: modifyFields(BILLING_SOURCE_FIELDS)
             };
 
             const result = costManagementFields(
                 APPLICATIONS,
                 SOURCE_TYPE,
-                EDITING,
-                SET_EDIT,
                 APP_TYPES,
                 SOURCE,
             );
@@ -147,7 +131,7 @@ describe('application edit form parser', () => {
                     component: componentTypes.SUB_FORM,
                     title: COSTMANAGEMENT_APP.display_name,
                     name: COSTMANAGEMENT_APP.display_name,
-                    fields: modifyFields(BILLING_SOURCE_FIELDS, EDITING, SET_EDIT)
+                    fields: modifyFields(BILLING_SOURCE_FIELDS)
                 };
 
                 EXPECTED_RESULT = [
@@ -159,8 +143,6 @@ describe('application edit form parser', () => {
                 const result = applicationsFields(
                     APPLICATIONS,
                     SOURCE_TYPE,
-                    EDITING,
-                    SET_EDIT,
                     APP_TYPES,
                     SOURCE,
                 );
@@ -174,8 +156,6 @@ describe('application edit form parser', () => {
                 const result = applicationsFields(
                     APPLICATIONS,
                     SOURCE_TYPE,
-                    EDITING,
-                    SET_EDIT,
                     APP_TYPES,
                     SOURCE_WITH_NO_AUTHS,
                 );
@@ -262,38 +242,23 @@ describe('application edit form parser', () => {
         });
 
         describe('appendClusterIdentifier', () => {
-            const EDITING = {};
-            const SET_EDIT = jest.fn();
             const SOURCE_TYPE = { name: 'openshift' };
 
             it('returns cluster identifier field when type is openshift', () => {
-                expect(appendClusterIdentifier(EDITING, SET_EDIT, SOURCE_TYPE)).toEqual([{
+                expect(appendClusterIdentifier(SOURCE_TYPE)).toEqual([{
                     name: 'source.source_ref',
                     label: expect.any(Object),
                     isRequired: true,
-                    setEdit: SET_EDIT,
                     validate: [{ type: validatorTypes.REQUIRED }],
-                    component: EDIT_FIELD_NAME
+                    component: EDIT_FIELD_NAME,
+                    originalComponent: componentTypes.TEXT_FIELD,
                 }]);
             });
 
             it('dont return cluster identifier field when type is not openshift', () => {
                 const AWS_SOURCE_TYPE = { name: 'aws' };
 
-                expect(appendClusterIdentifier(EDITING, SET_EDIT, AWS_SOURCE_TYPE)).toEqual([]);
-            });
-
-            it('returns cluster identifier field when type is openshift and its being edited', () => {
-                const EDITING_REF = { 'source.source_ref': true };
-
-                expect(appendClusterIdentifier(EDITING_REF, SET_EDIT, SOURCE_TYPE)).toEqual([{
-                    name: 'source.source_ref',
-                    label: expect.any(Object),
-                    isRequired: true,
-                    setEdit: undefined,
-                    validate: [{ type: validatorTypes.REQUIRED }],
-                    component: componentTypes.TEXT_FIELD
-                }]);
+                expect(appendClusterIdentifier(AWS_SOURCE_TYPE)).toEqual([]);
             });
         });
     });

--- a/src/test/components/sourceEditForm/parser/authentication.test.js
+++ b/src/test/components/sourceEditForm/parser/authentication.test.js
@@ -1,6 +1,5 @@
 import { validatorTypes, componentTypes } from '@data-driven-forms/react-form-renderer';
 
-import { EDIT_FIELD_NAME } from '../../../../components/EditField/EditField';
 import {
     createAuthFieldName,
     getLastPartOfName,
@@ -14,6 +13,7 @@ import { unsupportedAuthTypeField } from '../../../../components/SourceEditForm/
 import { applicationTypesData } from '../../../__mocks__/applicationTypesData';
 import AuthenticationManagement from '../../../../components/SourceEditForm/parser/AuthenticationManagement';
 import RemoveAuthPlaceholder from '../../../../components/SourceEditForm/parser/RemoveAuthPlaceholder';
+import { modifyFields } from '../../../../components/SourceEditForm/parser/helpers';
 
 jest.mock('@redhat-cloud-services/frontend-components-sources', () => ({
     hardcodedSchemas: {
@@ -103,8 +103,6 @@ describe('authentication edit source parser', () => {
     describe('modifyAuthSchemas', () => {
         let FIELDS;
         let ID;
-        let EDITING;
-        let SET_EDIT;
         let FIELD_NAME;
 
         beforeEach(() => {
@@ -112,28 +110,18 @@ describe('authentication edit source parser', () => {
             FIELDS = [
                 { name: FIELD_NAME, component: componentTypes.TEXT_FIELD }
             ];
-            EDITING = {};
-            SET_EDIT = jest.fn();
             ID = '1231325314';
-        });
-
-        afterEach(() => {
-            SET_EDIT.mockReset();
         });
 
         it('parses correctly (change components to edit field)', () => {
             const result = modifyAuthSchemas(
                 FIELDS,
                 ID,
-                EDITING,
-                SET_EDIT
             );
 
             expect(result).toEqual([{
                 ...FIELDS[0],
-                component: EDIT_FIELD_NAME,
                 name: createAuthFieldName(FIELD_NAME, ID),
-                setEdit: SET_EDIT
             }]);
         });
 
@@ -147,33 +135,11 @@ describe('authentication edit source parser', () => {
             const result = modifyAuthSchemas(
                 FIELDS,
                 ID,
-                EDITING,
-                SET_EDIT
             );
 
             expect(result).toEqual([{
                 ...FIELDS[0],
-                component: EDIT_FIELD_NAME,
                 name: NOT_AUTH_NAME,
-                setEdit: SET_EDIT
-            }]);
-        });
-
-        it('parses editing correctly', () => {
-            EDITING = {
-                [createAuthFieldName(FIELD_NAME, ID)]: true
-            };
-
-            const result = modifyAuthSchemas(
-                FIELDS,
-                ID,
-                EDITING,
-                SET_EDIT
-            );
-
-            expect(result).toEqual([{
-                ...FIELDS[0],
-                name: createAuthFieldName(FIELD_NAME, ID)
             }]);
         });
 
@@ -193,15 +159,11 @@ describe('authentication edit source parser', () => {
             const result = modifyAuthSchemas(
                 FIELDS_WITH_PASSWORD,
                 ID,
-                EDITING,
-                SET_EDIT
             );
 
             expect(result).toEqual([{
-                ...FIELDS[0],
-                component: EDIT_FIELD_NAME,
+                ...FIELDS_WITH_PASSWORD[0],
                 name: createAuthFieldName(PASSWORD_NAME, ID),
-                setEdit: SET_EDIT,
                 isRequired: false,
                 validate: [],
                 helperText: expect.any(Object)
@@ -212,8 +174,6 @@ describe('authentication edit source parser', () => {
     describe('authenticationFields', () => {
         let AUTHENTICATIONS;
         let SOURCE_TYPE;
-        let EDITING;
-        let SET_EDIT;
         let AUTHTYPE;
         let ID;
         let APP_TYPES;
@@ -244,13 +204,7 @@ describe('authentication edit source parser', () => {
                     ]
                 }
             };
-            EDITING = {};
-            SET_EDIT = jest.fn();
             APP_TYPES = applicationTypesData.data;
-        });
-
-        afterEach(() => {
-            SET_EDIT.mockReset();
         });
 
         it('returns empty array when no authentications', () => {
@@ -259,8 +213,6 @@ describe('authentication edit source parser', () => {
             const result = authenticationFields(
                 EMPTY_AUTHENTICATIONS,
                 SOURCE_TYPE,
-                EDITING,
-                SET_EDIT,
                 APP_TYPES
             );
 
@@ -271,8 +223,6 @@ describe('authentication edit source parser', () => {
             const result = authenticationFields(
                 AUTHENTICATIONS,
                 SOURCE_TYPE,
-                EDITING,
-                SET_EDIT,
                 APP_TYPES
             );
 
@@ -292,7 +242,7 @@ describe('authentication edit source parser', () => {
                         auth: AUTHENTICATIONS[0],
                         isDeleting: undefined
                     },
-                    modifyAuthSchemas(FIELDS_WITHOUT_STEPKEYS, ID, EDITING, SET_EDIT)
+                    modifyFields(modifyAuthSchemas(FIELDS_WITHOUT_STEPKEYS, ID))
                 ]
             };
 
@@ -307,8 +257,6 @@ describe('authentication edit source parser', () => {
             const result = authenticationFields(
                 AUTHENTICATIONS,
                 SOURCE_TYPE,
-                EDITING,
-                SET_EDIT,
                 APP_TYPES
             );
 
@@ -347,8 +295,6 @@ describe('authentication edit source parser', () => {
             const result = authenticationFields(
                 UNSUPPORTED_AUTHENTICATIONS,
                 SOURCE_TYPE,
-                EDITING,
-                SET_EDIT,
                 APP_TYPES
             );
 
@@ -368,8 +314,6 @@ describe('authentication edit source parser', () => {
             const result = authenticationFields(
                 AUTHENTICATIONS,
                 SOURCE_TYPE_WITHOUT_SCHEMA,
-                EDITING,
-                SET_EDIT,
                 APP_TYPES
             );
 
@@ -389,8 +333,6 @@ describe('authentication edit source parser', () => {
             const result = authenticationFields(
                 AUTHENTICATIONS,
                 SOURCE_TYPE_WITHOUT_SCHEMA_AUTH,
-                EDITING,
-                SET_EDIT,
                 APP_TYPES
             );
 

--- a/src/test/components/sourceEditForm/parser/genericInfo.test.js
+++ b/src/test/components/sourceEditForm/parser/genericInfo.test.js
@@ -9,52 +9,26 @@ jest.mock('@redhat-cloud-services/frontend-components-sources', () => ({
 }));
 
 describe('generic info edit form parser', () => {
-    const EDITING = {};
-    const SET_EDIT = jest.fn();
     const SOURCE_ID = '1233465';
 
-    const EXPECTED_TYPE_FIELD = {
-        name: 'source_type',
-        label: expect.any(Object),
-        isReadOnly: true,
-        component: EDIT_FIELD_NAME
-    };
+    it('should generate generic info form group', () => {
 
-    it('should generate generic info form group when not editing name', () => {
-        const EXPECTED_NAME_FIELD = {
-            name: 'source.name',
+        const EXPECTED_TYPE_FIELD = {
+            name: 'source_type',
             label: expect.any(Object),
+            isReadOnly: true,
             component: EDIT_FIELD_NAME,
-            setEdit: SET_EDIT,
-            validate: [
-                expect.any(Function),
-                { type: validatorTypes.REQUIRED }
-            ],
-            isRequired: true
         };
-
-        const EXPECTED_FORM_GROUP = [
-            expect.objectContaining(EXPECTED_NAME_FIELD),
-            expect.objectContaining(EXPECTED_TYPE_FIELD)
-        ];
-
-        expect(genericInfo(EDITING, SET_EDIT, SOURCE_ID)).toEqual(EXPECTED_FORM_GROUP);
-    });
-
-    it('should generate generic info form group when editing name', () => {
-        const EDITING = { 'source.name': true };
-        const SET_EDIT = jest.fn();
-        const SOURCE_ID = '1233465';
-
         const EXPECTED_NAME_FIELD = {
             name: 'source.name',
             label: expect.any(Object),
-            component: componentTypes.TEXT_FIELD,
             validate: [
                 expect.any(Function),
                 { type: validatorTypes.REQUIRED }
             ],
-            isRequired: true
+            isRequired: true,
+            originalComponent: componentTypes.TEXT_FIELD,
+            component: EDIT_FIELD_NAME,
         };
 
         const EXPECTED_FORM_GROUP = [
@@ -62,11 +36,11 @@ describe('generic info edit form parser', () => {
             expect.objectContaining(EXPECTED_TYPE_FIELD)
         ];
 
-        expect(genericInfo(EDITING, SET_EDIT, SOURCE_ID)).toEqual(EXPECTED_FORM_GROUP);
+        expect(genericInfo(SOURCE_ID)).toEqual(EXPECTED_FORM_GROUP);
     });
 
     it('should return debounced validate function', () => {
-        const schema = genericInfo(EDITING, SET_EDIT, SOURCE_ID);
+        const schema = genericInfo(SOURCE_ID);
 
         const returnedFunction = schema[0].validate[0]('some value', SOURCE_ID);
 

--- a/src/test/components/sourceEditForm/parser/helpers.test.js
+++ b/src/test/components/sourceEditForm/parser/helpers.test.js
@@ -7,7 +7,7 @@ describe('source edit form parser helpers', () => {
         const NAME = '123';
         const FIELDS = [{ component: componentTypes.TEXT_FIELD, name: NAME }];
 
-        it('adds component type when not editing', () => {
+        it('adds originalComponent and component', () => {
             const EDITING = {};
             const SET_EDIT = jest.fn();
 
@@ -15,25 +15,9 @@ describe('source edit form parser helpers', () => {
                 {
                     ...FIELDS[0],
                     component: EDIT_FIELD_NAME,
-                    setEdit: SET_EDIT
+                    originalComponent: componentTypes.TEXT_FIELD
                 }
             ]);
-        });
-
-        it('adds nothing type when editing', () => {
-            const EDITING = { [NAME]: true };
-            const SET_EDIT = jest.fn();
-
-            expect(modifyFields(FIELDS, EDITING, SET_EDIT)).toEqual(FIELDS);
-        });
-
-        it('do not change switch and checkbox components', () => {
-            const EDITING = {};
-            const SET_EDIT = jest.fn();
-
-            const FIELDS = [{ component: componentTypes.SWITCH, name: NAME }, { component: componentTypes.CHECKBOX, name: NAME }];
-
-            expect(modifyFields(FIELDS, EDITING, SET_EDIT)).toEqual(FIELDS);
         });
     });
 });

--- a/src/test/components/sourceEditForm/parser/parseSourceToSchema.test.js
+++ b/src/test/components/sourceEditForm/parser/parseSourceToSchema.test.js
@@ -7,8 +7,6 @@ import * as app from '../../../../components/SourceEditForm/parser/application';
 
 describe('parseSourceToSchema', () => {
     let SOURCE;
-    let EDITING;
-    let SET_EDIT;
     let SOURCE_TYPE;
     let APP_TYPES;
 
@@ -19,8 +17,6 @@ describe('parseSourceToSchema', () => {
             applications: [],
             endpoints: [{}]
         };
-        EDITING = {};
-        SET_EDIT = jest.fn();
         SOURCE_TYPE = {
             id: '2',
             schema: {
@@ -43,43 +39,29 @@ describe('parseSourceToSchema', () => {
         end.endpointFields = jest.fn().mockImplementation(() => (undefined));
     });
 
-    afterEach(() => {
-        SET_EDIT.mockReset();
-    });
-
     it('calls all subsections', () => {
         parseSourceToSchema(
             SOURCE,
-            EDITING,
-            SET_EDIT,
             SOURCE_TYPE,
             APP_TYPES
         );
 
         expect(gen.genericInfo).toHaveBeenCalledWith(
-            EDITING,
-            SET_EDIT,
             SOURCE.source.id
         );
         expect(auth.authenticationFields).toHaveBeenCalledWith(
             SOURCE.authentications,
             SOURCE_TYPE,
-            EDITING,
-            SET_EDIT,
             APP_TYPES
         );
         expect(app.applicationsFields).toHaveBeenCalledWith(
             SOURCE.applications,
             SOURCE_TYPE,
-            EDITING,
-            SET_EDIT,
             APP_TYPES,
             SOURCE,
         );
         expect(end.endpointFields).toHaveBeenCalledWith(
             SOURCE_TYPE,
-            EDITING,
-            SET_EDIT
         );
     });
 
@@ -91,29 +73,21 @@ describe('parseSourceToSchema', () => {
 
         parseSourceToSchema(
             SOURCE_WITH_NO_ENDPOINT,
-            EDITING,
-            SET_EDIT,
             SOURCE_TYPE,
             APP_TYPES
         );
 
         expect(gen.genericInfo).toHaveBeenCalledWith(
-            EDITING,
-            SET_EDIT,
             SOURCE.source.id
         );
         expect(auth.authenticationFields).toHaveBeenCalledWith(
             SOURCE.authentications,
             SOURCE_TYPE,
-            EDITING,
-            SET_EDIT,
             APP_TYPES
         );
         expect(app.applicationsFields).toHaveBeenCalledWith(
             SOURCE.applications,
             SOURCE_TYPE,
-            EDITING,
-            SET_EDIT,
             APP_TYPES,
             SOURCE_WITH_NO_ENDPOINT,
         );
@@ -128,29 +102,21 @@ describe('parseSourceToSchema', () => {
 
         parseSourceToSchema(
             SOURCE_WITH_NO_ENDPOINT,
-            EDITING,
-            SET_EDIT,
             SOURCE_TYPE,
             APP_TYPES
         );
 
         expect(gen.genericInfo).toHaveBeenCalledWith(
-            EDITING,
-            SET_EDIT,
             SOURCE.source.id
         );
         expect(auth.authenticationFields).toHaveBeenCalledWith(
             SOURCE.authentications,
             SOURCE_TYPE,
-            EDITING,
-            SET_EDIT,
             APP_TYPES
         );
         expect(app.applicationsFields).toHaveBeenCalledWith(
             SOURCE.applications,
             SOURCE_TYPE,
-            EDITING,
-            SET_EDIT,
             APP_TYPES,
             SOURCE_WITH_NO_ENDPOINT,
         );
@@ -169,8 +135,6 @@ describe('parseSourceToSchema', () => {
 
         const result = parseSourceToSchema(
             SOURCE,
-            EDITING,
-            SET_EDIT,
             SOURCE_TYPE,
             APP_TYPES
         );

--- a/src/utilities/SourcesFormRenderer.js
+++ b/src/utilities/SourcesFormRenderer.js
@@ -10,7 +10,7 @@ import componentMapper from '@data-driven-forms/pf4-component-mapper/dist/cjs/co
 
 import { mapperExtension } from '@redhat-cloud-services/frontend-components-sources';
 
-import EditField from '../components/EditField/EditField';
+import EditFieldWrapper from '../components/EditField/EditFieldWrapper';
 
 const SourcesFormRenderer = props => (
     <FormRenderer
@@ -18,7 +18,7 @@ const SourcesFormRenderer = props => (
         componentMapper={{
             ...componentMapper,
             ...mapperExtension,
-            'edit-field': EditField,
+            'edit-field': EditFieldWrapper,
             'switch-field': componentMapper[componentTypes.SWITCH]
         }}
         validatorMapper={{


### PR DESCRIPTION
There are two kinds of updates:

- removing updates errors in redirectNoId/redirectNotAdmin components
- changing EditField to use props shared via Context, I thought this is going to remove the update error there, but sometimes it still occurs, so further investigation is needed. However, this refactoring should at least bring better performance and cleaner code.