### PR TITLE
Add helper functions to dev store

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This application allows to
 - [Running locally](#running-locally)
 - [Build app](#build-app)
   - [With locally linked Sources Wizard package](#with-locally-linked-sources-wizard-package)
+  - [Debug functions](#debug-functions)
   - [Testing](#testing)
 - [Patternfly](#patternfly)
 - [Data-driven forms](#data-driven-forms)
@@ -66,6 +67,28 @@ If you linked Sources Wizard package via npm link, run the application with a fo
 - ```npm run start:link```
 
 This command ensures that the application and the package is using the same node_modules folder and it prevents any conflicts between various React instancies.
+
+## Debug functions
+
+Sources UI provides easy way how to test different states of the application when running in dev environment.
+
+Run from the console one of following commands:
+
+- ```sourcesDebug.showEmptyState```
+
+Sets number of currently loaded sources to 0. Shows empty state.
+
+- ```sourcesDebug.setCount```
+
+Changes number of sources to a value you need.
+
+- ```sourcesDebug.removePermissions```
+
+Removes write permissions.
+
+- ```sourcesDebug.setPermissions```
+
+Grants write permissions.
 
 ## Testing
 

--- a/src/test/utilities/store.test.js
+++ b/src/test/utilities/store.test.js
@@ -13,9 +13,39 @@ describe('store creator', () => {
   };
 
   it('creates DevStore', () => {
+    const tmp = console.log;
+    const tmpGroup = console.group;
+    console.log = jest.fn();
+    console.group = jest.fn();
+
+    expect(window.sourcesDebug).toEqual(undefined);
+
     const store = getDevStore();
 
     expect(store.getState()).toEqual(EXPECTED_DEFAULT_STATE);
+
+    expect(window.sourcesDebug).toEqual({
+      showEmptyState: expect.any(Function),
+      removePermissions: expect.any(Function),
+      setCount: expect.any(Function),
+      setPermissions: expect.any(Function),
+    });
+
+    window.sourcesDebug.setCount(12);
+    expect(store.getState().sources.numberOfEntities).toEqual(12);
+
+    window.sourcesDebug.showEmptyState();
+    expect(store.getState().sources.numberOfEntities).toEqual(0);
+
+    window.sourcesDebug.setPermissions();
+    expect(store.getState().user.isOrgAdmin).toEqual(true);
+
+    window.sourcesDebug.removePermissions();
+    expect(store.getState().user.isOrgAdmin).toEqual(false);
+
+    window.sourcesDebug = {};
+    console.log = tmp;
+    console.group = tmpGroup;
   });
 
   it('creates ProdStore', () => {

--- a/src/utilities/getDevStore.js
+++ b/src/utilities/getDevStore.js
@@ -1,4 +1,39 @@
 import { logger } from 'redux-logger';
+
+import { SET_COUNT } from '../redux/sources/actionTypes';
+import { ACTION_TYPES } from '../redux/user/actionTypes';
 import { getStore } from './store';
 
-export const getDevStore = () => getStore([logger]);
+export const getDevStore = () => {
+  const store = getStore([logger]);
+
+  const removePermissions = () => {
+    store.dispatch({ type: ACTION_TYPES.SET_ORG_ADMIN_FULFILLED, payload: false });
+    store.dispatch({ type: ACTION_TYPES.SET_WRITE_PERMISSIONS_FULFILLED, payload: false });
+  };
+
+  const setPermissions = () => {
+    store.dispatch({ type: ACTION_TYPES.SET_ORG_ADMIN_FULFILLED, payload: true });
+  };
+
+  const setCount = (count) =>
+    store.dispatch({
+      type: SET_COUNT,
+      payload: { count },
+    });
+
+  window.sourcesDebug = {};
+  window.sourcesDebug.showEmptyState = () => setCount(0);
+  window.sourcesDebug.removePermissions = removePermissions;
+  window.sourcesDebug.setCount = setCount;
+  window.sourcesDebug.setPermissions = setPermissions;
+
+  console.log('%cYou are using DEV version of Sources.', 'color: red; background: yellow');
+  console.log('%cYou can call several functions from console:', 'color: red; background: yellow');
+  console.log('%c  - sourcesDebug.showEmptyState', 'color: red; background: yellow');
+  console.log('%c  - sourcesDebug.changeCount', 'color: red; background: yellow');
+  console.log('%c  - sourcesDebug.removePermissions', 'color: red; background: yellow');
+  console.log('%c  - sourcesDebug.setPermissions', 'color: red; background: yellow');
+
+  return store;
+};


### PR DESCRIPTION
This PR adds several functions to global window to ease development.

**DEV STORE IS NOT BUNDLED IN PROD** (and these functions are nothing users can access anyway..)

![debughelper](https://user-images.githubusercontent.com/32869456/104017107-cb809a00-51b7-11eb-8bff-556b94a0ac0a.gif)
