### PR TITLE
Show only enabled CloudTypes in empty state

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -5,6 +5,7 @@ webpackConfig.devServer = {
   port: 8002,
   contentBase: config.paths.public,
   historyApiFallback: true,
+  disableHostCheck: true,
 };
 
 module.exports = {

--- a/src/components/CloudTiles/CloudTiles.js
+++ b/src/components/CloudTiles/CloudTiles.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useHistory } from 'react-router-dom';
+import { shallowEqual, useSelector } from 'react-redux';
 import { routes } from '../../Routes';
 
 import { Tile } from '@patternfly/react-core/dist/esm/components/Tile/Tile';
@@ -9,21 +10,12 @@ import ImageWithPlaceholder from '../TilesShared/ImageWithPlaceholder';
 import { useHasWritePermissions } from '../../hooks/useHasWritePermissions';
 import DisabledTile from '../TilesShared/DisabledTile';
 
-const CloudTiles = ({ setSelectedType }) => {
-  const { push } = useHistory();
-  const hasWritePermissions = useHasWritePermissions();
-
-  const openWizard = (type) => {
-    setSelectedType(type);
-    push(routes.sourcesNew.path);
-  };
-
-  const TileComponent = hasWritePermissions ? Tile : DisabledTile;
-
-  return (
-    <React.Fragment>
+const mapper = (type, openWizard, TileComponent) =>
+  ({
+    amazon: (
       <TileComponent
         isStacked
+        key={type}
         title="Amazon Web Services"
         onClick={() => openWizard('amazon')}
         className="tile pf-u-mr-md-on-md pf-u-mt-md pf-u-mt-0-on-md"
@@ -35,8 +27,11 @@ const CloudTiles = ({ setSelectedType }) => {
           />
         }
       />
+    ),
+    google: (
       <TileComponent
         isStacked
+        key={type}
         title="Google Cloud"
         className="tile pf-u-mr-md-on-md pf-u-mt-md pf-u-mt-0-on-md"
         onClick={() => openWizard('google')}
@@ -48,8 +43,11 @@ const CloudTiles = ({ setSelectedType }) => {
           />
         }
       />
+    ),
+    azure: (
       <TileComponent
         isStacked
+        key={type}
         title="Microsoft Azure"
         onClick={() => openWizard('azure')}
         className="tile pf-u-mr-md-on-md pf-u-mt-md pf-u-mt-0-on-md"
@@ -61,8 +59,24 @@ const CloudTiles = ({ setSelectedType }) => {
           />
         }
       />
-    </React.Fragment>
-  );
+    ),
+  }[type]);
+
+const CloudTiles = ({ setSelectedType }) => {
+  const { sourceTypes } = useSelector(({ sources }) => sources, shallowEqual);
+  const { push } = useHistory();
+  const hasWritePermissions = useHasWritePermissions();
+
+  const openWizard = (type) => {
+    setSelectedType(type);
+    push(routes.sourcesNew.path);
+  };
+
+  const TileComponent = hasWritePermissions ? Tile : DisabledTile;
+
+  return sourceTypes
+    .sort((a, b) => a.product_name.localeCompare(b.product_name))
+    .map(({ name }) => mapper(name, openWizard, TileComponent));
 };
 
 CloudTiles.propTypes = {

--- a/src/test/__mocks__/sourceTypesData.js
+++ b/src/test/__mocks__/sourceTypesData.js
@@ -437,4 +437,47 @@ export const AMAZON = sourceTypesData.data[AMAZON_INDEX];
 export const ANSIBLE_TOWER = sourceTypesData.data[ANSIBLE_TOWER_INDEX];
 export const SATELLITE = sourceTypesData.data[SATELLITE_INDEX];
 
+export const googleType = {
+  created_at: '2021-01-22T16:53:04Z',
+  icon_url: '/apps/frontend-assets/partners-icons/google-cloud.svg',
+  id: '10',
+  name: 'google',
+  product_name: 'Google Cloud',
+  schema: {
+    endpoint: {
+      fields: [
+        { name: 'endpoint.role', component: 'text-field', hideField: true, initialValue: 'google', initializeOnMount: true },
+      ],
+      hidden: true,
+    },
+    authentication: [
+      {
+        name: 'Project ID and Service Account JSON',
+        type: 'project_id_service_account_json',
+        fields: [
+          {
+            name: 'authentication.authtype',
+            component: 'text-field',
+            hideField: true,
+            initialValue: 'project_id_service_account_json',
+            initializeOnMount: true,
+          },
+          { name: 'authentication.username', label: 'Project ID', component: 'text-field' },
+          { name: 'authentication.password', label: 'Service Account JSON', component: 'textarea' },
+          {
+            name: 'application.extra.dataset',
+            label: 'Dataset name',
+            stepKey: 'cost-management',
+            validate: [{ type: 'required' }],
+            component: 'text-field',
+            isRequired: true,
+          },
+        ],
+      },
+    ],
+  },
+  updated_at: '2021-01-22T16:53:04Z',
+  vendor: 'Google',
+};
+
 export default sourceTypesData;

--- a/src/test/components/cloudTiles/CloudEmptyState.test.js
+++ b/src/test/components/cloudTiles/CloudEmptyState.test.js
@@ -9,6 +9,7 @@ import componentWrapperIntl from '../../../utilities/testsHelpers';
 import CloudEmptyState from '../../../components/CloudTiles/CloudEmptyState';
 import CloudTiles from '../../../components/CloudTiles/CloudTiles';
 import mockStore from '../../__mocks__/mockStore';
+import sourceTypes, { googleType } from '../../__mocks__/sourceTypesData';
 
 describe('CloudEmptyState', () => {
   let wrapper;
@@ -23,7 +24,7 @@ describe('CloudEmptyState', () => {
       setSelectedType,
     };
 
-    store = mockStore({ user: { isOrgAdmin: true } });
+    store = mockStore({ user: { isOrgAdmin: true }, sources: { sourceTypes: [...sourceTypes.data, googleType] } });
   });
 
   it('renders correctly', async () => {

--- a/src/test/components/cloudTiles/CloudTiles.test.js
+++ b/src/test/components/cloudTiles/CloudTiles.test.js
@@ -9,6 +9,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { routes } from '../../../Routes';
 import CloudTiles from '../../../components/CloudTiles/CloudTiles';
 import mockStore from '../../__mocks__/mockStore';
+import sourceTypes, { googleType } from '../../__mocks__/sourceTypesData';
 
 describe('CloudTiles', () => {
   let wrapper;
@@ -23,7 +24,7 @@ describe('CloudTiles', () => {
       setSelectedType,
     };
 
-    store = mockStore({ user: { isOrgAdmin: true } });
+    store = mockStore({ user: { isOrgAdmin: true }, sources: { sourceTypes: [...sourceTypes.data, googleType] } });
   });
 
   it('renders correctly', async () => {
@@ -42,7 +43,7 @@ describe('CloudTiles', () => {
   });
 
   it('renders correctly when no permissions', async () => {
-    store = mockStore({ user: { isOrgAdmin: false } });
+    store = mockStore({ user: { isOrgAdmin: false }, sources: { sourceTypes: [...sourceTypes.data, googleType] } });
 
     await act(async () => {
       wrapper = mount(componentWrapperIntl(<CloudTiles {...initialProps} />, store));


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-12385

Generate empty state from available source types. Should prevent showing types that are not in DB.