### PR TITLE
Added missing "rm -rf" between calls to release.sh

### DIFF
--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -3,10 +3,20 @@
 NODE_ENV=production npm run build
 
 if [ "${TRAVIS_BRANCH}" = "master" ]; then
+    echo "PUSHING ci-beta"
+    rm -rf dist/.git
     .travis/release.sh "ci-beta"
+
+    echo "PUSHING qa-beta"
+    rm -rf dist/.git
     .travis/release.sh "qa-beta"
 elif [ "${TRAVIS_BRANCH}" = "master-stable" ]; then
+    echo "PUSHING ci-stable"
+    rm -rf dist/.git
     .travis/release.sh "ci-stable"
+    
+    echo "PUSHING qa-stable"
+    rm -rf dist/.git
     .travis/release.sh "qa-stable"
 elif [[ "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ]]; then
     .travis/release.sh "${TRAVIS_BRANCH}"

--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -1,23 +1,31 @@
 #!/usr/bin/env bash
+set -e
+set -x
 
 NODE_ENV=production npm run build
 
-if [ "${TRAVIS_BRANCH}" = "master" ]; then
-    echo "PUSHING ci-beta"
-    rm -rf dist/.git
-    .travis/release.sh "ci-beta"
+if [ "${TRAVIS_BRANCH}" = "master" ]
+then
+    for env in ci qa
+    do
+        echo "PUSHING ${env}-beta"
+        rm -rf ./dist/.git
+        .travis/release.sh "${env}-beta"
+    done
+fi
 
-    echo "PUSHING qa-beta"
-    rm -rf dist/.git
-    .travis/release.sh "qa-beta"
-elif [ "${TRAVIS_BRANCH}" = "master-stable" ]; then
-    echo "PUSHING ci-stable"
-    rm -rf dist/.git
-    .travis/release.sh "ci-stable"
-    
-    echo "PUSHING qa-stable"
-    rm -rf dist/.git
-    .travis/release.sh "qa-stable"
-elif [[ "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ]]; then
+if [ "${TRAVIS_BRANCH}" = "master-stable" ]
+then
+    for env in ci qa
+    do
+        echo "PUSHING ${env}-stable"
+        rm -rf ./dist/.git
+        .travis/release.sh "${env}-stable"
+    done
+fi
+
+if [[ "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ]]; then
+    echo "PUSHING ${TRAVIS_BRANCH}"
+    rm -rf ./build/.git
     .travis/release.sh "${TRAVIS_BRANCH}"
 fi


### PR DESCRIPTION
Realized that the qa-beta branch for [sources-ui-deploy](https://github.com/RedHatInsights/sources-ui-deploy/tree/qa-beta) repo was 24 days old when it should have been updated with the last merge to master based on the update to this script.

However, we were missing the call to `rm -rf dist/.git` between calls to `.travis/release.sh` which I believe is the root cause.

cc @eclarizio