### PR TITLE
Reset loading when super key source is changed

### DIFF
--- a/src/components/SourceDetail/ResourcesTable.js
+++ b/src/components/SourceDetail/ResourcesTable.js
@@ -112,6 +112,11 @@ const reducer = (state, { type, intl, source, activeTab, appTypes, sourceType })
         ...state,
         activeTab,
       };
+    case 'setLoading':
+      return {
+        ...state,
+        loading: true,
+      };
   }
 };
 
@@ -126,6 +131,8 @@ const ResourcesTable = () => {
 
   useEffect(() => {
     if (source && isLoaded && appTypesLoaded && sourceTypesLoaded && source?.applications?.length) {
+      dispatch({ type: 'setLoading' });
+
       doLoadSourceForEdit(source, appTypes, sourceTypes).then((source) => {
         const sourceType = sourceTypes.find(({ id }) => id === source.source.source_type_id);
 


### PR DESCRIPTION
When an application is removed, the table is being reloaded - however, the state was missing and the table was empty. You could see it in the latest demo.