### PR TITLE
Run production build after test

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "lint": "npm-run-all lint:*",
     "lint:js": "eslint config src",
     "server:ctr": "node src/server/generateServerKey.js",
-    "travis:verify": "NODE_ENV=production npm-run-all build:prod lint test",
+    "travis:verify": "npm-run-all lint test build:prod",
     "verify": "npm-run-all build lint test",
     "extract:messages": "npx @formatjs/cli extract 'src/**/*.{js,jsx}' --out-file ./translations/messages.json",
     "prod": "NODE_ENV=production webpack serve --config config/dev.webpack.config.js",


### PR DESCRIPTION
- tests do not like running in production env
- remove warnings from tests in CI

```jsx
  console.error
      act(...) is not supported in production builds of React, and might not behave as expected.
```