### PR TITLE
Show dots for filled authentication password

### DIFF
--- a/src/components/Authentication.js
+++ b/src/components/Authentication.js
@@ -1,0 +1,78 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { useIntl } from 'react-intl';
+import get from 'lodash/get';
+
+import { FormGroup } from '@patternfly/react-core/dist/js/components/Form/FormGroup';
+import { TextInput } from '@patternfly/react-core/dist/js/components/TextInput/TextInput';
+
+import TextField from '@data-driven-forms/pf4-component-mapper/dist/cjs/text-field';
+import useFormApi from '@data-driven-forms/react-form-renderer/dist/cjs/use-form-api';
+import validatorTypes from '@data-driven-forms/react-form-renderer/dist/cjs/validator-types';
+import validated from '@redhat-cloud-services/frontend-components-sources/cjs/validated';
+
+const Authentication = (rest) => {
+    const intl = useIntl();
+    const formOptions = useFormApi();
+    const values = formOptions.getState().values;
+
+    const [authenticationId] = rest?.name?.match(/\d+/) || [];
+    const isEditing = authenticationId || values.authentication?.id;
+
+    // If there is any value, the field is modified (password is always empty on start)
+    let isModified = get(values, rest.name);
+
+    const [edited, setEdited] = useState(!isEditing || isModified);
+    const firstClick = useRef(true);
+    const mounted = useRef(false);
+
+    useEffect(() => {
+        if (mounted.current) {
+            // reset on restart
+            if (
+                !firstClick.current && formOptions.getState().pristine
+            ) {
+                setEdited(false);
+                firstClick.current = true;
+            }
+
+            if (edited) {
+                firstClick.current = false;
+            }
+        }
+    });
+
+    useEffect(() => {
+        mounted.current = true;
+    }, []);
+
+    const doNotRequirePassword = rest.validate && rest.validate.filter(({ type }) => type !== validatorTypes.REQUIRED);
+
+    const componentProps = {
+        ...rest,
+        ...(isEditing ? {
+            isRequired: false,
+            helperText: intl.formatMessage({
+                id: 'wizard.changeAuthHelper',
+                defaultMessage: 'Changing this resets your current {label}.'
+            }, { label: rest.label }),
+            validate: doNotRequirePassword,
+            resolveProps: validated
+        } : {})
+    };
+
+    if (!edited) {
+        return (<FormGroup
+            helperText={componentProps.helperText}
+            label={componentProps.label}
+            onFocus={() => setEdited(true)}
+        >
+            <TextInput aria-label="pre-filled-authentication" value="•••••••••••••" />
+        </FormGroup>);
+    }
+
+    return (
+        <TextField { ...componentProps } autoFocus={true}/>
+    );
+};
+
+export default Authentication;

--- a/src/components/SourceEditForm/parser/authentication.js
+++ b/src/components/SourceEditForm/parser/authentication.js
@@ -1,9 +1,7 @@
-import React from 'react';
 import get from 'lodash/get';
 import componentTypes from '@data-driven-forms/react-form-renderer/dist/cjs/component-types';
 import validatorTypes from '@data-driven-forms/react-form-renderer/dist/cjs/validator-types';
 import hardcodedSchemas from '@redhat-cloud-services/frontend-components-sources/cjs/hardcodedSchemas';
-import { FormattedMessage } from 'react-intl';
 
 import { unsupportedAuthTypeField } from './unsupportedAuthType';
 import AuthenticationManagement from './AuthenticationManagement';
@@ -32,15 +30,7 @@ export const modifyAuthSchemas = (fields, id) => fields.map((field) => {
     const isPassword = getLastPartOfName(finalField.name) === 'password';
 
     if (isPassword) {
-        finalField.helperText = (<FormattedMessage
-            id="sources.passwordResetHelperText"
-            defaultMessage={`Changing this resets your current { label }.`}
-            values={{
-                label: finalField.label
-            }}
-        />);
-        finalField.isRequired = false;
-        finalField.validate = removeRequiredValidator(finalField.validate);
+        finalField.component = 'authentication';
     }
 
     return finalField;

--- a/src/test/components/Authentication.test.js
+++ b/src/test/components/Authentication.test.js
@@ -1,0 +1,218 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+
+import { FormGroup, TextInput, Button } from '@patternfly/react-core';
+import { validatorTypes } from '@data-driven-forms/react-form-renderer';
+
+import FormTemplate from '@data-driven-forms/pf4-component-mapper/dist/cjs/form-template';
+import TextField from '@data-driven-forms/pf4-component-mapper/dist/cjs/text-field';
+
+import { componentWrapperIntl } from '../../utilities/testsHelpers';
+
+import Authentication from '../../components/Authentication';
+import SourcesFormRenderer from '../../utilities/SourcesFormRenderer';
+
+describe('Authentication test', () => {
+    let schema;
+    let onSubmit;
+    let initialProps;
+
+    beforeEach(() => {
+        schema = {
+            fields: [{
+                component: 'authentication',
+                name: 'authentication.password',
+                validate: [
+                    { type: validatorTypes.REQUIRED },
+                    {
+                        type: validatorTypes.MIN_LENGTH,
+                        threshold: 2
+                    }
+                ],
+                isRequired: true
+            }]
+        };
+        onSubmit = jest.fn();
+        initialProps = {
+            formFieldsMapper: {
+                authentication: Authentication
+            },
+            schema,
+            onSubmit: (values) => onSubmit(values),
+            FormTemplate
+        };
+    });
+
+    it('renders with no validation', () => {
+        schema = {
+            fields: [{
+                component: 'authentication',
+                name: 'authentication.password',
+                isRequired: true
+            }]
+        };
+
+        const wrapper = mount(
+            componentWrapperIntl(<SourcesFormRenderer
+                {...initialProps}
+                schema={schema}
+                initialValues={{
+                    authentication: {
+                        id: 'someid'
+                    }
+                }}
+            />));
+
+        expect(wrapper.find(Authentication)).toHaveLength(1);
+    });
+
+    it('renders with func validation', () => {
+        schema = {
+            fields: [{
+                component: 'authentication',
+                name: 'authentication.password',
+                isRequired: true,
+                validate: [() => undefined]
+            }]
+        };
+
+        const wrapper = mount(componentWrapperIntl(<SourcesFormRenderer
+            {...initialProps}
+            schema={schema}
+            initialValues={{
+                authentication: {
+                    id: 'someid'
+                }
+            }}
+        />));
+
+        expect(wrapper.find(Authentication)).toHaveLength(1);
+    });
+
+    it('renders not editing', () => {
+        const wrapper = mount(
+            componentWrapperIntl(<SourcesFormRenderer
+                {...initialProps}
+            />)
+        );
+
+        expect(wrapper.find(Authentication)).toHaveLength(1);
+
+        expect(wrapper.find(TextField).props().isRequired).toEqual(true);
+        expect(wrapper.find(TextField).props().helperText).toEqual(undefined);
+
+        wrapper.find('form').simulate('submit');
+        wrapper.update();
+
+        expect(onSubmit).not.toHaveBeenCalled();
+
+        wrapper.find('input').instance().value = 's'; // too short
+        wrapper.find('input').simulate('change');
+        wrapper.update();
+
+        wrapper.find('form').simulate('submit');
+        wrapper.update();
+
+        expect(onSubmit).not.toHaveBeenCalled();
+
+        wrapper.find('input').instance().value = 'some-value';
+        wrapper.find('input').simulate('change');
+        wrapper.update();
+
+        wrapper.find('form').simulate('submit');
+        expect(onSubmit).toHaveBeenCalledWith({
+            authentication: {
+                password: 'some-value'
+            }
+        });
+    });
+
+    it('renders editing and removes required validator (min length still works)', async () => {
+        const wrapper = mount(componentWrapperIntl(<SourcesFormRenderer
+            {...initialProps}
+            initialValues={{
+                authentication: {
+                    id: 'someid'
+                }
+            }}
+        />));
+
+        expect(wrapper.find(FormGroup)).toHaveLength(1);
+        expect(wrapper.find(TextInput)).toHaveLength(1);
+        expect(wrapper.find(TextInput).props().value).toEqual('•••••••••••••');
+
+        await act(async () => {
+            wrapper.find(FormGroup).first().simulate('focus');
+        });
+        wrapper.update();
+
+        expect(wrapper.find(Authentication)).toHaveLength(1);
+        expect(wrapper.find(TextField).props().isRequired).toEqual(false);
+        expect(wrapper.find(TextField).props().helperText).toEqual('Changing this resets your current .');
+
+        wrapper.find('form').simulate('submit');
+        wrapper.update();
+
+        expect(onSubmit).toHaveBeenCalledWith({
+            authentication: {
+                id: 'someid'
+            }
+        });
+        onSubmit.mockClear();
+
+        wrapper.find('input').instance().value = 's';
+        wrapper.find('input').simulate('change');
+        wrapper.update();
+
+        wrapper.find('form').simulate('submit');
+        expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('reset when form resets', async () => {
+        let wrapper;
+
+        await act(async () => {
+            wrapper = mount(componentWrapperIntl(<SourcesFormRenderer
+                {...initialProps}
+                FormTemplate={(props) => <FormTemplate {...props} canReset/>}
+                initialValues={{
+                    authentication: {
+                        id: 'someid'
+                    }
+                }}
+            />));
+        });
+
+        expect(wrapper.find(FormGroup)).toHaveLength(1);
+        expect(wrapper.find(TextInput)).toHaveLength(1);
+        expect(wrapper.find(TextInput).props().value).toEqual('•••••••••••••');
+        expect(wrapper.find(TextField)).toHaveLength(0);
+
+        await act(async () => {
+            wrapper.find(FormGroup).first().simulate('focus');
+        });
+        wrapper.update();
+
+        expect(wrapper.find(Authentication)).toHaveLength(1);
+        expect(wrapper.find(TextField).props().isRequired).toEqual(false);
+        expect(wrapper.find(TextField).props().helperText).toEqual('Changing this resets your current .');
+
+        await act(async () => {
+            wrapper.find('input').instance().value = 's';
+            wrapper.find('input').simulate('change');
+            wrapper.update();
+        });
+        wrapper.update();
+
+        // reset
+        await act(async () => {
+            wrapper.find(Button).at(1).simulate('click');
+        });
+        wrapper.update();
+
+        expect(wrapper.find(FormGroup)).toHaveLength(1);
+        expect(wrapper.find(TextInput)).toHaveLength(1);
+        expect(wrapper.find(TextInput).props().value).toEqual('•••••••••••••');
+        expect(wrapper.find(TextField)).toHaveLength(0);
+    });
+});

--- a/src/test/components/sourceEditForm/parser/authentication.test.js
+++ b/src/test/components/sourceEditForm/parser/authentication.test.js
@@ -162,10 +162,8 @@ describe('authentication edit source parser', () => {
 
             expect(result).toEqual([{
                 ...FIELDS_WITH_PASSWORD[0],
+                component: 'authentication',
                 name: createAuthFieldName(PASSWORD_NAME, ID),
-                isRequired: false,
-                validate: [],
-                helperText: expect.any(Object)
             }]);
         });
     });

--- a/src/utilities/SourcesFormRenderer.js
+++ b/src/utilities/SourcesFormRenderer.js
@@ -10,12 +10,15 @@ import componentMapper from '@data-driven-forms/pf4-component-mapper/dist/cjs/co
 
 import { mapperExtension } from '@redhat-cloud-services/frontend-components-sources/cjs/sourceFormRenderer';
 
+import Authentication from '../components/Authentication';
+
 const SourcesFormRenderer = props => (
     <FormRenderer
         FormTemplate={FormTemplate}
         componentMapper={{
             ...componentMapper,
             ...mapperExtension,
+            authentication: Authentication,
             'switch-field': componentMapper[componentTypes.SWITCH]
         }}
         validatorMapper={{


### PR DESCRIPTION
part of https://issues.redhat.com/browse/TPINVTRY-1089

- [x] Rebase after https://github.com/RedHatInsights/sources-ui/pull/419

Will show pre-filled `authentication.password` using placeholder dots

![passwordedit](https://user-images.githubusercontent.com/32869456/93450752-9f729d80-f8d6-11ea-84ed-86c8a8a8b076.gif)
