### PR TITLE
Refactor formatters to make code cleaner

### DIFF
--- a/src/api/doUpdateSource.js
+++ b/src/api/doUpdateSource.js
@@ -1,4 +1,4 @@
-import { defaultPort } from '../components/SourcesTable/formatters';
+import { defaultPort } from '../views/formatters';
 import { getSourcesApi } from './entities';
 import { patchCmValues } from './patchCmValues';
 

--- a/src/components/AddApplication/AddApplication.js
+++ b/src/components/AddApplication/AddApplication.js
@@ -22,7 +22,7 @@ import { getSourcesApi } from '../../api/entities';
 
 import { useSource } from '../../hooks/useSource';
 import { useIsLoaded } from '../../hooks/useIsLoaded';
-import { endpointToUrl } from '../SourcesTable/formatters';
+import { endpointToUrl } from '../../views/formatters';
 import { routes, replaceRouteId } from '../../Routes';
 
 import { doAttachApp } from '../../api/doAttachApp';

--- a/src/components/SourceEditForm/helpers.js
+++ b/src/components/SourceEditForm/helpers.js
@@ -1,7 +1,7 @@
 import get from 'lodash/get';
 import set from 'lodash/set';
 
-import { endpointToUrl } from '../SourcesTable/formatters';
+import { endpointToUrl } from '../../views/formatters';
 import { APP_NAMES } from './parser/application';
 
 export const selectOnlyEditedValues = (values, editing) => {

--- a/src/components/SourceEditForm/onSubmit.js
+++ b/src/components/SourceEditForm/onSubmit.js
@@ -6,7 +6,7 @@ import { checkSourceStatus } from '../../api/checkSourceStatus';
 import { doLoadSourceForEdit } from '../../api/doLoadSourceForEdit';
 import { doUpdateSource } from '../../api/doUpdateSource';
 
-import { UNAVAILABLE } from '../SourcesTable/formatters';
+import { UNAVAILABLE } from '../../views/formatters';
 
 export const onSubmit = async (values, editing, dispatch, source, intl, setState, hasCostManagement) => {
   setState({ type: 'submit', values, editing });

--- a/src/components/SourcesTable/SourcesTable.js
+++ b/src/components/SourcesTable/SourcesTable.js
@@ -5,7 +5,6 @@ import { Table, TableHeader, TableBody, sortable, wrappable } from '@patternfly/
 import { useIntl } from 'react-intl';
 
 import { sortEntities } from '../../redux/sources/actions';
-import { formatters } from './formatters';
 import { PlaceHolderTable, RowWrapperLoader } from './loaders';
 import { sourcesColumns, COLUMN_COUNT } from '../../views/sourcesViewDefinition';
 import EmptyStateTable from './EmptyStateTable';
@@ -18,7 +17,7 @@ const itemToCells = (item, columns, sourceTypes, appTypes) =>
     .filter((column) => column.title || column.hidden)
     .map((col) => ({
       title: col.formatter
-        ? formatters(col.formatter)(item[col.value], item, {
+        ? col.formatter(item[col.value], item, {
             sourceTypes,
             appTypes,
           })

--- a/src/test/components/sourceEditForm/onSubmit.test.js
+++ b/src/test/components/sourceEditForm/onSubmit.test.js
@@ -5,7 +5,7 @@ import * as doUpdateSource from '../../../api/doUpdateSource';
 import * as doLoadSourceForEdit from '../../../api/doLoadSourceForEdit';
 
 import * as getAppStatus from '@redhat-cloud-services/frontend-components-sources/cjs/getApplicationStatus';
-import { UNAVAILABLE, AVAILABLE } from '../../../components/SourcesTable/formatters';
+import { UNAVAILABLE, AVAILABLE } from '../../../views/formatters';
 
 describe('editSourceModal - on submit', () => {
   let VALUES;

--- a/src/test/views/formatters.test.js
+++ b/src/test/views/formatters.test.js
@@ -1,6 +1,4 @@
 import {
-  formatters,
-  defaultFormatter,
   nameFormatter,
   dateFormatter,
   sourceTypeFormatter,
@@ -22,15 +20,15 @@ import {
   UNAVAILABLE,
   UnknownError,
   getStatusColor,
-} from '../../../components/SourcesTable/formatters';
-import { sourceTypesData, OPENSHIFT_ID, AMAZON_ID, OPENSHIFT_INDEX } from '../../__mocks__/sourceTypesData';
+} from '../../views/formatters';
+import { sourceTypesData, OPENSHIFT_ID, AMAZON_ID, OPENSHIFT_INDEX } from '../__mocks__/sourceTypesData';
 import {
   sourcesDataGraphQl,
   SOURCE_CATALOGAPP_INDEX,
   SOURCE_ALL_APS_INDEX,
   SOURCE_NO_APS_INDEX,
   SOURCE_ENDPOINT_URL_INDEX,
-} from '../../__mocks__/sourcesData';
+} from '../__mocks__/sourcesData';
 import {
   applicationTypesData,
   CATALOG_INDEX,
@@ -38,57 +36,13 @@ import {
   COSTMANAGEMENET_INDEX,
   COSTMANAGEMENT_APP,
   CATALOG_APP,
-} from '../../__mocks__/applicationTypesData';
+} from '../__mocks__/applicationTypesData';
 import { Badge, Tooltip, Label } from '@patternfly/react-core';
 import { DateFormat } from '@redhat-cloud-services/frontend-components/components/cjs/DateFormat';
 import { IntlProvider } from 'react-intl';
 
 describe('formatters', () => {
   const wrapperWithIntl = (children) => <IntlProvider locale="en">{children}</IntlProvider>;
-
-  describe('formatters', () => {
-    it('returns nameFormatter', () => {
-      expect(formatters('nameFormatter')).toEqual(nameFormatter);
-    });
-
-    it('returns dateFormatter', () => {
-      expect(formatters('dateFormatter')).toEqual(dateFormatter);
-    });
-
-    it('returns sourceTypeFormatter', () => {
-      expect(formatters('sourceTypeFormatter')).toEqual(sourceTypeFormatter);
-    });
-
-    it('returns applicationFormatter', () => {
-      expect(formatters('applicationFormatter')).toEqual(applicationFormatter);
-    });
-
-    it('returns importedFormatter', () => {
-      expect(formatters('importedFormatter')).toEqual(importedFormatter);
-    });
-
-    it('returns availabilityFormatter', () => {
-      expect(formatters('availabilityFormatter')).toEqual(availabilityFormatter);
-    });
-
-    it('returns defaultFormatter when non-sense', () => {
-      const nonsenseFormatter = 'peknaKravina';
-      const value = 'some value';
-      expect(formatters(nonsenseFormatter)(value)).toEqual(`undefined ${nonsenseFormatter} formatter of value: ${value}`);
-    });
-  });
-
-  describe('defaultFormatter', () => {
-    it('returns string message', () => {
-      const VALUE = 'ahoj';
-      const NAME = 'dateFormatter';
-
-      const result = defaultFormatter(NAME)(VALUE);
-
-      expect(result.includes(NAME)).toEqual(true);
-      expect(result.includes(VALUE)).toEqual(true);
-    });
-  });
 
   describe('sourceIsOpenShift', () => {
     it('returns true when is openshift', () => {

--- a/src/views/formatters.js
+++ b/src/views/formatters.js
@@ -97,8 +97,6 @@ export const nameFormatter = (name, source, { sourceTypes }) => (
   </TextContent>
 );
 
-export const defaultFormatter = (name) => (value) => `undefined ${name} formatter of value: ${value}`;
-
 export const importedFormatter = (value) => {
   if (!value) {
     return null;
@@ -332,13 +330,3 @@ export const availabilityFormatter = (_status, source, { appTypes }) => {
     </TextContent>
   );
 };
-
-export const formatters = (name) =>
-  ({
-    nameFormatter,
-    dateFormatter,
-    applicationFormatter,
-    sourceTypeFormatter,
-    importedFormatter,
-    availabilityFormatter,
-  }[name] || defaultFormatter(name));

--- a/src/views/sourcesViewDefinition.js
+++ b/src/views/sourcesViewDefinition.js
@@ -1,3 +1,12 @@
+import {
+  applicationFormatter,
+  availabilityFormatter,
+  dateFormatter,
+  importedFormatter,
+  nameFormatter,
+  sourceTypeFormatter,
+} from './formatters';
+
 export const sourcesColumns = (intl, notSortable = false) => [
   {
     title: intl.formatMessage({
@@ -5,7 +14,7 @@ export const sourcesColumns = (intl, notSortable = false) => [
       defaultMessage: 'Name',
     }),
     value: 'name',
-    formatter: 'nameFormatter',
+    formatter: nameFormatter,
     sortable: !notSortable,
   },
   {
@@ -14,7 +23,7 @@ export const sourcesColumns = (intl, notSortable = false) => [
       defaultMessage: 'Type',
     }),
     value: 'source_type_id',
-    formatter: 'sourceTypeFormatter',
+    formatter: sourceTypeFormatter,
     sortable: !notSortable,
   },
   {
@@ -23,7 +32,7 @@ export const sourcesColumns = (intl, notSortable = false) => [
       defaultMessage: 'Applications',
     }),
     value: 'applications',
-    formatter: 'applicationFormatter',
+    formatter: applicationFormatter,
   },
   {
     title: intl.formatMessage({
@@ -31,13 +40,13 @@ export const sourcesColumns = (intl, notSortable = false) => [
       defaultMessage: 'Date added',
     }),
     value: 'created_at',
-    formatter: 'dateFormatter',
+    formatter: dateFormatter,
     sortable: !notSortable,
   },
   {
     hidden: true,
     value: 'imported',
-    formatter: 'importedFormatter',
+    formatter: importedFormatter,
   },
   {
     title: intl.formatMessage({
@@ -45,7 +54,7 @@ export const sourcesColumns = (intl, notSortable = false) => [
       defaultMessage: 'Status',
     }),
     value: 'availability_status',
-    formatter: 'availabilityFormatter',
+    formatter: availabilityFormatter,
   },
 ];
 


### PR DESCRIPTION
Just small refactoring to make using of `formatters` more understable