### PR TITLE
Set initial warning messages in source edit

### DIFF
--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -204,6 +204,7 @@ export const doLoadApplicationsForEdit = (id) =>
             { applications {
                 application_type_id,
                 id,
+                availability_status_error,
                 authentications {
                     id
                 }

--- a/src/components/SourceEditForm/SourceEditModal.js
+++ b/src/components/SourceEditForm/SourceEditModal.js
@@ -15,7 +15,7 @@ import { useIsLoaded } from '../../hooks/useIsLoaded';
 import reducer, { initialState } from './reducer';
 import SubmittingModal from './SubmittingModal';
 import ErroredModal from './ErroredModal';
-import { hasCostManagement } from './helpers';
+import { hasCostManagement, prepareMessages } from './helpers';
 
 const SourceEditModal = () => {
   const [state, setState] = useReducer(reducer, initialState);
@@ -51,7 +51,9 @@ const SourceEditModal = () => {
   useEffect(() => {
     if (sourceRedux && initialLoad && appTypesLoaded) {
       doLoadSourceForEdit(sourceRedux, hasCostManagement(sourceRedux, appTypes)).then((source) => {
-        setState({ type: 'setSource', source });
+        const messages = prepareMessages(source, intl);
+
+        setState({ type: 'setSource', source, messages });
       });
     }
   }, [sourceRedux, isLoaded, appTypesLoaded, initialLoad]);

--- a/src/components/SourceEditForm/helpers.js
+++ b/src/components/SourceEditForm/helpers.js
@@ -105,3 +105,39 @@ export const getEditedApplications = (source, editing, appTypes) => {
 
   return editedApplications.filter(Boolean);
 };
+
+export const prepareMessages = (source, intl) => {
+  const messages = {};
+
+  source.applications.forEach(({ id, availability_status_error }) => {
+    if (availability_status_error) {
+      messages[id] = {
+        title: intl.formatMessage({
+          id: 'wizard.failEditToastTitleBeforeEdit',
+          defaultMessage: 'This application is unavailable',
+        }),
+        description: availability_status_error,
+        variant: 'danger',
+      };
+    }
+  });
+
+  if (source.endpoints?.[0]?.availability_status_error) {
+    const applicationsUsingEndpoint = source.applications
+      .map((app) => (app.authentications.find(({ resource_type }) => resource_type === 'Endpoint') ? app.id : undefined))
+      .filter(Boolean);
+
+    applicationsUsingEndpoint.forEach((id) => {
+      messages[id] = {
+        title: intl.formatMessage({
+          id: 'wizard.failEditToastTitleBeforeEdit',
+          defaultMessage: 'This application is unavailable',
+        }),
+        description: source.endpoints?.[0]?.availability_status_error,
+        variant: 'danger',
+      };
+    });
+  }
+
+  return messages;
+};

--- a/src/components/SourceEditForm/onSubmit.js
+++ b/src/components/SourceEditForm/onSubmit.js
@@ -5,7 +5,7 @@ import { loadEntities } from '../../redux/sources/actions';
 import { checkSourceStatus } from '../../api/checkSourceStatus';
 import { doUpdateSource } from '../../api/doUpdateSource';
 
-import { UNAVAILABLE } from '../../views/formatters';
+import { AVAILABLE, UNAVAILABLE } from '../../views/formatters';
 
 export const onSubmit = async (values, editing, dispatch, source, intl, setState, appTypes) => {
   setState({ type: 'submit', values, editing });
@@ -23,7 +23,6 @@ export const onSubmit = async (values, editing, dispatch, source, intl, setState
 
   checkSourceStatus(source.source.id);
 
-  let message = {};
   let messages = {};
 
   const checkApplications = getEditedApplications(source, editing, appTypes);
@@ -54,11 +53,22 @@ export const onSubmit = async (values, editing, dispatch, source, intl, setState
     }
 
     statusResults.forEach(({ availability_status, availability_status_error, id }) => {
+      if (availability_status === AVAILABLE) {
+        messages[id] = {
+          title: intl.formatMessage({
+            id: 'wizard.successEditToastTitle',
+            defaultMessage: 'Application credentials were edited successfully.',
+          }),
+          description: availability_status_error,
+          variant: 'success',
+        };
+      }
+
       if (availability_status === UNAVAILABLE) {
         messages[id] = {
           title: intl.formatMessage({
             id: 'wizard.failEditToastTitle',
-            defaultMessage: 'Edit application credentials failed',
+            defaultMessage: 'Edit application credentials failed.',
           }),
           description: availability_status_error,
           variant: 'danger',
@@ -82,19 +92,6 @@ export const onSubmit = async (values, editing, dispatch, source, intl, setState
     });
   }
 
-  if (Object.keys(message).length === 0 && Object.keys(messages).length === 0) {
-    message = {
-      title: intl.formatMessage(
-        {
-          id: 'wizard.successEditToastTitle',
-          defaultMessage: 'Source ‘{name}’ was edited successfully.',
-        },
-        { name: source.source.name }
-      ),
-      variant: 'success',
-    };
-  }
-
   await dispatch(loadEntities());
-  setState({ type: 'submitFinished', message, messages });
+  setState({ type: 'submitFinished', messages });
 };

--- a/src/components/SourceEditForm/parser/parseSourceToSchema.js
+++ b/src/components/SourceEditForm/parser/parseSourceToSchema.js
@@ -1,6 +1,5 @@
 import { endpointFields } from './endpoint';
 import { applicationsFields } from './application';
-import EditAlert from './EditAlert';
 
 export const parseSourceToSchema = (source, sourceType, appTypes, intl) => ({
   description: intl.formatMessage({
@@ -8,15 +7,6 @@ export const parseSourceToSchema = (source, sourceType, appTypes, intl) => ({
     defaultMessage: 'Use the form fields to edit application credentials.',
   }),
   fields: [
-    {
-      name: 'message',
-      component: 'description',
-      Content: EditAlert,
-      condition: {
-        when: 'message',
-        isNotEmpty: true,
-      },
-    },
     ...applicationsFields(source.applications, sourceType, appTypes),
     source.endpoints && source.endpoints.length > 0 ? endpointFields(sourceType) : false,
   ].filter(Boolean),

--- a/src/components/SourceEditForm/reducer.js
+++ b/src/components/SourceEditForm/reducer.js
@@ -12,7 +12,7 @@ export const initialState = {
   submitError: false,
 };
 
-const reducer = (state, { type, source, sourceType, appTypes, intl, message, values, editing, messages }) => {
+const reducer = (state, { type, source, sourceType, appTypes, intl, values, editing, messages }) => {
   switch (type) {
     case 'createForm':
       return {
@@ -25,6 +25,10 @@ const reducer = (state, { type, source, sourceType, appTypes, intl, message, val
     case 'setSource':
       return {
         ...state,
+        messages: {
+          ...messages,
+          ...state.messages,
+        },
         source,
         initialLoad: false,
       };
@@ -41,7 +45,6 @@ const reducer = (state, { type, source, sourceType, appTypes, intl, message, val
         ...state,
         isSubmitting: false,
         source,
-        message,
         messages,
       };
     case 'submitFailed':
@@ -49,7 +52,6 @@ const reducer = (state, { type, source, sourceType, appTypes, intl, message, val
         ...state,
         isSubmitting: false,
         submitError: true,
-        message: undefined,
         messages: undefined,
       };
     case 'sourceChanged':

--- a/src/test/components/sourceEditForm/helpers.test.js
+++ b/src/test/components/sourceEditForm/helpers.test.js
@@ -1,4 +1,9 @@
-import { getEditedApplications, prepareInitialValues, selectOnlyEditedValues } from '../../../components/SourceEditForm/helpers';
+import {
+  getEditedApplications,
+  prepareInitialValues,
+  prepareMessages,
+  selectOnlyEditedValues,
+} from '../../../components/SourceEditForm/helpers';
 import applicationTypesData, { COSTMANAGEMENT_APP } from '../../__mocks__/applicationTypesData';
 
 describe('edit form helpers', () => {
@@ -286,6 +291,58 @@ describe('edit form helpers', () => {
       };
 
       expect(getEditedApplications(source, edited, appTypes)).toEqual(['456']);
+    });
+  });
+
+  describe('prepareMessages', () => {
+    let source;
+    let intl = { formatMessage: ({ defaultMessage }) => defaultMessage };
+
+    it('prepare application messages', () => {
+      source = {
+        applications: [
+          { id: 'app1', availability_status_error: 'some error' },
+          { id: 'app2' },
+          { id: 'app3', availability_status_error: 'some error 3' },
+        ],
+      };
+
+      expect(prepareMessages(source, intl)).toEqual({
+        app1: {
+          description: 'some error',
+          title: 'This application is unavailable',
+          variant: 'danger',
+        },
+        app3: {
+          description: 'some error 3',
+          title: 'This application is unavailable',
+          variant: 'danger',
+        },
+      });
+    });
+
+    it('prepare endpoint messages', () => {
+      source = {
+        applications: [
+          { id: 'app1', authentications: [{ resource_type: 'Endpoint' }] },
+          { id: 'app2', authentications: [] },
+          { id: 'app3', authentications: [{ resource_type: 'Endpoint' }] },
+        ],
+        endpoints: [{ availability_status_error: 'endpoint error' }],
+      };
+
+      expect(prepareMessages(source, intl)).toEqual({
+        app1: {
+          description: 'endpoint error',
+          title: 'This application is unavailable',
+          variant: 'danger',
+        },
+        app3: {
+          description: 'endpoint error',
+          title: 'This application is unavailable',
+          variant: 'danger',
+        },
+      });
     });
   });
 });

--- a/src/test/components/sourceEditForm/onSubmit.test.js
+++ b/src/test/components/sourceEditForm/onSubmit.test.js
@@ -45,35 +45,6 @@ describe('editSourceModal - on submit', () => {
     actions.loadEntities = jest.fn();
   });
 
-  it('submit values successfuly with cost management', async () => {
-    doUpdateSource.doUpdateSource = jest.fn().mockImplementation(() => Promise.resolve('OK'));
-
-    const FILTERED_VALUES = {
-      source: {
-        type: 'openshift',
-      },
-    };
-
-    await onSubmit(VALUES, EDITING, DISPATCH, SOURCE, INTL, SET_STATE, APP_TYPES);
-
-    expect(doUpdateSource.doUpdateSource).toHaveBeenCalledWith(SOURCE, FILTERED_VALUES);
-    expect(SET_STATE.mock.calls[0][0]).toEqual({
-      type: 'submit',
-      values: VALUES,
-      editing: EDITING,
-    });
-    expect(actions.loadEntities).toHaveBeenCalled();
-    expect(checkSourceStatus.checkSourceStatus).toHaveBeenCalledWith('2342');
-    expect(SET_STATE.mock.calls[1][0]).toEqual({
-      type: 'submitFinished',
-      messages: {},
-      message: {
-        variant: 'success',
-        title: 'Source ‘{name}’ was edited successfully.',
-      },
-    });
-  });
-
   it('checks endpoint availability', async () => {
     doUpdateSource.doUpdateSource = jest.fn().mockImplementation(() => Promise.resolve('OK'));
 
@@ -118,10 +89,11 @@ describe('editSourceModal - on submit', () => {
     expect(checkSourceStatus.checkSourceStatus).toHaveBeenCalledWith('2342');
     expect(SET_STATE.mock.calls[1][0]).toEqual({
       type: 'submitFinished',
-      messages: {},
-      message: {
-        variant: 'success',
-        title: 'Source ‘{name}’ was edited successfully.',
+      messages: {
+        123: {
+          variant: 'success',
+          title: 'Application credentials were edited successfully.',
+        },
       },
     });
     expect(getAppStatus.checkAppAvailability).toHaveBeenCalledWith(
@@ -247,11 +219,10 @@ describe('editSourceModal - on submit', () => {
     );
     expect(SET_STATE.mock.calls[1][0]).toEqual({
       type: 'submitFinished',
-      message: {},
       messages: {
         'application-id': {
           variant: 'danger',
-          title: 'Edit application credentials failed',
+          title: 'Edit application credentials failed.',
           description: APP_ERROR,
         },
       },
@@ -266,6 +237,7 @@ describe('editSourceModal - on submit', () => {
       .mockImplementationOnce(() =>
         Promise.resolve({
           availability_status: AVAILABLE,
+          id: 'application-id-1',
         })
       )
       .mockImplementationOnce(() =>
@@ -316,11 +288,14 @@ describe('editSourceModal - on submit', () => {
     expect(getAppStatus.checkAppAvailability.mock.calls[1][0]).toEqual('application-id-2');
     expect(SET_STATE.mock.calls[1][0]).toEqual({
       type: 'submitFinished',
-      message: {},
       messages: {
+        'application-id-1': {
+          variant: 'success',
+          title: 'Application credentials were edited successfully.',
+        },
         'application-id-2': {
           variant: 'danger',
-          title: 'Edit application credentials failed',
+          title: 'Edit application credentials failed.',
           description: APP_ERROR,
         },
       },
@@ -382,11 +357,10 @@ describe('editSourceModal - on submit', () => {
       messages: {
         'application-id': {
           variant: 'danger',
-          title: 'Edit application credentials failed',
+          title: 'Edit application credentials failed.',
           description: ERROR,
         },
       },
-      message: {},
     });
   });
 
@@ -438,7 +412,6 @@ describe('editSourceModal - on submit', () => {
     );
     expect(SET_STATE.mock.calls[1][0]).toEqual({
       type: 'submitFinished',
-      message: {},
       messages: {
         'application-id': {
           variant: 'warning',
@@ -453,6 +426,7 @@ describe('editSourceModal - on submit', () => {
   it('check app availablity status - available', async () => {
     getAppStatus.checkAppAvailability = jest.fn().mockImplementation(() =>
       Promise.resolve({
+        id: 'application-id',
         availability_status: AVAILABLE,
       })
     );
@@ -497,10 +471,11 @@ describe('editSourceModal - on submit', () => {
     );
     expect(SET_STATE.mock.calls[1][0]).toEqual({
       type: 'submitFinished',
-      messages: {},
-      message: {
-        variant: 'success',
-        title: 'Source ‘{name}’ was edited successfully.',
+      messages: {
+        'application-id': {
+          variant: 'success',
+          title: 'Application credentials were edited successfully.',
+        },
       },
     });
   });

--- a/src/test/components/sourceEditForm/parser/parseSourceToSchema.test.js
+++ b/src/test/components/sourceEditForm/parser/parseSourceToSchema.test.js
@@ -86,17 +86,7 @@ describe('parseSourceToSchema', () => {
     const result = parseSourceToSchema(SOURCE, SOURCE_TYPE, APP_TYPES, INTL);
 
     expect(result).toEqual({
-      fields: [
-        {
-          name: 'message',
-          component: 'description',
-          Content: expect.any(Function),
-          condition: {
-            when: 'message',
-            isNotEmpty: true,
-          },
-        },
-      ],
+      fields: [],
     });
   });
 });


### PR DESCRIPTION
Source Edit form gets messages set from the status

**After**

![image](https://user-images.githubusercontent.com/32869456/101026973-d2dcd400-3577-11eb-9c27-d731f47f7edc.png)
![initialMessages](https://user-images.githubusercontent.com/32869456/101026987-d6705b00-3577-11eb-9f6f-803c83b238f0.gif)
