### PR TITLE
Rename master-stable branch to stable

### DIFF
--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -14,7 +14,7 @@ then
     done
 fi
 
-if [ "${TRAVIS_BRANCH}" = "master-stable" ]
+if [ "${TRAVIS_BRANCH}" = "stable" ]
 then
     for env in ci qa
     do


### PR DESCRIPTION
Simple rename of the release branch from `master-stable` to `stable`