### PR TITLE
Add new state for loading errors

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -97,6 +97,7 @@
 .ins-c-sources__empty-state {
   // should be 64px from the top, content has padding --pf-global--spacer--lg, so we have to calculate the rest of it
   padding-top: calc(0px - var(--pf-global--spacer--lg) + 64px) !important;
+  max-width: 576px;
 }
 
 .ins-c-sources__disabled-drodpown-item {

--- a/src/components/SourcesEmptyState.js
+++ b/src/components/SourcesEmptyState.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 
 import { Button } from '@patternfly/react-core/dist/js/components/Button/Button';
@@ -15,7 +14,7 @@ import { Link } from 'react-router-dom';
 import { routes } from '../Routes';
 import { useIsOrgAdmin } from '../hooks/useIsOrgAdmin';
 
-const SourcesEmptyState = ({ title, body }) => {
+const SourcesEmptyState = () => {
     const isOrgAdmin = useIsOrgAdmin();
     const intl = useIntl();
 
@@ -24,16 +23,17 @@ const SourcesEmptyState = ({ title, body }) => {
             <EmptyState className="ins-c-sources__empty-state">
                 <EmptyStateIcon icon={WrenchIcon} />
                 <Title headingLevel="h5" size="lg">
-                    {title ? title :
+                    {
                         intl.formatMessage({ id: 'sources.emptyStateTitle', defaultMessage: 'No sources' })
                     }
                 </Title>
                 <EmptyStateBody>
-                    {body ? body :
+                    {
                         isOrgAdmin && intl.formatMessage({
                             id: 'sources.emptyStateBody',
                             defaultMessage: 'No sources have been defined. To start define a source.'
-                        })}
+                        })
+                    }
                     {!isOrgAdmin && <React.Fragment>
                         <br />
                         {intl.formatMessage({
@@ -66,11 +66,6 @@ const SourcesEmptyState = ({ title, body }) => {
             </EmptyState>
         </Bullseye>
     );
-};
-
-SourcesEmptyState.propTypes = {
-    title: PropTypes.node,
-    body: PropTypes.node
 };
 
 export default SourcesEmptyState;

--- a/src/components/SourcesErrorState.js
+++ b/src/components/SourcesErrorState.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { useIntl } from 'react-intl';
+
+import { Button } from '@patternfly/react-core/dist/js/components/Button/Button';
+import { EmptyState } from '@patternfly/react-core/dist/js/components/EmptyState/EmptyState';
+import { EmptyStateIcon } from '@patternfly/react-core/dist/js/components/EmptyState/EmptyStateIcon';
+import { EmptyStateBody } from '@patternfly/react-core/dist/js/components/EmptyState/EmptyStateBody';
+import { Bullseye } from '@patternfly/react-core/dist/js/layouts/Bullseye/Bullseye';
+import { Title } from '@patternfly/react-core/dist/js/components/Title/Title';
+import { Text } from '@patternfly/react-core/dist/js/components/Text/Text';
+
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
+
+const SourcesErrorState = () => {
+    const intl = useIntl();
+
+    return (
+        <Bullseye>
+            <EmptyState className="ins-c-sources__empty-state">
+                <EmptyStateIcon icon={ExclamationCircleIcon} color="var(--pf-global--danger-color--100)"/>
+                <Title headingLevel="h5" size="lg">
+                    {
+                        intl.formatMessage({
+                            id: 'sources.errorStateTitle',
+                            defaultMessage: 'Something went wrong'
+                        })
+                    }
+                </Title>
+                <EmptyStateBody>
+                    {intl.formatMessage({
+                        id: 'sources.errorStateBody',
+                        // eslint-disable-next-line max-len
+                        defaultMessage: 'There was a problem processing the request. Try refreshing the page. If the problem persists, contact <a>Red Hat support.</a>'
+                    }, {
+                        // eslint-disable-next-line react/display-name
+                        a: (chunks) => (<Text
+                            key="link"
+                            component="a"
+                            href="https://access.redhat.com/support"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            {chunks}
+                        </Text>)
+                    })}
+                </EmptyStateBody>
+                <Button
+                    className="pf-u-mt-xl"
+                    variant="primary"
+                    component="a"
+                    href={window.location.href}
+                >
+                    { intl.formatMessage({
+                        id: 'sources.retry',
+                        defaultMessage: 'Retry'
+                    }) }
+                </Button>
+            </EmptyState>
+        </Bullseye>
+    );
+};
+
+export default SourcesErrorState;

--- a/src/redux/sources/actions.js
+++ b/src/redux/sources/actions.js
@@ -35,6 +35,7 @@ export const loadEntities = (options) => (dispatch, getState) => {
         payload: sources
     })).catch(error => dispatch({
         type: ACTION_TYPES.LOAD_ENTITIES_REJECTED,
+        meta: { noError: true },
         payload: { error: { detail: error.detail || error.data, title: error.title || 'Fetching data failed, try refresh page' } }
     }));
 };

--- a/src/test/components/SourcesEmptyState.test.js
+++ b/src/test/components/SourcesEmptyState.test.js
@@ -32,14 +32,6 @@ describe('SourcesEmptyState', () => {
         expect(wrapper.find(EmptyState).props().className).toEqual('ins-c-sources__empty-state');
     });
 
-    it('renders correctly with custom props', () => {
-        const wrapper = mount(componentWrapperIntl(<SourcesEmptyState title="Chyba" body="Velmi oskliva chyba"/>, store));
-
-        expect(wrapper.find(Title).text().includes('Chyba')).toEqual(true);
-        expect(wrapper.find(EmptyStateBody).text().includes('Velmi oskliva chyba')).toEqual(true);
-        expect(wrapper.find(EmptyState).props().className).toEqual('ins-c-sources__empty-state');
-    });
-
     it('renders as not org admin', () => {
         store = mockStore({ user: { isOrgAdmin: false } });
 

--- a/src/test/components/SourcesErrorState.test.js
+++ b/src/test/components/SourcesErrorState.test.js
@@ -1,0 +1,37 @@
+import SourcesErrorState from '../../components/SourcesErrorState';
+import {
+    Bullseye,
+    Title,
+    Button,
+    EmptyState,
+    EmptyStateIcon,
+    EmptyStateBody
+} from '@patternfly/react-core';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
+
+import configureStore from 'redux-mock-store';
+import { componentWrapperIntl } from '../../utilities/testsHelpers';
+
+describe('SourcesErrorState', () => {
+    let mockStore;
+    let store;
+
+    beforeEach(() => {
+        mockStore = configureStore([]);
+        store = mockStore();
+    });
+
+    it('renders correctly', () => {
+        const wrapper = mount(componentWrapperIntl(<SourcesErrorState />, store));
+
+        expect(wrapper.find(EmptyState)).toHaveLength(1);
+        expect(wrapper.find(EmptyStateIcon)).toHaveLength(1);
+        expect(wrapper.find(EmptyStateBody)).toHaveLength(1);
+        expect(wrapper.find(ExclamationCircleIcon)).toHaveLength(1);
+        expect(wrapper.find(Button)).toHaveLength(1);
+        expect(wrapper.find(Button).text()).toEqual('Retry');
+        expect(wrapper.find(Title)).toHaveLength(1);
+        expect(wrapper.find(Bullseye)).toHaveLength(1);
+        expect(wrapper.find(EmptyState).props().className).toEqual('ins-c-sources__empty-state');
+    });
+});

--- a/src/test/pages/Sources.test.js
+++ b/src/test/pages/Sources.test.js
@@ -33,6 +33,7 @@ import * as SourceRemoveModal from '../../components/SourceRemoveModal/SourceRem
 import * as urlQuery from '../../utilities/urlQuery';
 import { PlaceHolderTable, PaginationLoader } from '../../components/SourcesTable/loaders';
 import { Table } from '@patternfly/react-table';
+import SourcesErrorState from '../../components/SourcesErrorState';
 
 describe('SourcesPage', () => {
     const middlewares = [thunk, notificationsMiddleware()];
@@ -108,7 +109,7 @@ describe('SourcesPage', () => {
         expect(wrapper.find(SourcesTable)).toHaveLength(0);
     });
 
-    it('renders empty state when there is fetching error', async () => {
+    it('renders error state when there is fetching (loadEntities) error', async () => {
         const ERROR_MESSAGE = 'ERROR_MESSAGE';
         api.doLoadEntities = jest.fn().mockImplementation(() => Promise.reject({ detail: ERROR_MESSAGE }));
 
@@ -117,10 +118,23 @@ describe('SourcesPage', () => {
         });
 
         wrapper.update();
-        expect(wrapper.find(SourcesEmptyState)).toHaveLength(1);
+        expect(wrapper.find(SourcesErrorState)).toHaveLength(1);
         expect(wrapper.find(PrimaryToolbar)).toHaveLength(0);
         expect(wrapper.find(SourcesTable)).toHaveLength(0);
-        expect(wrapper.text().includes(ERROR_MESSAGE)).toEqual(true);
+    });
+
+    it('renders error state when there is loading (sourceTypes/appTypes) error', async () => {
+        const ERROR_MESSAGE = 'ERROR_MESSAGE';
+        api.doLoadAppTypes = jest.fn().mockImplementation(() => Promise.reject({ detail: ERROR_MESSAGE }));
+
+        await act(async() => {
+            wrapper = mount(componentWrapperIntl(<SourcesPage { ...initialProps } />, store));
+        });
+
+        wrapper.update();
+        expect(wrapper.find(SourcesErrorState)).toHaveLength(1);
+        expect(wrapper.find(PrimaryToolbar)).toHaveLength(0);
+        expect(wrapper.find(SourcesTable)).toHaveLength(0);
     });
 
     it('renders table and filtering - loading', async () => {

--- a/src/test/redux/sources/actions.test.js
+++ b/src/test/redux/sources/actions.test.js
@@ -222,6 +222,7 @@ describe('redux actions', () => {
             });
             expect(dispatch.mock.calls[2][0]).toEqual({
                 type: ACTION_TYPES.LOAD_ENTITIES_REJECTED,
+                meta: { noError: true },
                 payload: { error: { detail: ERROR_DETAIL, title: expect.any(String) } }
             });
         });
@@ -243,6 +244,7 @@ describe('redux actions', () => {
             });
             expect(dispatch.mock.calls[2][0]).toEqual({
                 type: ACTION_TYPES.LOAD_ENTITIES_REJECTED,
+                meta: { noError: true },
                 payload: { error: { detail: ERROR_DETAIL, title: ERROR_TITLE } }
             });
         });


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/TPINVTRY-1030

- adds a new error state when loading of the data fails, also removes the toast for loadEntities error

**After**

![image](https://user-images.githubusercontent.com/32869456/89011924-8eaf9d80-d311-11ea-9f56-b8a20325631f.png)
