### PR TITLE
Add default API path when it's undefined

### DIFF
--- a/src/api/constants.js
+++ b/src/api/constants.js
@@ -1,2 +1,2 @@
-export const COST_MANAGEMENT_API_BASE = `${process.env.BASE_PATH}/cost-management/v1`;
-export const SOURCES_API_BASE_V3 = `${process.env.BASE_PATH}/sources/v3.0`;
+export const COST_MANAGEMENT_API_BASE = `${process.env.BASE_PATH || '/api'}/cost-management/v1`;
+export const SOURCES_API_BASE_V3 = `${process.env.BASE_PATH || '/api'}/sources/v3.0`;


### PR DESCRIPTION
The variable is no longer used in config.