### PR TITLE
Build Red Hat types selection based on DB data

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -162,6 +162,10 @@
     .provider-icon {
       opacity: 0.5;
     }
+
+    .redhat-icon {
+      opacity: 0.5;
+    }
   }
 }
 

--- a/src/components/CloudTiles/CloudTiles.js
+++ b/src/components/CloudTiles/CloudTiles.js
@@ -1,14 +1,6 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { useHistory } from 'react-router-dom';
-import { shallowEqual, useSelector } from 'react-redux';
-import { routes } from '../../Routes';
-
-import { Tile } from '@patternfly/react-core/dist/esm/components/Tile/Tile';
-
 import ImageWithPlaceholder from '../TilesShared/ImageWithPlaceholder';
-import { useHasWritePermissions } from '../../hooks/useHasWritePermissions';
-import DisabledTile from '../TilesShared/DisabledTile';
+import TilesArray from '../TilesShared/TilesArray';
 
 const mapper = (type, openWizard, TileComponent) =>
   ({
@@ -37,7 +29,7 @@ const mapper = (type, openWizard, TileComponent) =>
         onClick={() => openWizard('google')}
         icon={
           <ImageWithPlaceholder
-            className="provider-icon pf-u-mb-sm disabled-icon"
+            className="provider-icon pf-u-mb-sm"
             src="/apps/frontend-assets/partners-icons/google-cloud-short.svg"
             alt="google logo"
           />
@@ -62,25 +54,6 @@ const mapper = (type, openWizard, TileComponent) =>
     ),
   }[type]);
 
-const CloudTiles = ({ setSelectedType }) => {
-  const { sourceTypes } = useSelector(({ sources }) => sources, shallowEqual);
-  const { push } = useHistory();
-  const hasWritePermissions = useHasWritePermissions();
-
-  const openWizard = (type) => {
-    setSelectedType(type);
-    push(routes.sourcesNew.path);
-  };
-
-  const TileComponent = hasWritePermissions ? Tile : DisabledTile;
-
-  return sourceTypes
-    .sort((a, b) => a.product_name.localeCompare(b.product_name))
-    .map(({ name }) => mapper(name, openWizard, TileComponent));
-};
-
-CloudTiles.propTypes = {
-  setSelectedType: PropTypes.func.isRequired,
-};
+const CloudTiles = (props) => <TilesArray {...props} mapper={mapper} />;
 
 export default CloudTiles;

--- a/src/components/RedHatTiles/RedHatTiles.js
+++ b/src/components/RedHatTiles/RedHatTiles.js
@@ -1,51 +1,36 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { useHistory } from 'react-router-dom';
-import { routes } from '../../Routes';
-
-import { Tile } from '@patternfly/react-core/dist/esm/components/Tile/Tile';
 
 import ImageWithPlaceholder from '../TilesShared/ImageWithPlaceholder';
-import { useHasWritePermissions } from '../../hooks/useHasWritePermissions';
-import DisabledTile from '../TilesShared/DisabledTile';
+import TilesArray from '../TilesShared/TilesArray';
 
-const RedHatTiles = ({ setSelectedType }) => {
-  const { push } = useHistory();
-  const hasWritePermissions = useHasWritePermissions();
+const icon = (
+  <ImageWithPlaceholder className="redhat-icon" src="/apps/frontend-assets/red-hat-logos/stacked.svg" alt="red hat logo" />
+);
 
-  const openWizard = (type) => {
-    setSelectedType(type);
-    push(routes.sourcesNew.path);
-  };
-
-  const TileComponent = hasWritePermissions ? Tile : DisabledTile;
-
-  const icon = (
-    <ImageWithPlaceholder className="redhat-icon" src="/apps/frontend-assets/red-hat-logos/stacked.svg" alt="red hat logo" />
-  );
-
-  return (
-    <React.Fragment>
+const mapper = (type, openWizard, TileComponent) =>
+  ({
+    ['ansible-tower']: (
       <TileComponent
         isStacked
+        key={type}
         title="Ansible Automation Platform"
         onClick={() => openWizard('ansible-tower')}
         className="tile pf-u-mr-md-on-md pf-u-mt-md pf-u-mt-0-on-md"
         icon={icon}
       />
+    ),
+    openshift: (
       <TileComponent
         isStacked
+        key={type}
         title="OpenShift Container Platfrom"
         className="tile pf-u-mr-md-on-md pf-u-mt-md pf-u-mt-0-on-md"
         onClick={() => openWizard('openshift')}
         icon={icon}
       />
-    </React.Fragment>
-  );
-};
+    ),
+  }[type]);
 
-RedHatTiles.propTypes = {
-  setSelectedType: PropTypes.func.isRequired,
-};
+const RedHatTiles = (props) => <TilesArray {...props} mapper={mapper} />;
 
 export default RedHatTiles;

--- a/src/components/TilesShared/TilesArray.js
+++ b/src/components/TilesShared/TilesArray.js
@@ -1,0 +1,35 @@
+import PropTypes from 'prop-types';
+import { useHistory } from 'react-router-dom';
+import { shallowEqual, useSelector } from 'react-redux';
+import { routes } from '../../Routes';
+
+import { Tile } from '@patternfly/react-core/dist/esm/components/Tile/Tile';
+
+import { useHasWritePermissions } from '../../hooks/useHasWritePermissions';
+import DisabledTile from '../TilesShared/DisabledTile';
+import { filterVendorTypes } from '../../addSourceWizard/utilities/filterTypes';
+
+const TilesArray = ({ setSelectedType, mapper }) => {
+  const sourceTypes = useSelector(({ sources }) => sources.sourceTypes, shallowEqual);
+  const { push } = useHistory();
+  const hasWritePermissions = useHasWritePermissions();
+
+  const openWizard = (type) => {
+    setSelectedType(type);
+    push(routes.sourcesNew.path);
+  };
+
+  const TileComponent = hasWritePermissions ? Tile : DisabledTile;
+
+  return sourceTypes
+    .filter(filterVendorTypes)
+    .sort((a, b) => a.product_name.localeCompare(b.product_name))
+    .map(({ name }) => mapper(name, openWizard, TileComponent));
+};
+
+TilesArray.propTypes = {
+  setSelectedType: PropTypes.func.isRequired,
+  mapper: PropTypes.func.isRequired,
+};
+
+export default TilesArray;

--- a/src/test/components/cloudTiles/CloudEmptyState.test.js
+++ b/src/test/components/cloudTiles/CloudEmptyState.test.js
@@ -10,6 +10,7 @@ import CloudEmptyState from '../../../components/CloudTiles/CloudEmptyState';
 import CloudTiles from '../../../components/CloudTiles/CloudTiles';
 import mockStore from '../../__mocks__/mockStore';
 import sourceTypes, { googleType } from '../../__mocks__/sourceTypesData';
+import * as constants from '../../../utilities/constants';
 
 describe('CloudEmptyState', () => {
   let wrapper;
@@ -25,6 +26,8 @@ describe('CloudEmptyState', () => {
     };
 
     store = mockStore({ user: { isOrgAdmin: true }, sources: { sourceTypes: [...sourceTypes.data, googleType] } });
+
+    constants.getActiveVendor = () => constants.CLOUD_VENDOR;
   });
 
   it('renders correctly', async () => {

--- a/src/test/components/cloudTiles/CloudTiles.test.js
+++ b/src/test/components/cloudTiles/CloudTiles.test.js
@@ -10,6 +10,7 @@ import { routes } from '../../../Routes';
 import CloudTiles from '../../../components/CloudTiles/CloudTiles';
 import mockStore from '../../__mocks__/mockStore';
 import sourceTypes, { googleType } from '../../__mocks__/sourceTypesData';
+import * as constants from '../../../utilities/constants';
 
 describe('CloudTiles', () => {
   let wrapper;
@@ -25,6 +26,8 @@ describe('CloudTiles', () => {
     };
 
     store = mockStore({ user: { isOrgAdmin: true }, sources: { sourceTypes: [...sourceTypes.data, googleType] } });
+
+    constants.getActiveVendor = () => constants.CLOUD_VENDOR;
   });
 
   it('renders correctly', async () => {

--- a/src/test/components/redhatTiles/RedHatEmptyState.test.js
+++ b/src/test/components/redhatTiles/RedHatEmptyState.test.js
@@ -9,6 +9,8 @@ import componentWrapperIntl from '../../../utilities/testsHelpers';
 import mockStore from '../../__mocks__/mockStore';
 import RedHatEmptyState from '../../../components/RedHatTiles/RedHatEmptyState';
 import RedHatTiles from '../../../components/RedHatTiles/RedHatTiles';
+import sourceTypes from '../../__mocks__/sourceTypesData';
+import * as constants from '../../../utilities/constants';
 
 describe('RedhatEmptyState', () => {
   let wrapper;
@@ -23,7 +25,9 @@ describe('RedhatEmptyState', () => {
       setSelectedType,
     };
 
-    store = mockStore({ user: { isOrgAdmin: true } });
+    store = mockStore({ user: { isOrgAdmin: true }, sources: { sourceTypes: sourceTypes.data } });
+
+    constants.getActiveVendor = () => constants.REDHAT_VENDOR;
   });
 
   it('renders correctly', async () => {

--- a/src/test/components/redhatTiles/RedHatTiles.test.js
+++ b/src/test/components/redhatTiles/RedHatTiles.test.js
@@ -9,6 +9,8 @@ import { MemoryRouter } from 'react-router-dom';
 import { routes } from '../../../Routes';
 import mockStore from '../../__mocks__/mockStore';
 import RedHatTiles from '../../../components/RedHatTiles/RedHatTiles';
+import sourceTypes from '../../__mocks__/sourceTypesData';
+import * as constants from '../../../utilities/constants';
 
 describe('RedhatTiles', () => {
   let wrapper;
@@ -23,7 +25,9 @@ describe('RedhatTiles', () => {
       setSelectedType,
     };
 
-    store = mockStore({ user: { isOrgAdmin: true } });
+    store = mockStore({ user: { isOrgAdmin: true }, sources: { sourceTypes: sourceTypes.data } });
+
+    constants.getActiveVendor = () => constants.REDHAT_VENDOR;
   });
 
   it('renders correctly', async () => {
@@ -41,7 +45,7 @@ describe('RedhatTiles', () => {
   });
 
   it('renders correctly when no permissions', async () => {
-    store = mockStore({ user: { isOrgAdmin: false } });
+    store = mockStore({ user: { isOrgAdmin: false }, sources: { sourceTypes: sourceTypes.data } });
 
     await act(async () => {
       wrapper = mount(componentWrapperIntl(<RedHatTiles {...initialProps} />, store));

--- a/src/test/pages/Sources.test.js
+++ b/src/test/pages/Sources.test.js
@@ -139,6 +139,14 @@ describe('SourcesPage', () => {
   });
 
   it('renders empty state when there are no Sources and open AWS selection', async () => {
+    let tmpLocation;
+
+    tmpLocation = Object.assign({}, window.location);
+    delete window.location;
+    window.location = {};
+    window.location.pathname = routes.sources.path;
+    window.location.search = `?activeVendor=${CLOUD_VENDOR}`;
+
     store = getStore([], {
       sources: { activeVendor: CLOUD_VENDOR },
       user: { isOrgAdmin: true },
@@ -161,6 +169,8 @@ describe('SourcesPage', () => {
 
     expect(wrapper.find(MemoryRouter).instance().history.location.pathname).toEqual(routes.sourcesNew.path);
     expect(wrapper.find(AddSourceWizard).props().selectedType).toEqual('amazon');
+
+    window.location = tmpLocation;
   });
 
   it('renders empty state when there are no Sources - RED HAT', async () => {


### PR DESCRIPTION
This is the same PR I did a few weeks ago for Cloud types.

In Red Hat Empty state the tiles will be shown only for types existing in the DB.

+ the same component is refactored into one file