### PR TITLE
Replace PF imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
       "\\.(css|scss)$": "identity-obj-proxy"
     },
     "transformIgnorePatterns": [
-      "<rootDir>/node_modules/(?!(@patternfly)).*$"
+      "<rootDir>/node_modules/(?!(@patternfly/react-icons)).*$"
     ]
   },
   "devDependencies": {

--- a/src/components/AddApplication/AddApplication.js
+++ b/src/components/AddApplication/AddApplication.js
@@ -22,8 +22,7 @@ import { doAttachApp } from '../../api/doAttachApp';
 import { checkSourceStatus } from '../../api/checkSourceStatus';
 
 import reducer, { initialState } from './reducer';
-import { Button } from '@patternfly/react-core/dist/esm/components/Button';
-import { Text } from '@patternfly/react-core/dist/esm/components/Text';
+import { Button, Text } from '@patternfly/react-core';
 
 import removeAppSubmit from './removeAppSubmit';
 import { diff } from 'deep-object-diff';

--- a/src/components/AddApplication/AddApplicationSchema.js
+++ b/src/components/AddApplication/AddApplicationSchema.js
@@ -1,9 +1,7 @@
 import React from 'react';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
 
-import { Text, TextVariants } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
-
+import { Text, TextVariants, TextContent } from '@patternfly/react-core';
 import { useIntl } from 'react-intl';
 import * as schemaBuilder from '../../components/addSourceWizard/schemaBuilder';
 import get from 'lodash/get';

--- a/src/components/AddApplication/RemoveAppModal.js
+++ b/src/components/AddApplication/RemoveAppModal.js
@@ -3,12 +3,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { useIntl } from 'react-intl';
 import { Redirect, useHistory, useParams } from 'react-router-dom';
 
-import { Text, TextVariants } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
-import { Modal } from '@patternfly/react-core/dist/esm/components/Modal/Modal';
-import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
-
+import { Text, TextVariants, TextContent, Button, Modal, Title } from '@patternfly/react-core';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
 
 import { useSource } from '../../hooks/useSource';

--- a/src/components/AddApplication/WizardBody.js
+++ b/src/components/AddApplication/WizardBody.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
-import { Wizard } from '@patternfly/react-core/dist/esm/components/Wizard/Wizard';
+import { Wizard } from '@patternfly/react-core';
 
 const WizardBodyAttach = ({ step, goToSources, title, description }) => (
   <Wizard

--- a/src/components/AddApplication/schema/selectAuthenticationStep.js
+++ b/src/components/AddApplication/schema/selectAuthenticationStep.js
@@ -6,9 +6,7 @@ import { useIntl } from 'react-intl';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
 import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
 
-import { Text, TextVariants } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
-
+import { Text, TextVariants, TextContent } from '@patternfly/react-core';
 import { AuthTypeSetter } from '../AuthTypeSetter';
 
 export const SelectAuthenticationDescription = ({ applicationTypeName, authenticationTypeName }) => {

--- a/src/components/Authentication.js
+++ b/src/components/Authentication.js
@@ -1,8 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import get from 'lodash/get';
 
-import { FormGroup } from '@patternfly/react-core/dist/esm/components/Form/FormGroup';
-import { TextInput } from '@patternfly/react-core/dist/esm/components/TextInput/TextInput';
+import { FormGroup, TextInput } from '@patternfly/react-core';
 
 import TextField from '@data-driven-forms/pf4-component-mapper/text-field';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';

--- a/src/components/CloseModal.js
+++ b/src/components/CloseModal.js
@@ -2,9 +2,7 @@ import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl, FormattedMessage } from 'react-intl';
 
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
-import { Modal } from '@patternfly/react-core/dist/esm/components/Modal/Modal';
-import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
+import { Button, Modal, Title } from '@patternfly/react-core';
 
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
 

--- a/src/components/CloudTiles/CloudCards.js
+++ b/src/components/CloudTiles/CloudCards.js
@@ -2,18 +2,20 @@
 import React, { useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
 
-import { Grid } from '@patternfly/react-core/dist/esm/layouts/Grid/Grid';
-import { GridItem } from '@patternfly/react-core/dist/esm/layouts/Grid/GridItem';
-import { Stack } from '@patternfly/react-core/dist/esm/layouts/Stack/Stack';
-import { StackItem } from '@patternfly/react-core/dist/esm/layouts/Stack/StackItem';
-import { Card } from '@patternfly/react-core/dist/esm/components/Card/Card';
-import { CardBody } from '@patternfly/react-core/dist/esm/components/Card/CardBody';
-import { CardTitle } from '@patternfly/react-core/dist/esm/components/Card/CardTitle';
-import { CardHeader } from '@patternfly/react-core/dist/esm/components/Card/CardHeader';
-import { CardExpandableContent } from '@patternfly/react-core/dist/esm/components/Card/CardExpandableContent';
-import { Text } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
-import { Label } from '@patternfly/react-core/dist/esm/components/Label/Label';
+import {
+  Grid,
+  GridItem,
+  Stack,
+  StackItem,
+  Card,
+  CardBody,
+  CardTitle,
+  CardHeader,
+  CardExpandableContent,
+  Text,
+  TextContent,
+  Label,
+} from '@patternfly/react-core';
 
 import ArrowRightIcon from '@patternfly/react-icons/dist/esm/icons/arrow-right-icon';
 import BuilderImageIcon from '@patternfly/react-icons/dist/esm/icons/builder-image-icon';

--- a/src/components/CloudTiles/CloudEmptyState.js
+++ b/src/components/CloudTiles/CloudEmptyState.js
@@ -3,11 +3,7 @@ import React from 'react';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 
-import { Card } from '@patternfly/react-core/dist/esm/components/Card/Card';
-import { CardBody } from '@patternfly/react-core/dist/esm/components/Card/CardBody';
-import { CardTitle } from '@patternfly/react-core/dist/esm/components/Card/CardTitle';
-import { CardFooter } from '@patternfly/react-core/dist/esm/components/Card/CardFooter';
-import { Text } from '@patternfly/react-core/dist/esm/components/Text/Text';
+import { Card, CardBody, CardTitle, CardFooter, Text } from '@patternfly/react-core';
 
 import CloudTiles from './CloudTiles';
 

--- a/src/components/CredentialsForm/CredentialsForm.js
+++ b/src/components/CredentialsForm/CredentialsForm.js
@@ -3,9 +3,7 @@ import { useIntl } from 'react-intl';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 
-import { Modal } from '@patternfly/react-core/dist/esm/components/Modal';
-import { Spinner } from '@patternfly/react-core/dist/esm/components/Spinner';
-import { Bullseye } from '@patternfly/react-core/dist/esm/layouts/Bullseye';
+import { Modal, Spinner, Bullseye } from '@patternfly/react-core';
 
 import { useSource } from '../../hooks/useSource';
 

--- a/src/components/CredentialsForm/ModalFormTemplate.js
+++ b/src/components/CredentialsForm/ModalFormTemplate.js
@@ -6,10 +6,7 @@ import FormSpy from '@data-driven-forms/react-form-renderer/form-spy';
 import FormTemplate from '@data-driven-forms/pf4-component-mapper/form-template';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
 
-import { Modal } from '@patternfly/react-core/dist/esm/components/Modal';
-import { ActionGroup } from '@patternfly/react-core/dist/esm/components/Form/ActionGroup';
-import { Button } from '@patternfly/react-core/dist/esm/components/Button';
-import { Form } from '@patternfly/react-core/dist/esm/components/Form/Form';
+import { Modal, ActionGroup, Button, Form } from '@patternfly/react-core';
 
 const CustomFormWrapper = (props) => <Form {...props} id="modal-form" />;
 

--- a/src/components/FormComponents/AuthSelect.js
+++ b/src/components/FormComponents/AuthSelect.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Radio } from '@patternfly/react-core/dist/esm/components/Radio/Radio';
+import { Radio } from '@patternfly/react-core';
 import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
 
 const AuthRadio = (props) => {

--- a/src/components/FormComponents/CardSelect.js
+++ b/src/components/FormComponents/CardSelect.js
@@ -1,10 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
-import { FormGroup } from '@patternfly/react-core/dist/esm/components/Form/FormGroup';
-import { GridItem } from '@patternfly/react-core/dist/esm/layouts/Grid/GridItem';
-import { Tile } from '@patternfly/react-core/dist/esm/components/Tile/Tile';
-import { Grid } from '@patternfly/react-core/dist/esm/layouts/Grid/Grid';
+import { FormGroup, GridItem, Tile, Grid } from '@patternfly/react-core';
 
 import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';

--- a/src/components/FormComponents/SourceWizardSummary.js
+++ b/src/components/FormComponents/SourceWizardSummary.js
@@ -2,12 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, useIntl } from 'react-intl';
 
-import { Label } from '@patternfly/react-core/dist/esm/components/Label/Label';
-import { Alert } from '@patternfly/react-core/dist/esm/components/Alert/Alert';
-import { DescriptionList } from '@patternfly/react-core/dist/esm/components/DescriptionList/DescriptionList';
-import { DescriptionListDescription } from '@patternfly/react-core/dist/esm/components/DescriptionList/DescriptionListDescription';
-import { DescriptionListGroup } from '@patternfly/react-core/dist/esm/components/DescriptionList/DescriptionListGroup';
-import { DescriptionListTerm } from '@patternfly/react-core/dist/esm/components/DescriptionList/DescriptionListTerm';
+import {
+  Label,
+  Alert,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+} from '@patternfly/react-core';
 
 import get from 'lodash/get';
 

--- a/src/components/FormComponents/SwitchGroup.js
+++ b/src/components/FormComponents/SwitchGroup.js
@@ -1,9 +1,6 @@
 import React, { useEffect } from 'react';
 
-import { Switch } from '@patternfly/react-core/dist/esm/components/Switch/Switch';
-import { FormGroup } from '@patternfly/react-core/dist/esm/components/Form/FormGroup';
-import { Stack } from '@patternfly/react-core/dist/esm/layouts/Stack/Stack';
-import { StackItem } from '@patternfly/react-core/dist/esm/layouts/Stack/StackItem';
+import { Switch, FormGroup, Stack, StackItem } from '@patternfly/react-core';
 
 import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';

--- a/src/components/FormComponents/ValuePopover.js
+++ b/src/components/FormComponents/ValuePopover.js
@@ -2,8 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
-import { Popover } from '@patternfly/react-core/dist/esm/components/Popover/Popover';
+import { Button, Popover } from '@patternfly/react-core';
 
 const ValuePopover = ({ label, value }) => {
   const intl = useIntl();

--- a/src/components/RedHatTiles/RedHatEmptyState.js
+++ b/src/components/RedHatTiles/RedHatEmptyState.js
@@ -3,10 +3,7 @@ import React from 'react';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 
-import { Card } from '@patternfly/react-core/dist/esm/components/Card/Card';
-import { CardBody } from '@patternfly/react-core/dist/esm/components/Card/CardBody';
-import { CardTitle } from '@patternfly/react-core/dist/esm/components/Card/CardTitle';
-import { Text } from '@patternfly/react-core/dist/esm/components/Text/Text';
+import { Card, CardBody, CardTitle, Text } from '@patternfly/react-core';
 
 import RedHatTiles from './RedHatTiles';
 

--- a/src/components/SourceDetail/ApplicationResourcesCard.js
+++ b/src/components/SourceDetail/ApplicationResourcesCard.js
@@ -1,9 +1,7 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
 
-import { Card } from '@patternfly/react-core/dist/esm/components/Card/Card';
-import { CardBody } from '@patternfly/react-core/dist/esm/components/Card/CardBody';
-import { CardTitle } from '@patternfly/react-core/dist/esm/components/Card/CardTitle';
+import { Card, CardBody, CardTitle } from '@patternfly/react-core';
 
 import NoApplications from './NoApplications';
 import { useHasWritePermissions } from '../../hooks/useHasWritePermissions';

--- a/src/components/SourceDetail/ApplicationStatusLabel.js
+++ b/src/components/SourceDetail/ApplicationStatusLabel.js
@@ -3,8 +3,7 @@ import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 
-import { Label } from '@patternfly/react-core/dist/esm/components/Label/Label';
-import { Popover } from '@patternfly/react-core/dist/esm/components/Popover/Popover';
+import { Label, Popover } from '@patternfly/react-core';
 
 import { useSource } from '../../hooks/useSource';
 import { getAppStatus, getStatusTooltipTextApp, getStatusColor, getStatusText } from '../../views/formatters';

--- a/src/components/SourceDetail/ApplicationsCard.js
+++ b/src/components/SourceDetail/ApplicationsCard.js
@@ -3,11 +3,7 @@ import { useIntl } from 'react-intl';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 
-import { Card } from '@patternfly/react-core/dist/esm/components/Card/Card';
-import { CardBody } from '@patternfly/react-core/dist/esm/components/Card/CardBody';
-import { CardTitle } from '@patternfly/react-core/dist/esm/components/Card/CardTitle';
-import { Switch } from '@patternfly/react-core/dist/esm/components/Switch/Switch';
-import { FormGroup } from '@patternfly/react-core/dist/esm/components/Form/FormGroup';
+import { Card, CardBody, CardTitle, Switch, FormGroup } from '@patternfly/react-core';
 
 import { useSource } from '../../hooks/useSource';
 import { replaceRouteId, routes } from '../../Routes';

--- a/src/components/SourceDetail/AvailabilityChecker.js
+++ b/src/components/SourceDetail/AvailabilityChecker.js
@@ -3,8 +3,7 @@ import { useIntl } from 'react-intl';
 import { useDispatch } from 'react-redux';
 
 import RedoIcon from '@patternfly/react-icons/dist/esm/icons/redo-icon';
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
-import { Spinner } from '@patternfly/react-core/dist/esm/components/Spinner/Spinner';
+import { Button, Spinner } from '@patternfly/react-core';
 
 import { useSource } from '../../hooks/useSource';
 import checkSourceStatus from '../../api/checkSourceStatus';

--- a/src/components/SourceDetail/Breadcrumbs.js
+++ b/src/components/SourceDetail/Breadcrumbs.js
@@ -2,8 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 
-import { Breadcrumb } from '@patternfly/react-core/dist/esm/components/Breadcrumb/Breadcrumb';
-import { BreadcrumbItem } from '@patternfly/react-core/dist/esm/components/Breadcrumb/BreadcrumbItem';
+import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 import { routes } from '../../Routes';
 import { useSource } from '../../hooks/useSource';
 

--- a/src/components/SourceDetail/DetailHeader.js
+++ b/src/components/SourceDetail/DetailHeader.js
@@ -3,11 +3,7 @@ import { useIntl } from 'react-intl';
 import { shallowEqual, useSelector } from 'react-redux';
 
 import { PageHeader } from '@redhat-cloud-services/frontend-components/PageHeader';
-import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
-import { Text } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { Flex } from '@patternfly/react-core/dist/esm/layouts/Flex/Flex';
-import { FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex/FlexItem';
+import { Title, TextContent, Text, Flex, FlexItem } from '@patternfly/react-core';
 
 import Breadcrumbs from './Breadcrumbs';
 import { useSource } from '../../hooks/useSource';

--- a/src/components/SourceDetail/NoApplications.js
+++ b/src/components/SourceDetail/NoApplications.js
@@ -1,10 +1,7 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
 
-import { EmptyState } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyState';
-import { EmptyStateIcon } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateIcon';
-import { EmptyStateBody } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateBody';
-import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
+import { EmptyState, EmptyStateIcon, EmptyStateBody, Title } from '@patternfly/react-core';
 import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 
 const NoApplications = () => {

--- a/src/components/SourceDetail/NoPermissions.js
+++ b/src/components/SourceDetail/NoPermissions.js
@@ -1,10 +1,7 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
 
-import { EmptyState } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyState';
-import { EmptyStateIcon } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateIcon';
-import { EmptyStateBody } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateBody';
-import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
+import { EmptyState, EmptyStateIcon, EmptyStateBody, Title } from '@patternfly/react-core';
 import PrivateIcon from '@patternfly/react-icons/dist/esm/icons/private-icon';
 
 const NoPermissions = () => {

--- a/src/components/SourceDetail/ResourcesTable.js
+++ b/src/components/SourceDetail/ResourcesTable.js
@@ -7,17 +7,22 @@ import get from 'lodash/get';
 import { Table, TableHeader, TableBody } from '@patternfly/react-table';
 import WrenchIcon from '@patternfly/react-icons/dist/esm/icons/wrench-icon';
 
-import { Card } from '@patternfly/react-core/dist/esm/components/Card/Card';
-import { CardBody } from '@patternfly/react-core/dist/esm/components/Card/CardBody';
-import { CardTitle } from '@patternfly/react-core/dist/esm/components/Card/CardTitle';
-import { Text } from '@patternfly/react-core/dist/esm/components/Text';
-import { Spinner } from '@patternfly/react-core/dist/esm/components/Spinner';
-import { Bullseye } from '@patternfly/react-core/dist/esm/layouts/Bullseye';
-import { Tabs, Tab, TabTitleText } from '@patternfly/react-core/dist/esm/components/Tabs';
-import { EmptyState, EmptyStateVariant } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyState';
-import { EmptyStateIcon } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateIcon';
-import { EmptyStateBody } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateBody';
-import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  Text,
+  Spinner,
+  Bullseye,
+  Tabs,
+  Tab,
+  TabTitleText,
+  EmptyState,
+  EmptyStateVariant,
+  EmptyStateIcon,
+  EmptyStateBody,
+  Title,
+} from '@patternfly/react-core';
 
 import NoApplications from './NoApplications';
 import { useSource } from '../../hooks/useSource';

--- a/src/components/SourceDetail/SourceKebab.js
+++ b/src/components/SourceDetail/SourceKebab.js
@@ -2,9 +2,7 @@ import React, { useState } from 'react';
 import { useIntl } from 'react-intl';
 import { useHistory } from 'react-router-dom';
 
-import { Dropdown } from '@patternfly/react-core/dist/esm/components/Dropdown/Dropdown';
-import { DropdownItem } from '@patternfly/react-core/dist/esm/components/Dropdown/DropdownItem';
-import { KebabToggle } from '@patternfly/react-core/dist/esm/components/Dropdown/KebabToggle';
+import { Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
 
 import { replaceRouteId, routes } from '../../Routes';
 import { useSource } from '../../hooks/useSource';

--- a/src/components/SourceDetail/SourceRenameModal.js
+++ b/src/components/SourceDetail/SourceRenameModal.js
@@ -3,7 +3,7 @@ import { useIntl } from 'react-intl';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 
-import { Modal } from '@patternfly/react-core/dist/esm/components/Modal/Modal';
+import { Modal } from '@patternfly/react-core';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
 import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
 import FormTemplate from '@data-driven-forms/pf4-component-mapper/form-template';

--- a/src/components/SourceDetail/SourceSummaryCard.js
+++ b/src/components/SourceDetail/SourceSummaryCard.js
@@ -3,13 +3,15 @@ import { useIntl } from 'react-intl';
 import { shallowEqual, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import { Card } from '@patternfly/react-core/dist/esm/components/Card/Card';
-import { CardBody } from '@patternfly/react-core/dist/esm/components/Card/CardBody';
-import { CardTitle } from '@patternfly/react-core/dist/esm/components/Card/CardTitle';
-import { DescriptionList } from '@patternfly/react-core/dist/esm/components/DescriptionList/DescriptionList';
-import { DescriptionListGroup } from '@patternfly/react-core/dist/esm/components/DescriptionList/DescriptionListGroup';
-import { DescriptionListTerm } from '@patternfly/react-core/dist/esm/components/DescriptionList/DescriptionListTerm';
-import { DescriptionListDescription } from '@patternfly/react-core/dist/esm/components/DescriptionList/DescriptionListDescription';
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+} from '@patternfly/react-core';
 
 import { useSource } from '../../hooks/useSource';
 import { configurationModeFormatter, dateFormatter, sourceTypeFormatter } from '../../views/formatters';

--- a/src/components/SourceEditForm/ErroredModal.js
+++ b/src/components/SourceEditForm/ErroredModal.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 
-import { Text } from '@patternfly/react-core/dist/esm/components/Text/Text';
+import { Text } from '@patternfly/react-core';
 
 import ErroredStep from '../steps/ErroredStep';
 

--- a/src/components/SourceEditForm/SourceEditModal.js
+++ b/src/components/SourceEditForm/SourceEditModal.js
@@ -1,8 +1,7 @@
 import React, { useEffect, useReducer } from 'react';
 import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { useIntl } from 'react-intl';
-import { Spinner } from '@patternfly/react-core/dist/esm/components/Spinner';
-import { Bullseye } from '@patternfly/react-core/dist/esm/layouts/Bullseye';
+import { Spinner, Bullseye } from '@patternfly/react-core';
 
 import FormTemplate from '@data-driven-forms/pf4-component-mapper/form-template';
 

--- a/src/components/SourceEditForm/parser/EditAlert.js
+++ b/src/components/SourceEditForm/parser/EditAlert.js
@@ -4,7 +4,7 @@ import get from 'lodash/get';
 
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
 
-import { Alert } from '@patternfly/react-core/dist/esm/components/Alert/Alert';
+import { Alert } from '@patternfly/react-core';
 
 const EditAlert = ({ name }) => {
   const formOptions = useFormApi();

--- a/src/components/SourceRemoveModal/AppListInRemoval.js
+++ b/src/components/SourceRemoveModal/AppListInRemoval.js
@@ -2,9 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useSelector, shallowEqual } from 'react-redux';
 
-import { TextList } from '@patternfly/react-core/dist/esm/components/Text/TextList';
-import { TextListItem } from '@patternfly/react-core/dist/esm/components/Text/TextListItem';
-import { Text, TextVariants } from '@patternfly/react-core/dist/esm/components/Text/Text';
+import { TextList, TextListItem, Text, TextVariants } from '@patternfly/react-core';
 
 import { idToName } from './helpers';
 

--- a/src/components/SourceRemoveModal/SourceRemoveModal.js
+++ b/src/components/SourceRemoveModal/SourceRemoveModal.js
@@ -4,12 +4,7 @@ import { useHistory } from 'react-router-dom';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { useIntl } from 'react-intl';
 
-import { Text, TextVariants } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
-import { Modal } from '@patternfly/react-core/dist/esm/components/Modal/Modal';
-import { Checkbox } from '@patternfly/react-core/dist/esm/components/Checkbox/Checkbox';
-import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
+import { Text, TextVariants, TextContent, Button, Modal, Checkbox, Title } from '@patternfly/react-core';
 
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
 

--- a/src/components/SourcesErrorState.js
+++ b/src/components/SourcesErrorState.js
@@ -1,14 +1,7 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
 
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
-import { EmptyState } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyState';
-import { EmptyStateIcon } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateIcon';
-import { EmptyStateBody } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateBody';
-import { Bullseye } from '@patternfly/react-core/dist/esm/layouts/Bullseye/Bullseye';
-import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
-import { Text } from '@patternfly/react-core/dist/esm/components/Text/Text';
-
+import { Button, EmptyState, EmptyStateIcon, EmptyStateBody, Bullseye, Title, Text } from '@patternfly/react-core';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 
 const SourcesErrorState = () => {

--- a/src/components/SourcesTable/EmptyStateTable.js
+++ b/src/components/SourcesTable/EmptyStateTable.js
@@ -1,11 +1,6 @@
 import React from 'react';
 
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
-import { EmptyState, EmptyStateVariant } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyState';
-import { EmptyStateIcon } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateIcon';
-import { EmptyStateBody } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateBody';
-import { Bullseye } from '@patternfly/react-core/dist/esm/layouts/Bullseye/Bullseye';
-import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
+import { Button, EmptyState, EmptyStateVariant, EmptyStateIcon, EmptyStateBody, Bullseye, Title } from '@patternfly/react-core';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import { useIntl } from 'react-intl';
 import { useDispatch } from 'react-redux';

--- a/src/components/SourcesTable/loaders.js
+++ b/src/components/SourcesTable/loaders.js
@@ -1,14 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { RowWrapper } from '@patternfly/react-table';
-import { Spinner } from '@patternfly/react-core/dist/esm/components/Spinner';
-import { Bullseye } from '@patternfly/react-core/dist/esm/layouts/Bullseye';
 import { PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components/PageHeader';
 import { Section } from '@redhat-cloud-services/frontend-components/Section';
-import { Grid } from '@patternfly/react-core/dist/esm/layouts/Grid/Grid';
-import { GridItem } from '@patternfly/react-core/dist/esm/layouts/Grid/GridItem';
-import { Card } from '@patternfly/react-core/dist/esm/components/Card/Card';
-import { CardBody } from '@patternfly/react-core/dist/esm/components/Card/CardBody';
+
+import { Spinner, Bullseye, Grid, GridItem, Card, CardBody } from '@patternfly/react-core';
 
 import { COLUMN_COUNT } from '../../views/sourcesViewDefinition';
 

--- a/src/components/TabNavigation.js
+++ b/src/components/TabNavigation.js
@@ -2,10 +2,7 @@ import React from 'react';
 import { useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { Tabs } from '@patternfly/react-core/dist/esm/components/Tabs/Tabs';
-import { Tab } from '@patternfly/react-core/dist/esm/components/Tabs/Tab';
-import { TabTitleIcon } from '@patternfly/react-core/dist/esm/components/Tabs/TabTitleIcon';
-import { TabTitleText } from '@patternfly/react-core/dist/esm/components/Tabs/TabTitleText';
+import { Tabs, Tab, TabTitleIcon, TabTitleText } from '@patternfly/react-core';
 import RedhatIcon from '@patternfly/react-icons/dist/esm/icons/redhat-icon';
 import CloudIcon from '@patternfly/react-icons/dist/esm/icons/cloud-icon';
 

--- a/src/components/TilesShared/DisabledTile.js
+++ b/src/components/TilesShared/DisabledTile.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
 
-import { Tile } from '@patternfly/react-core/dist/esm/components/Tile/Tile';
-import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip/Tooltip';
+import { Tile, Tooltip } from '@patternfly/react-core';
 
 const DisabledTile = (props) => {
   const intl = useIntl();

--- a/src/components/TilesShared/TilesArray.js
+++ b/src/components/TilesShared/TilesArray.js
@@ -3,7 +3,7 @@ import { useHistory } from 'react-router-dom';
 import { shallowEqual, useSelector } from 'react-redux';
 import { routes } from '../../Routes';
 
-import { Tile } from '@patternfly/react-core/dist/esm/components/Tile/Tile';
+import { Tile } from '@patternfly/react-core';
 
 import { useHasWritePermissions } from '../../hooks/useHasWritePermissions';
 import DisabledTile from '../TilesShared/DisabledTile';

--- a/src/components/addSourceWizard/EditLink.js
+++ b/src/components/addSourceWizard/EditLink.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { Link } from 'react-router-dom';
 
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
+import { Button } from '@patternfly/react-core';
 import computeSourcesUrl from '../../utilities/computeSourcesUrl';
 
 const EditLink = ({ id }) => {

--- a/src/components/addSourceWizard/FinalWizard.js
+++ b/src/components/addSourceWizard/FinalWizard.js
@@ -2,10 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 
-import { Text } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
-import { Wizard } from '@patternfly/react-core/dist/esm/components/Wizard/Wizard';
+import { Text, TextContent, Button, Wizard } from '@patternfly/react-core';
 
 import { wizardDescription, wizardTitle } from './stringConstants';
 import { getSourcesApi } from '../../api/entities';

--- a/src/components/addSourceWizard/SSLFormLabel.js
+++ b/src/components/addSourceWizard/SSLFormLabel.js
@@ -1,9 +1,7 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
 
-import { Text, TextVariants } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
-import { Popover } from '@patternfly/react-core/dist/esm/components/Popover/Popover';
+import { Text, TextVariants, TextContent, Popover } from '@patternfly/react-core';
 
 import QuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/question-circle-icon';
 

--- a/src/components/addSourceWizard/SourceAddModal.js
+++ b/src/components/addSourceWizard/SourceAddModal.js
@@ -4,7 +4,7 @@ import { useIntl } from 'react-intl';
 
 import FormTemplate from '@data-driven-forms/pf4-component-mapper/form-template';
 
-import { Wizard } from '@patternfly/react-core/dist/esm/components/Wizard/Wizard';
+import { Wizard } from '@patternfly/react-core';
 
 import createSchema from './SourceAddSchema';
 import { doLoadSourceTypes, doLoadApplicationTypes } from '../../api/wizardHelpers';

--- a/src/components/addSourceWizard/SourceAddSchema.js
+++ b/src/components/addSourceWizard/SourceAddSchema.js
@@ -3,8 +3,7 @@ import { useIntl } from 'react-intl';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
 import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
 
-import { Text, TextVariants } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
+import { Text, TextVariants, TextContent } from '@patternfly/react-core';
 
 import debouncePromise from '../../utilities/debouncePromise';
 import { findSource } from '../../api/wizardHelpers';

--- a/src/components/addSourceWizard/compileAllApplicationComboOptions.js
+++ b/src/components/addSourceWizard/compileAllApplicationComboOptions.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { NO_APPLICATION_VALUE } from './stringConstants';
 
-import { Label } from '@patternfly/react-core/dist/esm/components/Label/Label';
+import { Label } from '@patternfly/react-core';
 import SubWatchDescription from './descriptions/SubWatchDescription';
 import { CLOUD_METER_APP_NAME, COST_MANAGEMENT_APP_NAME, getActiveVendor, REDHAT_VENDOR } from '../../utilities/constants';
 

--- a/src/components/addSourceWizard/descriptions/SubWatchDescription.js
+++ b/src/components/addSourceWizard/descriptions/SubWatchDescription.js
@@ -2,11 +2,7 @@ import React from 'react';
 import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 
-import { Text } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { Stack } from '@patternfly/react-core/dist/esm/layouts/Stack/Stack';
-import { StackItem } from '@patternfly/react-core/dist/esm/layouts/Stack/StackItem';
-import { Flex } from '@patternfly/react-core/dist/esm/layouts/Flex/Flex';
-import { FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex/FlexItem';
+import { Text, Stack, StackItem, Flex, FlexItem } from '@patternfly/react-core';
 import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
 
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';

--- a/src/components/addSourceWizard/hardcodedComponents/aws/access_key.js
+++ b/src/components/addSourceWizard/hardcodedComponents/aws/access_key.js
@@ -2,9 +2,7 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
 
-import { Text } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
-import { Popover } from '@patternfly/react-core/dist/esm/components/Popover/Popover';
+import { Text, TextContent, Popover } from '@patternfly/react-core';
 
 import QuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/question-circle-icon';
 

--- a/src/components/addSourceWizard/hardcodedComponents/aws/arn.js
+++ b/src/components/addSourceWizard/hardcodedComponents/aws/arn.js
@@ -1,13 +1,20 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
 
-import { Text, TextVariants } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
-import { Button, ButtonVariant } from '@patternfly/react-core/dist/esm/components/Button/Button';
-import { Popover } from '@patternfly/react-core/dist/esm/components/Popover/Popover';
-import { TextList, TextListVariants } from '@patternfly/react-core/dist/esm/components/Text/TextList';
-import { TextListItem, TextListItemVariants } from '@patternfly/react-core/dist/esm/components/Text/TextListItem';
-import { ClipboardCopy, ClipboardCopyVariant } from '@patternfly/react-core/dist/esm/components/ClipboardCopy/ClipboardCopy';
+import {
+  Text,
+  TextVariants,
+  TextContent,
+  Button,
+  ButtonVariant,
+  Popover,
+  TextList,
+  TextListVariants,
+  TextListItem,
+  TextListItemVariants,
+  ClipboardCopy,
+  ClipboardCopyVariant,
+} from '@patternfly/react-core';
 
 import QuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/question-circle-icon';
 

--- a/src/components/addSourceWizard/hardcodedComponents/aws/subscriptionWatch.js
+++ b/src/components/addSourceWizard/hardcodedComponents/aws/subscriptionWatch.js
@@ -1,11 +1,17 @@
 import React, { useState, useEffect } from 'react';
 import { useIntl } from 'react-intl';
 
-import { Text, TextVariants } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
-import { TextList, TextListVariants } from '@patternfly/react-core/dist/esm/components/Text/TextList';
-import { TextListItem } from '@patternfly/react-core/dist/esm/components/Text/TextListItem';
-import { ClipboardCopy, ClipboardCopyVariant } from '@patternfly/react-core/dist/esm/components/ClipboardCopy/ClipboardCopy';
+import {
+  Text,
+  TextVariants,
+  TextContent,
+  TextList,
+  TextListVariants,
+  TextListItem,
+  ClipboardCopy,
+  ClipboardCopyVariant,
+} from '@patternfly/react-core';
+
 import { getSubWatchConfig } from '../../../../api/subscriptionWatch';
 
 const b = (chunks) => <b key={`b-${chunks.length}-${Math.floor(Math.random() * 1000)}`}>{chunks}</b>;

--- a/src/components/addSourceWizard/hardcodedComponents/azure/costManagement.js
+++ b/src/components/addSourceWizard/hardcodedComponents/azure/costManagement.js
@@ -1,11 +1,16 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
 
-import { Text, TextVariants } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
-import { TextList, TextListVariants } from '@patternfly/react-core/dist/esm/components/Text/TextList';
-import { TextListItem, TextListItemVariants } from '@patternfly/react-core/dist/esm/components/Text/TextListItem';
-import { ClipboardCopy } from '@patternfly/react-core/dist/esm/components/ClipboardCopy/ClipboardCopy';
+import {
+  Text,
+  TextVariants,
+  TextContent,
+  TextList,
+  TextListVariants,
+  TextListItem,
+  TextListItemVariants,
+  ClipboardCopy,
+} from '@patternfly/react-core';
 
 import { HCCM_DOCS_PREFIX } from '../../stringConstants';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';

--- a/src/components/addSourceWizard/hardcodedComponents/gcp/costManagement.js
+++ b/src/components/addSourceWizard/hardcodedComponents/gcp/costManagement.js
@@ -1,14 +1,18 @@
 import React, { useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
 
-import { Text, TextVariants } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
-import { TextList, TextListVariants } from '@patternfly/react-core/dist/esm/components/Text/TextList';
-import { TextListItem } from '@patternfly/react-core/dist/esm/components/Text/TextListItem';
-import { ClipboardCopy } from '@patternfly/react-core/dist/esm/components/ClipboardCopy/ClipboardCopy';
-import { Hint } from '@patternfly/react-core/dist/esm/components/Hint/Hint';
-import { HintTitle } from '@patternfly/react-core/dist/esm/components/Hint/HintTitle';
-import { HintBody } from '@patternfly/react-core/dist/esm/components/Hint/HintBody';
+import {
+  Text,
+  TextVariants,
+  TextContent,
+  TextList,
+  TextListVariants,
+  TextListItem,
+  ClipboardCopy,
+  Hint,
+  HintTitle,
+  HintBody,
+} from '@patternfly/react-core';
 
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
 

--- a/src/components/addSourceWizard/hardcodedComponents/openshift/costManagement.js
+++ b/src/components/addSourceWizard/hardcodedComponents/openshift/costManagement.js
@@ -2,8 +2,7 @@ import React from 'react';
 import { useIntl } from 'react-intl';
 import { HCCM_DOCS_PREFIX } from '../../stringConstants';
 
-import { Text, TextVariants } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
+import { Text, TextVariants, TextContent } from '@patternfly/react-core';
 
 const INSTALL_PREREQUISITE = `${HCCM_DOCS_PREFIX}/html/getting_started_with_cost_management/assembly_koku_cost_management_installing#proc_installation-overview-ocp45`;
 

--- a/src/components/addSourceWizard/hardcodedComponents/openshift/endpoint.js
+++ b/src/components/addSourceWizard/hardcodedComponents/openshift/endpoint.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
 
-import { Text, TextVariants } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
+import { Text, TextVariants, TextContent } from '@patternfly/react-core';
 
 export const EndpointDesc = () => {
   const intl = useIntl();

--- a/src/components/addSourceWizard/hardcodedComponents/openshift/token.js
+++ b/src/components/addSourceWizard/hardcodedComponents/openshift/token.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
 
-import { Text, TextVariants } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
-import { TextList } from '@patternfly/react-core/dist/esm/components/Text/TextList';
-import { TextListItem } from '@patternfly/react-core/dist/esm/components/Text/TextListItem';
-import { ClipboardCopy } from '@patternfly/react-core/dist/esm/components/ClipboardCopy/ClipboardCopy';
+import { Text, TextVariants, TextContent, TextList, TextListItem, ClipboardCopy } from '@patternfly/react-core';
 
 export const DescriptionSummary = () => {
   const intl = useIntl();

--- a/src/components/addSourceWizard/hardcodedComponents/tower/catalog.js
+++ b/src/components/addSourceWizard/hardcodedComponents/tower/catalog.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import { useIntl } from 'react-intl';
 
-import { Text, TextVariants } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
+import { Text, TextVariants, TextContent } from '@patternfly/react-core';
 
 export const AllFieldAreRequired = () => {
   const intl = useIntl();

--- a/src/components/addSourceWizard/hardcodedSchemas.js
+++ b/src/components/addSourceWizard/hardcodedSchemas.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
-import { FormHelperText } from '@patternfly/react-core/dist/esm/components/Form/FormHelperText';
+import { FormHelperText } from '@patternfly/react-core';
 
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
 import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';

--- a/src/components/addSourceWizard/index.js
+++ b/src/components/addSourceWizard/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import isEmpty from 'lodash/isEmpty';
 import { FormattedMessage } from 'react-intl';
 
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
+import { Button } from '@patternfly/react-core';
 
 import Form from './SourceAddModal';
 import FinalWizard from './FinalWizard';

--- a/src/components/addSourceWizard/superKey/configurationStep.js
+++ b/src/components/addSourceWizard/superKey/configurationStep.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
 import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
-import { Label } from '@patternfly/react-core/dist/esm/components/Label/Label';
+import { Label } from '@patternfly/react-core';
 import SuperKeyCredentials from './SuperKeyCredentials';
 
 const configurationStep = (intl, sourceTypes) => ({

--- a/src/components/steps/AmazonFinishedStep.js
+++ b/src/components/steps/AmazonFinishedStep.js
@@ -2,17 +2,20 @@ import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 
-import { Text } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
-import { EmptyState, EmptyStateVariant } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyState';
-import { EmptyStateIcon } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateIcon';
-import { EmptyStateBody } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateBody';
-import { EmptyStateSecondaryActions } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateSecondaryActions';
-import { Bullseye } from '@patternfly/react-core/dist/esm/layouts/Bullseye/Bullseye';
-import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
-import { GridItem } from '@patternfly/react-core/dist/esm/layouts/Grid/GridItem';
-import { Alert } from '@patternfly/react-core/dist/esm/components/Alert/Alert';
-import { Grid } from '@patternfly/react-core/dist/esm/layouts/Grid/Grid';
+import {
+  Text,
+  Button,
+  EmptyState,
+  EmptyStateVariant,
+  EmptyStateIcon,
+  EmptyStateBody,
+  EmptyStateSecondaryActions,
+  Bullseye,
+  Title,
+  GridItem,
+  Alert,
+  Grid,
+} from '@patternfly/react-core';
 
 import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
 

--- a/src/components/steps/ErroredStep.js
+++ b/src/components/steps/ErroredStep.js
@@ -2,13 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
-import { EmptyState, EmptyStateVariant } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyState';
-import { EmptyStateIcon } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateIcon';
-import { EmptyStateBody } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateBody';
-import { EmptyStateSecondaryActions } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateSecondaryActions';
-import { Bullseye } from '@patternfly/react-core/dist/esm/layouts/Bullseye/Bullseye';
-import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
+import {
+  Button,
+  EmptyState,
+  EmptyStateVariant,
+  EmptyStateIcon,
+  EmptyStateBody,
+  EmptyStateSecondaryActions,
+  Bullseye,
+  Title,
+} from '@patternfly/react-core';
 
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 

--- a/src/components/steps/FinishedStep.js
+++ b/src/components/steps/FinishedStep.js
@@ -2,13 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
-import { EmptyState, EmptyStateVariant } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyState';
-import { EmptyStateIcon } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateIcon';
-import { EmptyStateBody } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateBody';
-import { EmptyStateSecondaryActions } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateSecondaryActions';
-import { Bullseye } from '@patternfly/react-core/dist/esm/layouts/Bullseye/Bullseye';
-import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
+import {
+  Button,
+  EmptyState,
+  EmptyStateVariant,
+  EmptyStateIcon,
+  EmptyStateBody,
+  EmptyStateSecondaryActions,
+  Bullseye,
+  Title,
+} from '@patternfly/react-core';
 
 import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
 import computeSourcesUrl from '../../utilities/computeSourcesUrl';

--- a/src/components/steps/LoadingStep.js
+++ b/src/components/steps/LoadingStep.js
@@ -2,14 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
-import { EmptyState, EmptyStateVariant } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyState';
-import { EmptyStateIcon } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateIcon';
-import { EmptyStateBody } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateBody';
-import { EmptyStateSecondaryActions } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateSecondaryActions';
-import { Bullseye } from '@patternfly/react-core/dist/esm/layouts/Bullseye/Bullseye';
-import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
-import { Spinner } from '@patternfly/react-core/dist/esm/components/Spinner/Spinner';
+import {
+  Button,
+  EmptyState,
+  EmptyStateVariant,
+  EmptyStateIcon,
+  EmptyStateBody,
+  EmptyStateSecondaryActions,
+  Bullseye,
+  Title,
+  Spinner,
+} from '@patternfly/react-core';
 
 const LoadingStep = ({ onClose, customText, cancelTitle, description }) => (
   <Bullseye>

--- a/src/components/steps/TimeoutStep.js
+++ b/src/components/steps/TimeoutStep.js
@@ -2,13 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, useIntl } from 'react-intl';
 
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
-import { EmptyState, EmptyStateVariant } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyState';
-import { EmptyStateIcon } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateIcon';
-import { EmptyStateBody } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateBody';
-import { EmptyStateSecondaryActions } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateSecondaryActions';
-import { Bullseye } from '@patternfly/react-core/dist/esm/layouts/Bullseye/Bullseye';
-import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
+import {
+  Button,
+  EmptyState,
+  EmptyStateVariant,
+  EmptyStateIcon,
+  EmptyStateBody,
+  EmptyStateSecondaryActions,
+  Bullseye,
+  Title,
+} from '@patternfly/react-core';
 
 import WrenchIcon from '@patternfly/react-icons/dist/esm/icons/wrench-icon';
 

--- a/src/pages/Detail.js
+++ b/src/pages/Detail.js
@@ -1,7 +1,6 @@
 import React, { lazy, Suspense } from 'react';
 
-import { Grid } from '@patternfly/react-core/dist/esm/layouts/Grid/Grid';
-import { GridItem } from '@patternfly/react-core/dist/esm/layouts/Grid/GridItem';
+import { Grid, GridItem } from '@patternfly/react-core';
 
 import SourceSummaryCard from '../components/SourceDetail/SourceSummaryCard';
 import ApplicationsCard from '../components/SourceDetail/ApplicationsCard';

--- a/src/pages/Sources.js
+++ b/src/pages/Sources.js
@@ -1,7 +1,7 @@
 import React, { useEffect, lazy, Suspense, useReducer } from 'react';
 import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { Link, useHistory } from 'react-router-dom';
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
+import { Button, Tooltip } from '@patternfly/react-core';
 import { useIntl } from 'react-intl';
 
 import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components/PrimaryToolbar';
@@ -39,7 +39,6 @@ import {
 import { useIsLoaded } from '../hooks/useIsLoaded';
 import { useHasWritePermissions } from '../hooks/useHasWritePermissions';
 import CustomRoute from '../components/CustomRoute/CustomRoute';
-import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip/Tooltip';
 import { PaginationLoader } from '../components/SourcesTable/loaders';
 import TabNavigation from '../components/TabNavigation';
 import CloudCards from '../components/CloudTiles/CloudCards';

--- a/src/pages/Sources/helpers.js
+++ b/src/pages/Sources/helpers.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import awesomeDebounce from 'awesome-debounce-promise';
 
-import { AlertActionLink } from '@patternfly/react-core/dist/esm/components/Alert/AlertActionLink';
+import { AlertActionLink } from '@patternfly/react-core';
 
 import { loadEntities, filterSources, addMessage, removeMessage } from '../../redux/sources/actions';
 import { replaceRouteId, routes } from '../../Routes';

--- a/src/test/addSourceWizard/addSourceWizard/addSourceSchema.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/addSourceSchema.test.js
@@ -14,8 +14,7 @@ import {
 import sourceTypes, { OPENSHIFT_TYPE } from '../helpers/sourceTypes';
 import applicationTypes from '../helpers/applicationTypes';
 
-import { Text } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
+import { Text, TextContent } from '@patternfly/react-core';
 
 import mount from '../__mocks__/mount';
 import { NO_APPLICATION_VALUE } from '../../../components/addSourceWizard/stringConstants';

--- a/src/test/addSourceWizard/addSourceWizard/descriptions/subWatchDescription.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/descriptions/subWatchDescription.test.js
@@ -1,11 +1,7 @@
 /* eslint-disable react/display-name */
 import React from 'react';
 
-import { Text } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { Stack } from '@patternfly/react-core/dist/esm/layouts/Stack/Stack';
-import { StackItem } from '@patternfly/react-core/dist/esm/layouts/Stack/StackItem';
-import { Flex } from '@patternfly/react-core/dist/esm/layouts/Flex/Flex';
-import { FlexItem } from '@patternfly/react-core/dist/esm/layouts/Flex/FlexItem';
+import { Text, Stack, StackItem, Flex, FlexItem } from '@patternfly/react-core';
 import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
 
 import mount from '../../__mocks__/mount';

--- a/src/test/addSourceWizard/addSourceWizard/editLink.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/editLink.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
+import { Button } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 
 import EditLink from '../../../components/addSourceWizard/EditLink';

--- a/src/test/addSourceWizard/addSourceWizard/finalWizard.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/finalWizard.test.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
-import { EmptyState } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyState';
-import { EmptyStateBody } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateBody';
-import { EmptyStateSecondaryActions } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateSecondaryActions';
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
-import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
+import { EmptyState, EmptyStateBody, EmptyStateSecondaryActions, Button, Title } from '@patternfly/react-core';
 
 import FinalWizard from '../../../components/addSourceWizard/FinalWizard';
 import LoadingStep from '../../../components/steps/LoadingStep';

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/access_key.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/access_key.test.js
@@ -1,8 +1,6 @@
 import React from 'react';
 
-import { Text } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
-import { Popover } from '@patternfly/react-core/dist/esm/components/Popover/Popover';
+import { Text, TextContent, Popover } from '@patternfly/react-core';
 
 import * as AwsAccess from '../../../../components/addSourceWizard/hardcodedComponents/aws/access_key';
 import mount from '../../__mocks__/mount';

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/arn.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/arn.test.js
@@ -1,12 +1,6 @@
 import React from 'react';
 
-import { Text } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
-import { TextList } from '@patternfly/react-core/dist/esm/components/Text/TextList';
-import { TextListItem } from '@patternfly/react-core/dist/esm/components/Text/TextListItem';
-import { ClipboardCopy } from '@patternfly/react-core/dist/esm/components/ClipboardCopy/ClipboardCopy';
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
-import { Popover } from '@patternfly/react-core/dist/esm/components/Popover/Popover';
+import { Text, TextContent, TextList, TextListItem, ClipboardCopy, Button, Popover } from '@patternfly/react-core';
 
 import QuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/question-circle-icon';
 

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/cost_management_azure.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/cost_management_azure.test.js
@@ -1,8 +1,6 @@
 import React from 'react';
 
-import { Text } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
-import { ClipboardCopy } from '@patternfly/react-core/dist/esm/components/ClipboardCopy/ClipboardCopy';
+import { Text, TextContent, ClipboardCopy } from '@patternfly/react-core';
 
 import * as Cm from '.../../../../components/addSourceWizard/hardcodedComponents/azure/costManagement';
 import RenderContext from '@data-driven-forms/react-form-renderer/renderer-context';

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/google_cost.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/google_cost.test.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
-import { Text } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
-import { TextList } from '@patternfly/react-core/dist/esm/components/Text/TextList';
-import { TextListItem } from '@patternfly/react-core/dist/esm/components/Text/TextListItem';
-import { ClipboardCopy } from '@patternfly/react-core/dist/esm/components/ClipboardCopy/ClipboardCopy';
+import { Text, TextContent, TextList, TextListItem, ClipboardCopy } from '@patternfly/react-core';
 
 import * as api from '../../../../api/entities';
 

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/openshift.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/openshift.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import mount from '../../__mocks__/mount';
-import { Text } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
+import { Text, TextContent } from '@patternfly/react-core';
 
 import * as OpenShift from '../../../../components/addSourceWizard/hardcodedComponents/openshift/endpoint';
 

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/openshift_token.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/openshift_token.test.js
@@ -1,9 +1,6 @@
 import React from 'react';
 import mount from '../../__mocks__/mount';
-import { Text } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
-import { TextList } from '@patternfly/react-core/dist/esm/components/Text/TextList';
-import { TextListItem } from '@patternfly/react-core/dist/esm/components/Text/TextListItem';
+import { Text, TextContent, TextList, TextListItem } from '@patternfly/react-core';
 
 import * as OpToken from '../../../../components/addSourceWizard/hardcodedComponents/openshift/token';
 

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/subscription_watch_arn.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/subscription_watch_arn.test.js
@@ -2,11 +2,7 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 import mount from '../../__mocks__/mount';
 
-import { Text } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
-import { TextList } from '@patternfly/react-core/dist/esm/components/Text/TextList';
-import { TextListItem } from '@patternfly/react-core/dist/esm/components/Text/TextListItem';
-import { ClipboardCopy } from '@patternfly/react-core/dist/esm/components/ClipboardCopy/ClipboardCopy';
+import { Text, TextContent, TextList, TextListItem, ClipboardCopy } from '@patternfly/react-core';
 
 import * as SubsAwsArn from '../../../../components/addSourceWizard/hardcodedComponents/aws/subscriptionWatch';
 import * as api from '../../../../api/subscriptionWatch';

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/tower_catalog.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/tower_catalog.test.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import mount from '../../__mocks__/mount';
 
-import { Text } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
+import { Text, TextContent } from '@patternfly/react-core';
 
 import * as TowerCatalog from '../../../../components/addSourceWizard/hardcodedComponents/tower/catalog';
 

--- a/src/test/addSourceWizard/addSourceWizard/sourceAddModal.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/sourceAddModal.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
-import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import { Button } from '@patternfly/react-core';
 
 import AddSourceWizard from '../../../components/addSourceWizard/SourceAddModal';
 import sourceTypes from '../helpers/sourceTypes';

--- a/src/test/addSourceWizard/addSourceWizard/sslFormLabel.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/sslFormLabel.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Popover } from '@patternfly/react-core/dist/esm/components/Popover/Popover';
+import { Popover } from '@patternfly/react-core';
 
 import QuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/question-circle-icon';
 

--- a/src/test/addSourceWizard/addSourceWizard/steps.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/steps.test.js
@@ -1,13 +1,15 @@
 import React from 'react';
 
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
-import { EmptyState } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyState';
-import { EmptyStateBody } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateBody';
-import { EmptyStateSecondaryActions } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateSecondaryActions';
-import { Bullseye } from '@patternfly/react-core/dist/esm/layouts/Bullseye/Bullseye';
-import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
-import { Alert } from '@patternfly/react-core/dist/esm/components/Alert/Alert';
-import { Spinner } from '@patternfly/react-core/dist/esm/components/Spinner/Spinner';
+import {
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateSecondaryActions,
+  Bullseye,
+  Title,
+  Alert,
+  Spinner,
+} from '@patternfly/react-core';
 
 import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';

--- a/src/test/addSourceWizard/addSourceWizard/superKey/applicationsStep.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/superKey/applicationsStep.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Label } from '@patternfly/react-core/dist/esm/components/Label/Label';
+import { Label } from '@patternfly/react-core';
 
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
 import applicationsStep from '../../../../components/addSourceWizard/superKey/applicationsStep';

--- a/src/test/addSourceWizard/addSourceWizard/superKey/configurationStep.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/superKey/configurationStep.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Label } from '@patternfly/react-core/dist/esm/components/Label/Label';
+import { Label } from '@patternfly/react-core';
 
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
 import sourceTypes from '../../helpers/sourceTypes';

--- a/src/test/components/Authentication.test.js
+++ b/src/test/components/Authentication.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
-import { Button } from '@patternfly/react-core/dist/js/components/Button/Button';
+import { Button } from '@patternfly/react-core';
 
 import { validatorTypes } from '@data-driven-forms/react-form-renderer';
 

--- a/src/test/components/SourcesErrorState.test.js
+++ b/src/test/components/SourcesErrorState.test.js
@@ -1,11 +1,6 @@
 import SourcesErrorState from '../../components/SourcesErrorState';
 
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
-import { EmptyState } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyState';
-import { EmptyStateIcon } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateIcon';
-import { EmptyStateBody } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateBody';
-import { Bullseye } from '@patternfly/react-core/dist/esm/layouts/Bullseye/Bullseye';
-import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
+import { Button, EmptyState, EmptyStateIcon, EmptyStateBody, Bullseye, Title } from '@patternfly/react-core';
 
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 

--- a/src/test/components/TabNavigation.test.js
+++ b/src/test/components/TabNavigation.test.js
@@ -1,10 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
-import { Tabs } from '@patternfly/react-core/dist/esm/components/Tabs/Tabs';
-import { TabButton } from '@patternfly/react-core/dist/esm/components/Tabs/TabButton';
-import { TabTitleIcon } from '@patternfly/react-core/dist/esm/components/Tabs/TabTitleIcon';
-import { TabTitleText } from '@patternfly/react-core/dist/esm/components/Tabs/TabTitleText';
+import { Tabs, TabTitleIcon, TabTitleText } from '@patternfly/react-core';
 import RedhatIcon from '@patternfly/react-icons/dist/esm/icons/redhat-icon';
 import CloudIcon from '@patternfly/react-icons/dist/esm/icons/cloud-icon';
 
@@ -61,7 +58,7 @@ describe('TabNavigation', () => {
     expect(actions.setActiveVendor).not.toHaveBeenCalled();
 
     await act(async () => {
-      wrapper.find(TabButton).first().simulate('click');
+      wrapper.find('TabButton').first().simulate('click');
     });
     wrapper.update();
 
@@ -70,7 +67,7 @@ describe('TabNavigation', () => {
     actions.setActiveVendor.mockClear();
 
     await act(async () => {
-      wrapper.find(TabButton).last().simulate('click');
+      wrapper.find('TabButton').last().simulate('click');
     });
     wrapper.update();
 

--- a/src/test/components/addApplication/AddApplication.test.js
+++ b/src/test/components/addApplication/AddApplication.test.js
@@ -1,10 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import { EmptyStateBody } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateBody';
-import { EmptyStateSecondaryActions } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateSecondaryActions';
-import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
-import { Radio } from '@patternfly/react-core/dist/js/components/Radio/Radio';
+import { EmptyStateBody, EmptyStateSecondaryActions, Title, Radio } from '@patternfly/react-core';
 
 import { Route, MemoryRouter } from 'react-router-dom';
 

--- a/src/test/components/addApplication/RemoveAppModal.test.js
+++ b/src/test/components/addApplication/RemoveAppModal.test.js
@@ -1,9 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import { Text } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
-import { Modal } from '@patternfly/react-core/dist/esm/components/Modal/Modal';
+import { Text, Button, Modal } from '@patternfly/react-core';
 
 import { MemoryRouter, Route } from 'react-router-dom';
 import { act } from 'react-dom/test-utils';

--- a/src/test/components/addApplication/WizardBody.test.js
+++ b/src/test/components/addApplication/WizardBody.test.js
@@ -1,4 +1,4 @@
-import { Wizard } from '@patternfly/react-core/dist/esm/components/Wizard/Wizard';
+import { Wizard } from '@patternfly/react-core';
 
 import { componentWrapperIntl } from '../../../utilities/testsHelpers';
 import WizardBodyAttach from '../../../components/AddApplication/WizardBody';

--- a/src/test/components/closeModal.test.js
+++ b/src/test/components/closeModal.test.js
@@ -1,8 +1,6 @@
 import React from 'react';
 
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
-import { Modal } from '@patternfly/react-core/dist/esm/components/Modal/Modal';
-import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
+import { Button, Modal, Title } from '@patternfly/react-core';
 
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
 

--- a/src/test/components/cloudTiles/CloudCards.test.js
+++ b/src/test/components/cloudTiles/CloudCards.test.js
@@ -1,9 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
-import { Card } from '@patternfly/react-core/dist/esm/components/Card/Card';
-import { CardHeader } from '@patternfly/react-core/dist/esm/components/Card/CardHeader';
-import { GridItem } from '@patternfly/react-core/dist/esm/layouts/Grid/GridItem';
+import { Card, CardHeader, GridItem } from '@patternfly/react-core';
 
 import CloudCards, { CLOUD_CARDS_KEY } from '../../../components/CloudTiles/CloudCards';
 

--- a/src/test/components/cloudTiles/CloudEmptyState.test.js
+++ b/src/test/components/cloudTiles/CloudEmptyState.test.js
@@ -1,9 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
-import { Card } from '@patternfly/react-core/dist/esm/components/Card/Card';
-import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip/Tooltip';
-import { Tile } from '@patternfly/react-core/dist/esm/components/Tile/Tile';
+import { Card, Tooltip, Tile } from '@patternfly/react-core';
 
 import componentWrapperIntl from '../../../utilities/testsHelpers';
 import CloudEmptyState from '../../../components/CloudTiles/CloudEmptyState';

--- a/src/test/components/cloudTiles/CloudTiles.test.js
+++ b/src/test/components/cloudTiles/CloudTiles.test.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
-import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip/Tooltip';
-import { Tile } from '@patternfly/react-core/dist/esm/components/Tile/Tile';
+import { Tooltip, Tile } from '@patternfly/react-core';
 
 import componentWrapperIntl from '../../../utilities/testsHelpers';
 import { MemoryRouter } from 'react-router-dom';

--- a/src/test/components/credentialsForm/credentialsForm.test.js
+++ b/src/test/components/credentialsForm/credentialsForm.test.js
@@ -2,10 +2,7 @@ import React from 'react';
 import { MemoryRouter, Route } from 'react-router-dom';
 import { act } from 'react-dom/test-utils';
 
-import { Modal } from '@patternfly/react-core/dist/esm/components/Modal';
-import { Spinner } from '@patternfly/react-core/dist/esm/components/Spinner';
-import { Bullseye } from '@patternfly/react-core/dist/esm/layouts/Bullseye';
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
+import { Modal, Spinner, Bullseye, Button } from '@patternfly/react-core';
 
 import { replaceRouteId, routes } from '../../../Routes';
 import { componentWrapperIntl } from '../../../utilities/testsHelpers';

--- a/src/test/components/formComponents/authSelect.test.js
+++ b/src/test/components/formComponents/authSelect.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Radio } from '@patternfly/react-core/dist/esm/components/Radio/Radio';
+import { Radio } from '@patternfly/react-core';
 
 import FormRenderer from '@data-driven-forms/react-form-renderer/form-renderer';
 import FormTemplate from '@data-driven-forms/pf4-component-mapper/form-template';

--- a/src/test/components/formComponents/cardSelect.test.js
+++ b/src/test/components/formComponents/cardSelect.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import { Tile } from '@patternfly/react-core/dist/esm/components/Tile/Tile';
+import { Tile } from '@patternfly/react-core';
 import { AwsIcon, OpenshiftIcon } from '@patternfly/react-icons';
 
 import FormRenderer from '@data-driven-forms/react-form-renderer/form-renderer';

--- a/src/test/components/formComponents/sourceWizardSummary.test.js
+++ b/src/test/components/formComponents/sourceWizardSummary.test.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
-import { Label } from '@patternfly/react-core/dist/esm/components/Label/Label';
-import { Alert } from '@patternfly/react-core/dist/esm/components/Alert/Alert';
-import { DescriptionListDescription } from '@patternfly/react-core/dist/esm/components/DescriptionList/DescriptionListDescription';
-import { DescriptionListGroup } from '@patternfly/react-core/dist/esm/components/DescriptionList/DescriptionListGroup';
-import { DescriptionListTerm } from '@patternfly/react-core/dist/esm/components/DescriptionList/DescriptionListTerm';
+import { Label, Alert, DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from '@patternfly/react-core';
 
 import applicationTypes, {
   COST_MANAGEMENT_APP,

--- a/src/test/components/formComponents/switchGroup.test.js
+++ b/src/test/components/formComponents/switchGroup.test.js
@@ -2,8 +2,7 @@ import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 
-import { FormGroup } from '@patternfly/react-core/dist/esm/components/Form/FormGroup';
-import { Switch } from '@patternfly/react-core/dist/esm/components/Switch/Switch';
+import { FormGroup, Switch } from '@patternfly/react-core';
 
 import FormRenderer from '@data-driven-forms/react-form-renderer/form-renderer';
 import FormTemplate from '@data-driven-forms/pf4-component-mapper/form-template';

--- a/src/test/components/formComponents/valuePopover.test.js
+++ b/src/test/components/formComponents/valuePopover.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
-import { Popover } from '@patternfly/react-core/dist/esm/components/Popover/Popover';
+import { Button, Popover } from '@patternfly/react-core';
 
 import mount from '../../addSourceWizard/__mocks__/mount';
 import ValuePopover from '../../../components/FormComponents/ValuePopover';

--- a/src/test/components/redhatTiles/RedHatEmptyState.test.js
+++ b/src/test/components/redhatTiles/RedHatEmptyState.test.js
@@ -1,9 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
-import { Card } from '@patternfly/react-core/dist/esm/components/Card/Card';
-import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip/Tooltip';
-import { Tile } from '@patternfly/react-core/dist/esm/components/Tile/Tile';
+import { Card, Tooltip, Tile } from '@patternfly/react-core';
 
 import componentWrapperIntl from '../../../utilities/testsHelpers';
 import mockStore from '../../__mocks__/mockStore';

--- a/src/test/components/redhatTiles/RedHatTiles.test.js
+++ b/src/test/components/redhatTiles/RedHatTiles.test.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
-import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip/Tooltip';
-import { Tile } from '@patternfly/react-core/dist/esm/components/Tile/Tile';
+import { Tooltip, Tile } from '@patternfly/react-core';
 
 import componentWrapperIntl from '../../../utilities/testsHelpers';
 import { MemoryRouter } from 'react-router-dom';

--- a/src/test/components/sourceDetail/ApplicationResourcesCard.test.js
+++ b/src/test/components/sourceDetail/ApplicationResourcesCard.test.js
@@ -1,6 +1,4 @@
-import { Card } from '@patternfly/react-core/dist/esm/components/Card/Card';
-import { CardBody } from '@patternfly/react-core/dist/esm/components/Card/CardBody';
-import { CardTitle } from '@patternfly/react-core/dist/esm/components/Card/CardTitle';
+import { Card, CardBody, CardTitle } from '@patternfly/react-core';
 
 import React from 'react';
 import { Route } from 'react-router-dom';

--- a/src/test/components/sourceDetail/ApplicationStatusLabel.test.js
+++ b/src/test/components/sourceDetail/ApplicationStatusLabel.test.js
@@ -1,5 +1,4 @@
-import { Popover } from '@patternfly/react-core/dist/esm/components/Popover/Popover';
-import { Label } from '@patternfly/react-core/dist/esm/components/Label/Label';
+import { Popover, Label } from '@patternfly/react-core';
 
 import React from 'react';
 import { Route } from 'react-router-dom';

--- a/src/test/components/sourceDetail/ApplicationsCard.test.js
+++ b/src/test/components/sourceDetail/ApplicationsCard.test.js
@@ -2,11 +2,7 @@ import React from 'react';
 import { MemoryRouter, Route } from 'react-router-dom';
 import { act } from 'react-dom/test-utils';
 
-import { Card } from '@patternfly/react-core/dist/esm/components/Card/Card';
-import { CardBody } from '@patternfly/react-core/dist/esm/components/Card/CardBody';
-import { FormGroup } from '@patternfly/react-core/dist/esm/components/Form/FormGroup';
-import { CardTitle } from '@patternfly/react-core/dist/esm/components/Card/CardTitle';
-import { Switch } from '@patternfly/react-core/dist/esm/components/Switch/Switch';
+import { Card, CardBody, FormGroup, CardTitle, Switch } from '@patternfly/react-core';
 
 import ApplicationsCard from '../../../components/SourceDetail/ApplicationsCard';
 import { replaceRouteId, routes } from '../../../Routes';

--- a/src/test/components/sourceDetail/AvailabilityChecker.test.js
+++ b/src/test/components/sourceDetail/AvailabilityChecker.test.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
-import { Spinner } from '@patternfly/react-core/dist/esm/components/Spinner/Spinner';
+import { Button, Spinner } from '@patternfly/react-core';
 
 import RedoIcon from '@patternfly/react-icons/dist/esm/icons/redo-icon';
 

--- a/src/test/components/sourceDetail/Breadcrumbs.test.js
+++ b/src/test/components/sourceDetail/Breadcrumbs.test.js
@@ -2,8 +2,7 @@ import React from 'react';
 import { Link, MemoryRouter, Route } from 'react-router-dom';
 import { act } from 'react-dom/test-utils';
 
-import { Breadcrumb } from '@patternfly/react-core/dist/esm/components/Breadcrumb/Breadcrumb';
-import { BreadcrumbItem } from '@patternfly/react-core/dist/esm/components/Breadcrumb/BreadcrumbItem';
+import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 
 import { replaceRouteId, routes } from '../../../Routes';
 import { componentWrapperIntl } from '../../../utilities/testsHelpers';

--- a/src/test/components/sourceDetail/DetailHeader.test.js
+++ b/src/test/components/sourceDetail/DetailHeader.test.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
 
-import { Text } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
+import { Text, Title } from '@patternfly/react-core';
 
 import { replaceRouteId, routes } from '../../../Routes';
 import { componentWrapperIntl } from '../../../utilities/testsHelpers';

--- a/src/test/components/sourceDetail/NoApplications.test.js
+++ b/src/test/components/sourceDetail/NoApplications.test.js
@@ -1,9 +1,6 @@
 import React from 'react';
 
-import { EmptyState } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyState';
-import { EmptyStateIcon } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateIcon';
-import { EmptyStateBody } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateBody';
-import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
+import { EmptyState, EmptyStateIcon, EmptyStateBody, Title } from '@patternfly/react-core';
 
 import { componentWrapperIntl } from '../../../utilities/testsHelpers';
 import NoApplications from '../../../components/SourceDetail/NoApplications';

--- a/src/test/components/sourceDetail/NoPermissions.test.js
+++ b/src/test/components/sourceDetail/NoPermissions.test.js
@@ -1,9 +1,6 @@
 import React from 'react';
 
-import { EmptyState } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyState';
-import { EmptyStateIcon } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateIcon';
-import { EmptyStateBody } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateBody';
-import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
+import { EmptyState, EmptyStateIcon, EmptyStateBody, Title } from '@patternfly/react-core';
 
 import { componentWrapperIntl } from '../../../utilities/testsHelpers';
 import NoPermissions from '../../../components/SourceDetail/NoPermissions';

--- a/src/test/components/sourceDetail/ResourcesTable.test.js
+++ b/src/test/components/sourceDetail/ResourcesTable.test.js
@@ -1,13 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
-import { CardBody } from '@patternfly/react-core/dist/esm/components/Card/CardBody';
-import { CardTitle } from '@patternfly/react-core/dist/esm/components/Card/CardTitle';
-import { EmptyState } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyState';
-import { EmptyStateBody } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateBody';
-import { Spinner } from '@patternfly/react-core/dist/esm/components/Spinner';
-import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
-import { Tabs, TabTitleText } from '@patternfly/react-core/dist/esm/components/Tabs';
+import { CardBody, CardTitle, EmptyState, EmptyStateBody, Spinner, Title, Tabs, TabTitleText } from '@patternfly/react-core';
 
 import { Table } from '@patternfly/react-table';
 

--- a/src/test/components/sourceDetail/SourceKebab.test.js
+++ b/src/test/components/sourceDetail/SourceKebab.test.js
@@ -2,14 +2,11 @@ import React from 'react';
 import { MemoryRouter, Route } from 'react-router-dom';
 import { act } from 'react-dom/test-utils';
 
-import { Dropdown } from '@patternfly/react-core/dist/esm/components/Dropdown/Dropdown';
-import { DropdownItem } from '@patternfly/react-core/dist/esm/components/Dropdown/DropdownItem';
-import { KebabToggle } from '@patternfly/react-core/dist/esm/components/Dropdown/KebabToggle';
+import { Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
 
 import { replaceRouteId, routes } from '../../../Routes';
 import { componentWrapperIntl } from '../../../utilities/testsHelpers';
 import SourceKebab from '../../../components/SourceDetail/SourceKebab';
-import { InternalDropdownItem } from '@patternfly/react-core/dist/esm/components/Dropdown/InternalDropdownItem';
 import mockStore from '../../__mocks__/mockStore';
 
 describe('SourceKebab', () => {
@@ -47,12 +44,12 @@ describe('SourceKebab', () => {
     expect(wrapper.find(DropdownItem).first().props().tooltip).toEqual(
       'To perform this action, you must be granted write permissions from your Organization Administrator.'
     );
-    expect(wrapper.find(InternalDropdownItem).first().text()).toEqual('Rename');
+    expect(wrapper.find('InternalDropdownItem').first().text()).toEqual('Rename');
     expect(wrapper.find(DropdownItem).last().props().isDisabled).toEqual(true);
     expect(wrapper.find(DropdownItem).last().props().tooltip).toEqual(
       'To perform this action, you must be granted write permissions from your Organization Administrator.'
     );
-    expect(wrapper.find(InternalDropdownItem).last().text()).toEqual('Remove');
+    expect(wrapper.find('InternalDropdownItem').last().text()).toEqual('Remove');
   });
 
   describe('with permissions', () => {
@@ -84,10 +81,10 @@ describe('SourceKebab', () => {
       expect(wrapper.find(DropdownItem)).toHaveLength(2);
       expect(wrapper.find(DropdownItem).first().props().isDisabled).toEqual(undefined);
       expect(wrapper.find(DropdownItem).first().props().tooltip).toEqual(undefined);
-      expect(wrapper.find(InternalDropdownItem).first().text()).toEqual('Rename');
+      expect(wrapper.find('InternalDropdownItem').first().text()).toEqual('Rename');
       expect(wrapper.find(DropdownItem).last().props().isDisabled).toEqual(undefined);
       expect(wrapper.find(DropdownItem).last().props().tooltip).toEqual(undefined);
-      expect(wrapper.find(InternalDropdownItem).last().text()).toEqual('Remove');
+      expect(wrapper.find('InternalDropdownItem').last().text()).toEqual('Remove');
     });
 
     it('remove source', async () => {

--- a/src/test/components/sourceDetail/SourceRenameModal.test.js
+++ b/src/test/components/sourceDetail/SourceRenameModal.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Modal } from '@patternfly/react-core/dist/esm/components/Modal/Modal';
+import { Modal } from '@patternfly/react-core';
 
 import { act } from 'react-dom/test-utils';
 

--- a/src/test/components/sourceDetail/SourceSummaryCard.test.js
+++ b/src/test/components/sourceDetail/SourceSummaryCard.test.js
@@ -1,14 +1,16 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
-import { Card } from '@patternfly/react-core/dist/esm/components/Card/Card';
-import { CardBody } from '@patternfly/react-core/dist/esm/components/Card/CardBody';
-import { CardTitle } from '@patternfly/react-core/dist/esm/components/Card/CardTitle';
-import { DescriptionList } from '@patternfly/react-core/dist/esm/components/DescriptionList/DescriptionList';
-import { DescriptionListDescription } from '@patternfly/react-core/dist/esm/components/DescriptionList/DescriptionListDescription';
-import { DescriptionListGroup } from '@patternfly/react-core/dist/esm/components/DescriptionList/DescriptionListGroup';
-import { DescriptionListTerm } from '@patternfly/react-core/dist/esm/components/DescriptionList/DescriptionListTerm';
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Button,
+} from '@patternfly/react-core';
 
 import { componentWrapperIntl } from '../../../utilities/testsHelpers';
 import sourceTypesData, { AMAZON_ID } from '../../__mocks__/sourceTypesData';

--- a/src/test/components/sourceEditForm/SourceEditModal.test.js
+++ b/src/test/components/sourceEditForm/SourceEditModal.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { Route } from 'react-router-dom';
 import { act } from 'react-dom/test-utils';
-import { Spinner } from '@patternfly/react-core/dist/esm/components/Spinner';
 
 import { componentWrapperIntl } from '../../../utilities/testsHelpers';
 import SourceEditModal from '../../../components/SourceEditForm/SourceEditModal';
@@ -11,10 +10,7 @@ import { applicationTypesData, CATALOG_APP } from '../../__mocks__/applicationTy
 import { sourceTypesData, ANSIBLE_TOWER_ID } from '../../__mocks__/sourceTypesData';
 import { sourcesDataGraphQl } from '../../__mocks__/sourcesData';
 
-import { EmptyState } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyState';
-import { TextInput } from '@patternfly/react-core/dist/js/components/TextInput/TextInput';
-import { Alert } from '@patternfly/react-core/dist/esm/components/Alert/Alert';
-import { Form } from '@patternfly/react-core/dist/js/components/Form/Form';
+import { Spinner, EmptyState, TextInput, Alert, Form } from '@patternfly/react-core';
 
 import * as editApi from '../../../api/doLoadSourceForEdit';
 import * as submit from '../../../components/SourceEditForm/onSubmit';

--- a/src/test/components/sourceEditForm/erroredModal.test.js
+++ b/src/test/components/sourceEditForm/erroredModal.test.js
@@ -8,10 +8,7 @@ import { sourcesDataGraphQl } from '../../__mocks__/sourcesData';
 
 import ErroredModal from '../../../components/SourceEditForm/ErroredModal';
 
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
-import { EmptyState } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyState';
-import { EmptyStateBody } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateBody';
-import { Title } from '@patternfly/react-core/dist/esm/components/Title/Title';
+import { Button, EmptyState, EmptyStateBody, Title } from '@patternfly/react-core';
 
 import mockStore from '../../__mocks__/mockStore';
 import ErroredStep from '../../../components/steps/ErroredStep';

--- a/src/test/components/sourceEditForm/parser/EditAlert.test.js
+++ b/src/test/components/sourceEditForm/parser/EditAlert.test.js
@@ -1,6 +1,6 @@
 import SourcesFormRenderer from '../../../../utilities/SourcesFormRenderer';
 import EditAlert from '../../../../components/SourceEditForm/parser/EditAlert';
-import { Alert } from '@patternfly/react-core/dist/esm/components/Alert/Alert';
+import { Alert } from '@patternfly/react-core';
 
 describe('EditAlert', () => {
   it('renders correctly', () => {

--- a/src/test/components/sourceEditForm/submittingModal.test.js
+++ b/src/test/components/sourceEditForm/submittingModal.test.js
@@ -6,8 +6,7 @@ import { componentWrapperIntl } from '../../../utilities/testsHelpers';
 import { routes, replaceRouteId } from '../../../Routes';
 import { sourcesDataGraphQl } from '../../__mocks__/sourcesData';
 
-import { EmptyState } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyState';
-import { Spinner } from '@patternfly/react-core/dist/esm/components/Spinner/Spinner';
+import { EmptyState, Spinner } from '@patternfly/react-core';
 
 import SubmittingModal from '../../../components/SourceEditForm/SubmittingModal';
 import mockStore from '../../__mocks__/mockStore';

--- a/src/test/components/sourceRemoveModal/AppListInRemoval.test.js
+++ b/src/test/components/sourceRemoveModal/AppListInRemoval.test.js
@@ -5,9 +5,7 @@ import { componentWrapperIntl } from '../../../utilities/testsHelpers';
 import { replaceRouteId, routes } from '../../../Routes';
 import { applicationTypesData, CATALOG_APP, COSTMANAGEMENT_APP } from '../../__mocks__/applicationTypesData';
 
-import { Text } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextList } from '@patternfly/react-core/dist/esm/components/Text/TextList';
-import { TextListItem } from '@patternfly/react-core/dist/esm/components/Text/TextListItem';
+import { Text, TextList, TextListItem } from '@patternfly/react-core';
 
 import mockStore from '../../__mocks__/mockStore';
 

--- a/src/test/components/sourceRemoveModal/SourceRemoveModal.test.js
+++ b/src/test/components/sourceRemoveModal/SourceRemoveModal.test.js
@@ -2,8 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { Route } from 'react-router-dom';
 
-import { Text } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
+import { Text, Button } from '@patternfly/react-core';
 
 import { MemoryRouter } from 'react-router-dom';
 

--- a/src/test/components/sourcesTable/EmptyStateTable.test.js
+++ b/src/test/components/sourcesTable/EmptyStateTable.test.js
@@ -1,9 +1,6 @@
 import React from 'react';
 
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
-import { EmptyState } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyState';
-import { EmptyStateBody } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateBody';
-import { Bullseye } from '@patternfly/react-core/dist/esm/layouts/Bullseye/Bullseye';
+import { Button, EmptyState, EmptyStateBody, Bullseye } from '@patternfly/react-core';
 
 import { componentWrapperIntl } from '../../../utilities/testsHelpers';
 import EmptyStateTable from '../../../components/SourcesTable/EmptyStateTable';

--- a/src/test/components/sourcesTable/SourcesTable.test.js
+++ b/src/test/components/sourcesTable/SourcesTable.test.js
@@ -5,7 +5,7 @@ import { act } from 'react-dom/test-utils';
 import ArrowsAltVIcon from '@patternfly/react-icons/dist/js/icons/arrows-alt-v-icon';
 import LongArrowAltDownIcon from '@patternfly/react-icons/dist/js/icons/long-arrow-alt-down-icon';
 
-import { DropdownItem } from '@patternfly/react-core/dist/esm/components/Dropdown/DropdownItem';
+import { DropdownItem } from '@patternfly/react-core';
 
 import SourcesTable, {
   insertEditAction,

--- a/src/test/components/sourcesTable/loaders.test.js
+++ b/src/test/components/sourcesTable/loaders.test.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { RowWrapper } from '@patternfly/react-table';
-import { Spinner } from '@patternfly/react-core/dist/esm/components/Spinner';
-import { Bullseye } from '@patternfly/react-core/dist/esm/layouts/Bullseye';
-
-import { Card } from '@patternfly/react-core/dist/esm/components/Card/Card';
-import { CardBody } from '@patternfly/react-core/dist/esm/components/Card/CardBody';
+import { Spinner, Bullseye, Card, CardBody } from '@patternfly/react-core';
 
 import { PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components/PageHeader';
 import { Section } from '@redhat-cloud-services/frontend-components/Section';

--- a/src/test/pages/Detail.test.js
+++ b/src/test/pages/Detail.test.js
@@ -2,8 +2,7 @@ import React from 'react';
 import { Route } from 'react-router-dom';
 import { act } from 'react-dom/test-utils';
 
-import { GridItem } from '@patternfly/react-core/dist/esm/layouts/Grid/GridItem';
-import { Grid } from '@patternfly/react-core/dist/esm/layouts/Grid/Grid';
+import { GridItem, Grid } from '@patternfly/react-core';
 
 import Detail from '../../pages/Detail';
 import { DetailLoader } from '../../components/SourcesTable/loaders';

--- a/src/test/pages/Sources.test.js
+++ b/src/test/pages/Sources.test.js
@@ -2,14 +2,7 @@ import React from 'react';
 import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components/PrimaryToolbar';
 import { act } from 'react-dom/test-utils';
 
-import { Button } from '@patternfly/react-core/dist/js/components/Button/Button';
-import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip/Tooltip';
-import { Tile } from '@patternfly/react-core/dist/esm/components/Tile/Tile';
-import { Alert } from '@patternfly/react-core/dist/js/components/Alert/Alert';
-import { Pagination } from '@patternfly/react-core/dist/js/components/Pagination/Pagination';
-import { AlertActionLink } from '@patternfly/react-core/dist/esm/components/Alert/AlertActionLink';
-import { Chip } from '@patternfly/react-core/dist/js/components/ChipGroup/Chip';
-import { Select } from '@patternfly/react-core/dist/js/components/Select/Select';
+import { Button, Tooltip, Tile, Alert, Pagination, AlertActionLink, Chip, Select } from '@patternfly/react-core';
 
 import { MemoryRouter, Link } from 'react-router-dom';
 import NotificationsPortal from '@redhat-cloud-services/frontend-components-notifications/NotificationPortal';

--- a/src/test/utilities/resolveProps/validated.test.js
+++ b/src/test/utilities/resolveProps/validated.test.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import mount from '../../addSourceWizard/__mocks__/mount';
 
-import { Spinner } from '@patternfly/react-core/dist/esm/components/Spinner/Spinner';
-import { FormHelperText } from '@patternfly/react-core/dist/esm/components/Form/FormHelperText';
+import { Spinner, FormHelperText } from '@patternfly/react-core';
 
 import Form from '@data-driven-forms/react-form-renderer/form';
 

--- a/src/test/views/formatters.test.js
+++ b/src/test/views/formatters.test.js
@@ -43,12 +43,7 @@ import {
   CATALOG_APP,
 } from '../__mocks__/applicationTypesData';
 
-import { Badge } from '@patternfly/react-core/dist/esm/components/Badge/Badge';
-import { Popover } from '@patternfly/react-core/dist/esm/components/Popover/Popover';
-import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip/Tooltip';
-import { Label } from '@patternfly/react-core/dist/esm/components/Label/Label';
-import { LabelGroup } from '@patternfly/react-core/dist/esm/components/LabelGroup/LabelGroup';
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
+import { Badge, Popover, Tooltip, Label, LabelGroup, Button } from '@patternfly/react-core';
 
 import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 import { IntlProvider } from 'react-intl';

--- a/src/utilities/resolveProps/validated.js
+++ b/src/utilities/resolveProps/validated.js
@@ -2,8 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 
-import { Spinner } from '@patternfly/react-core/dist/esm/components/Spinner/Spinner';
-import { FormHelperText } from '@patternfly/react-core/dist/esm/components/Form/FormHelperText';
+import { Spinner, FormHelperText } from '@patternfly/react-core';
 
 import FormSpy from '@data-driven-forms/react-form-renderer/form-spy';
 

--- a/src/views/formatters.js
+++ b/src/views/formatters.js
@@ -1,14 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Text, TextVariants } from '@patternfly/react-core/dist/esm/components/Text/Text';
-import { TextContent } from '@patternfly/react-core/dist/esm/components/Text/TextContent';
-import { Badge } from '@patternfly/react-core/dist/esm/components/Badge/Badge';
-import { Popover } from '@patternfly/react-core/dist/esm/components/Popover/Popover';
-import { Tooltip } from '@patternfly/react-core/dist/esm/components/Tooltip/Tooltip';
-import { Label } from '@patternfly/react-core/dist/esm/components/Label/Label';
-import { LabelGroup } from '@patternfly/react-core/dist/esm/components/LabelGroup/LabelGroup';
-import { Button } from '@patternfly/react-core/dist/esm/components/Button/Button';
+import { Text, TextVariants, TextContent, Badge, Popover, Tooltip, Label, LabelGroup, Button } from '@patternfly/react-core';
 
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 


### PR DESCRIPTION
Replace PF imports to use automatic treeshaking.

**Before**

![Screenshot 2021-03-16 at 14 36 39](https://user-images.githubusercontent.com/32869456/111318222-237ac780-8665-11eb-91ae-0e8ac441cc63.png)

**After**

![Screenshot 2021-03-16 at 14 36 48](https://user-images.githubusercontent.com/32869456/111318253-2970a880-8665-11eb-8d93-746ed2536888.png)
