### PR TITLE
Refactor source remove to allow multiple deletions at once

### DIFF
--- a/src/components/SourcesTable/SourcesTable.js
+++ b/src/components/SourcesTable/SourcesTable.js
@@ -25,21 +25,23 @@ const itemToCells = (item, columns, sourceTypes, appTypes) =>
         : item[col.value] || '',
     }));
 
-const renderSources = (entities, columns, sourceTypes, appTypes) =>
+const renderSources = (entities, columns, sourceTypes, appTypes, removingSources) =>
   entities
     .filter(({ hidden }) => !hidden)
-    .reduce(
-      (acc, item) => [
+    .reduce((acc, item) => {
+      const isDeleting = removingSources.includes(item.id);
+
+      return [
         ...acc,
         {
           ...item,
           isOpen: !!item.expanded,
           cells: itemToCells(item, columns, sourceTypes, appTypes),
-          disableActions: !!item.isDeleting,
+          disableActions: isDeleting,
+          isDeleting,
         },
-      ],
-      []
-    );
+      ];
+    }, []);
 
 export const prepareColumnsCells = (columns) =>
   columns
@@ -126,6 +128,7 @@ const SourcesTable = () => {
     sortBy,
     sortDirection,
     numberOfEntities,
+    removingSources,
   } = useSelector(({ sources }) => sources, shallowEqual);
   const reduxDispatch = useDispatch();
 
@@ -145,7 +148,7 @@ const SourcesTable = () => {
     const columns = sourcesColumns(intl, notSortable);
 
     return dispatch({
-      rows: renderSources(entities, columns, sourceTypes, appTypes),
+      rows: renderSources(entities, columns, sourceTypes, appTypes, removingSources),
       cells: prepareColumnsCells(columns),
     });
   };
@@ -164,7 +167,7 @@ const SourcesTable = () => {
     if (state.isLoaded) {
       refreshSources();
     }
-  }, [entities]);
+  }, [entities, removingSources]);
 
   let shownRows = state.rows;
   if (numberOfEntities === 0 && state.isLoaded) {

--- a/src/redux/sources/reducer.js
+++ b/src/redux/sources/reducer.js
@@ -21,6 +21,7 @@ export const defaultSourcesState = {
   filterValue: {},
   sortBy: 'created_at',
   sortDirection: 'desc',
+  removingSources: [],
 };
 
 export const entitiesPending = (state, { options }) => ({
@@ -89,17 +90,18 @@ export const filterSources = (state, { payload: { value } }) => ({
 
 export const sourceEditRemovePending = (state, { meta }) => ({
   ...state,
-  entities: state.entities.map((entity) => (entity.id === meta.sourceId ? { ...entity, isDeleting: true } : entity)),
+  removingSources: [...state.removingSources, meta.sourceId],
 });
 
 export const sourceEditRemoveFulfilled = (state, { meta }) => ({
   ...state,
-  entities: state.entities.map((entity) => (entity.id === meta.sourceId ? undefined : entity)).filter((x) => x),
+  removingSources: state.removingSources.filter((id) => id !== meta.sourceId),
+  entities: state.entities.filter((entity) => entity.id !== meta.sourceId),
 });
 
 export const sourceEditRemoveRejected = (state, { meta }) => ({
   ...state,
-  entities: state.entities.map((entity) => (entity.id === meta.sourceId ? { ...entity, isDeleting: undefined } : entity)),
+  removingSources: state.removingSources.filter((id) => id !== meta.sourceId),
 });
 
 export const appRemovingPending = (state, { meta }) => ({

--- a/src/test/components/sourcesTable/SourcesTable.test.js
+++ b/src/test/components/sourcesTable/SourcesTable.test.js
@@ -74,13 +74,7 @@ describe('SourcesTable', () => {
       sources: {
         ...initialState.sources,
         ...loadedProps,
-        entities: [
-          {
-            ...sourcesDataGraphQl[0],
-            isDeleting: true,
-          },
-          ...sourcesDataGraphQl.slice(1),
-        ],
+        removingSources: [sourcesDataGraphQl[0].id],
       },
     };
 

--- a/src/test/redux/sources/reducer.test.js
+++ b/src/test/redux/sources/reducer.test.js
@@ -216,18 +216,16 @@ describe('redux > sources reducer', () => {
 
     it('pending marks source for deletion', () => {
       expect(sourcesReducer.sourceEditRemovePending(defaultState, payload)).toEqual({
-        ...defaultSourcesState,
-        entities: [
-          { id: '1235', name: 'do not remove this' },
-          { id: SOURCE_ID, name: 'delete this', isDeleting: true },
-        ],
+        ...defaultState,
+        removingSources: [SOURCE_ID],
       });
     });
 
     it('fullfiled deletes the source', () => {
-      expect(sourcesReducer.sourceEditRemoveFulfilled(defaultState, payload)).toEqual({
-        ...defaultSourcesState,
+      expect(sourcesReducer.sourceEditRemoveFulfilled({ ...defaultState, removingSources: [SOURCE_ID] }, payload)).toEqual({
+        ...defaultState,
         entities: [{ id: '1235', name: 'do not remove this' }],
+        removingSources: [],
       });
     });
 
@@ -240,12 +238,9 @@ describe('redux > sources reducer', () => {
         ],
       };
 
-      expect(sourcesReducer.sourceEditRemoveRejected(defaultState, payload)).toEqual({
-        ...defaultSourcesState,
-        entities: [
-          { id: '1235', name: 'do not remove this' },
-          { id: SOURCE_ID, name: 'delete this', isDeleting: undefined },
-        ],
+      expect(sourcesReducer.sourceEditRemoveRejected({ ...defaultState, removingSources: [SOURCE_ID] }, payload)).toEqual({
+        ...defaultState,
+        removingSources: [],
       });
     });
   });


### PR DESCRIPTION
Store removing sources in separate attribute to allow multiple deletions at once (before that, after refreshing the table all sources that were being removed were unflagged)