### PR TITLE
Handle falsy values in source error/status

### DIFF
--- a/src/addSourceWizard/utilities/computeSourceError.js
+++ b/src/addSourceWizard/utilities/computeSourceError.js
@@ -1,7 +1,10 @@
 const computeSourceError = (source, intl) =>
-  source.applications?.find(({ availability_status_error }) => availability_status_error)?.availability_status_error ||
-  source.endpoint?.find(({ availability_status_error }) => availability_status_error)?.availability_status_error ||
-  source.authentications?.find(({ availability_status_error }) => availability_status_error)?.availability_status_error ||
+  source.applications?.filter(Boolean).find(({ availability_status_error }) => availability_status_error)
+    ?.availability_status_error ||
+  source.endpoint?.filter(Boolean).find(({ availability_status_error }) => availability_status_error)
+    ?.availability_status_error ||
+  source.authentications?.filter(Boolean).find(({ availability_status_error }) => availability_status_error)
+    ?.availability_status_error ||
   intl.formatMessage({ id: 'wizard.unknownError', defaultMessage: 'Unknown error' });
 
 export default computeSourceError;

--- a/src/addSourceWizard/utilities/computeSourceStatus.js
+++ b/src/addSourceWizard/utilities/computeSourceStatus.js
@@ -4,7 +4,7 @@ export const computeSourceStatus = (source) => {
   const endpointStatuses =
     source.endpoint?.filter(Boolean).map(({ availability_status }) => availability_status || 'timeout') || [];
   const authenticationsStatuses =
-    source.authentiations?.filter(Boolean).map(({ availability_status }) => availability_status || 'timeout') || [];
+    source.authentications?.filter(Boolean).map(({ availability_status }) => availability_status || 'timeout') || [];
 
   const statuses = [...appStatuses, ...endpointStatuses, ...authenticationsStatuses];
 

--- a/src/addSourceWizard/utilities/computeSourceStatus.js
+++ b/src/addSourceWizard/utilities/computeSourceStatus.js
@@ -1,7 +1,10 @@
 export const computeSourceStatus = (source) => {
-  const appStatuses = source.applications?.map(({ availability_status }) => availability_status || 'timeout') || [];
-  const endpointStatuses = source.endpoint?.map(({ availability_status }) => availability_status || 'timeout') || [];
-  const authenticationsStatuses = source.authentiations?.map(({ availability_status }) => availability_status || 'timeout') || [];
+  const appStatuses =
+    source.applications?.filter(Boolean).map(({ availability_status }) => availability_status || 'timeout') || [];
+  const endpointStatuses =
+    source.endpoint?.filter(Boolean).map(({ availability_status }) => availability_status || 'timeout') || [];
+  const authenticationsStatuses =
+    source.authentiations?.filter(Boolean).map(({ availability_status }) => availability_status || 'timeout') || [];
 
   const statuses = [...appStatuses, ...endpointStatuses, ...authenticationsStatuses];
 

--- a/src/test/addSourceWizard/utilities/computeSourceError.test.js
+++ b/src/test/addSourceWizard/utilities/computeSourceError.test.js
@@ -49,4 +49,14 @@ describe('computeSourceError', () => {
 
     expect(computeSourceError(source, INTL)).toEqual('Unknown error');
   });
+
+  it('handle falsy values', () => {
+    source = {
+      applications: [undefined, {}],
+      authentications: [false],
+      endpoint: [{}],
+    };
+
+    expect(computeSourceError(source, INTL)).toEqual('Unknown error');
+  });
 });

--- a/src/test/addSourceWizard/utilities/computeSourceStatus.test.js
+++ b/src/test/addSourceWizard/utilities/computeSourceStatus.test.js
@@ -114,4 +114,10 @@ describe('computeSourceStatus', () => {
 
     expect(computeSourceStatus(source)).toEqual('finished');
   });
+
+  it('handle falsy values', () => {
+    source = { endpoint: [undefined, false] };
+
+    expect(computeSourceStatus(source)).toEqual('finished');
+  });
 });

--- a/src/test/addSourceWizard/utilities/computeSourceStatus.test.js
+++ b/src/test/addSourceWizard/utilities/computeSourceStatus.test.js
@@ -120,4 +120,16 @@ describe('computeSourceStatus', () => {
 
     expect(computeSourceStatus(source)).toEqual('finished');
   });
+
+  it('auhtentiation is available', () => {
+    source = {
+      authentications: [
+        {
+          availability_status: 'available',
+        },
+      ],
+    };
+
+    expect(computeSourceStatus(source)).toEqual('available');
+  });
 });


### PR DESCRIPTION
Arrays of values to check can have undefined, we have to filter them out first.