### PR TITLE
Show NAME as step as second in the add source wizard

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -3,9 +3,9 @@ const config = require('@redhat-cloud-services/frontend-components-config');
 const { config: webpackConfig, plugins } = config({
   rootFolder: resolve(__dirname, '../'),
   debug: true,
-  https: false,
   useFileHash: false,
   deployment: process.env.BETA ? 'beta/apps' : 'apps',
+  useProxy: true,
 });
 
 plugins.push(

--- a/src/components/TilesShared/TilesArray.js
+++ b/src/components/TilesShared/TilesArray.js
@@ -11,6 +11,8 @@ import { filterVendorTypes } from '../../utilities/filterTypes';
 
 const TilesArray = ({ setSelectedType, mapper }) => {
   const sourceTypes = useSelector(({ sources }) => sources.sourceTypes, shallowEqual);
+  const activeVendor = useSelector(({ sources }) => sources.activeVendor);
+
   const { push } = useHistory();
   const hasWritePermissions = useHasWritePermissions();
 
@@ -22,7 +24,7 @@ const TilesArray = ({ setSelectedType, mapper }) => {
   const TileComponent = hasWritePermissions ? Tile : DisabledTile;
 
   return sourceTypes
-    .filter(filterVendorTypes)
+    .filter(filterVendorTypes(activeVendor))
     .sort((a, b) => a.product_name.localeCompare(b.product_name))
     .map(({ name }) => mapper(name, openWizard, TileComponent));
 };

--- a/src/components/addSourceWizard/FinalWizard.js
+++ b/src/components/addSourceWizard/FinalWizard.js
@@ -29,6 +29,7 @@ const FinalWizard = ({
   tryAgain,
   afterSuccess,
   sourceTypes,
+  activeVendor,
 }) => {
   const [isDeletingSource, setIsDeleting] = useState();
   const [isAfterDeletion, setDeleted] = useState();
@@ -176,8 +177,8 @@ const FinalWizard = ({
       className="sources"
       isOpen={true}
       onClose={isFinished ? afterSubmit : afterError}
-      title={wizardTitle()}
-      description={wizardDescription()}
+      title={wizardTitle(activeVendor)}
+      description={wizardDescription(activeVendor)}
       steps={[
         {
           name: 'Finish',
@@ -208,6 +209,7 @@ FinalWizard.propTypes = {
       name: PropTypes.string.isRequired,
     })
   ),
+  activeVendor: PropTypes.string,
 };
 
 export default FinalWizard;

--- a/src/components/addSourceWizard/SourceAddModal.js
+++ b/src/components/addSourceWizard/SourceAddModal.js
@@ -23,20 +23,21 @@ const initialValues = {
 
 const reducer = (
   state,
-  { type, sourceTypes, applicationTypes, container, disableAppSelection, intl, selectedType, initialWizardState }
+  { type, sourceTypes, applicationTypes, container, disableAppSelection, intl, selectedType, initialWizardState, activeVendor }
 ) => {
   switch (type) {
     case 'loaded':
       return {
         ...state,
         schema: createSchema(
-          sourceTypes.filter(filterTypes).filter(filterVendorTypes),
-          applicationTypes.filter(filterApps).filter(filterVendorAppTypes(sourceTypes)),
+          sourceTypes.filter(filterTypes).filter(filterVendorTypes(activeVendor)),
+          applicationTypes.filter(filterApps).filter(filterVendorAppTypes(sourceTypes, activeVendor)),
           disableAppSelection,
           container,
           intl,
           selectedType,
-          initialWizardState
+          initialWizardState,
+          activeVendor
         ),
         isLoading: false,
         sourceTypes,
@@ -57,6 +58,7 @@ const SourceAddModal = ({
   onSubmit,
   selectedType,
   initialWizardState,
+  activeVendor,
 }) => {
   const [{ schema, sourceTypes: stateSourceTypes, applicationTypes: stateApplicationTypes, isLoading }, dispatch] = useReducer(
     reducer,
@@ -92,6 +94,7 @@ const SourceAddModal = ({
           intl,
           selectedType,
           initialWizardState,
+          activeVendor,
         });
       }
     });
@@ -111,8 +114,8 @@ const SourceAddModal = ({
         className="sources"
         isOpen={true}
         onClose={onCancel}
-        title={wizardTitle()}
-        description={wizardDescription()}
+        title={wizardTitle(activeVendor)}
+        description={wizardDescription(activeVendor)}
         steps={[
           {
             name: 'Loading',
@@ -168,6 +171,7 @@ SourceAddModal.propTypes = {
   isCancelling: PropTypes.bool,
   selectedType: PropTypes.string,
   initialWizardState: PropTypes.object,
+  activeVendor: PropTypes.string,
 };
 
 SourceAddModal.defaultProps = {

--- a/src/components/addSourceWizard/SourceAddSchema.js
+++ b/src/components/addSourceWizard/SourceAddSchema.js
@@ -9,11 +9,10 @@ import debouncePromise from '../../utilities/debouncePromise';
 import { findSource } from '../../api/wizardHelpers';
 import { schemaBuilder } from './schemaBuilder';
 import { NO_APPLICATION_VALUE, wizardDescription, wizardTitle } from './stringConstants';
-import ValidatorReset from './ValidatorReset';
 import configurationStep from './superKey/configurationStep';
 import { compileAllApplicationComboOptions } from './compileAllApplicationComboOptions';
 import applicationsStep from './superKey/applicationsStep';
-import { getActiveVendor, REDHAT_VENDOR } from '../../utilities/constants';
+import { REDHAT_VENDOR } from '../../utilities/constants';
 import validated from '../../utilities/resolveProps/validated';
 import handleError from '../../api/handleError';
 
@@ -119,11 +118,23 @@ export const iconMapper = (sourceTypes) => (name) => {
   return Icon;
 };
 
-export const nextStep = ({ values: { application, source_type } }) => {
+export const nextStep = (selectedType) => ({ values: { application, source_type } }) => {
+  if (selectedType) {
+    return 'application_step';
+  }
+
   const appId = application && application.application_type_id !== NO_APPLICATION_VALUE && application.application_type_id;
   const resultedStep = appId ? `${source_type}-${appId}` : source_type;
 
   return resultedStep;
+};
+
+export const hasSuperKeyType = (sourceType) => sourceType?.schema.authentication.find(({ is_superkey }) => is_superkey);
+
+export const nextStepCloud = (sourceTypes) => ({ values }) => {
+  const sourceType = sourceTypes.find(({ name }) => name === values.source_type);
+
+  return hasSuperKeyType(sourceType) ? 'configuration_step' : 'application_step';
 };
 
 const sourceTypeSelect = ({ intl, sourceTypes, applicationTypes }) => ({
@@ -152,7 +163,7 @@ const redhatTypes = ({ intl, sourceTypes, applicationTypes, disableAppSelection 
       id: 'wizard.selectApplication',
       defaultMessage: 'B. Application',
     }),
-    options: compileAllApplicationComboOptions(applicationTypes, intl, sourceTypes),
+    options: compileAllApplicationComboOptions(applicationTypes, intl, sourceTypes, REDHAT_VENDOR),
     mutator: appMutatorRedHat(applicationTypes),
     isDisabled: disableAppSelection,
     isRequired: true,
@@ -161,13 +172,13 @@ const redhatTypes = ({ intl, sourceTypes, applicationTypes, disableAppSelection 
   },
 ];
 
-export const applicationStep = (applicationTypes, intl) => ({
+export const applicationStep = (applicationTypes, intl, activeVendor) => ({
   name: 'application_step',
   title: intl.formatMessage({
     id: 'wizard.selectApplication',
     defaultMessage: 'Select application',
   }),
-  nextStep,
+  nextStep: nextStep(),
   fields: [
     {
       component: componentTypes.PLAIN_TEXT,
@@ -181,7 +192,7 @@ export const applicationStep = (applicationTypes, intl) => ({
     {
       component: 'enhanced-radio',
       name: 'application.application_type_id',
-      options: compileAllApplicationComboOptions(applicationTypes, intl),
+      options: compileAllApplicationComboOptions(applicationTypes, intl, activeVendor),
       mutator: appMutatorRedHat(applicationTypes),
       menuIsPortal: true,
     },
@@ -199,19 +210,9 @@ export const typesStep = (sourceTypes, applicationTypes, disableAppSelection, in
     defaultMessage: 'Source type and application',
   }),
   name: 'types_step',
-  nextStep,
-  fields: [
-    ...redhatTypes({ intl, sourceTypes, applicationTypes, disableAppSelection }),
-    {
-      component: 'description',
-      name: 'fixasyncvalidation',
-      Content: ValidatorReset,
-    },
-  ],
+  nextStep: 'name_step',
+  fields: redhatTypes({ intl, sourceTypes, applicationTypes, disableAppSelection }),
 });
-
-export const hasSuperKeyType = (sourceType) =>
-  sourceType?.schema.authentication.find(({ is_superkey, type }) => is_superkey || type === 'access_key_secret_key');
 
 export const cloudTypesStep = (sourceTypes, applicationTypes, intl) => ({
   title: intl.formatMessage({
@@ -219,15 +220,7 @@ export const cloudTypesStep = (sourceTypes, applicationTypes, intl) => ({
     defaultMessage: 'Select source type',
   }),
   name: 'types_step',
-  nextStep: ({ values }) => {
-    if (!values.source_type) {
-      return;
-    }
-
-    const sourceType = sourceTypes.find(({ name }) => name === values.source_type);
-
-    return hasSuperKeyType(sourceType) ? 'configuration_step' : 'application_step';
-  },
+  nextStep: 'name_step',
   fields: [
     {
       component: componentTypes.PLAIN_TEXT,
@@ -243,11 +236,6 @@ export const cloudTypesStep = (sourceTypes, applicationTypes, intl) => ({
         id: 'wizard.selectCloudProvider',
         defaultMessage: 'Select a cloud provider',
       }),
-    },
-    {
-      component: 'description',
-      name: 'fixasyncvalidation',
-      Content: ValidatorReset,
     },
   ],
 });
@@ -269,23 +257,13 @@ export const NameDescription = () => {
   );
 };
 
-const nameStep = (intl, selectedType, sourceTypes) => ({
+const nameStep = (intl, selectedType, sourceTypes, activeVendor) => ({
   title: intl.formatMessage({
     id: 'wizard.nameSource',
     defaultMessage: 'Name source',
   }),
   name: 'name_step',
-  nextStep: () => {
-    if (selectedType) {
-      if (hasSuperKeyType(sourceTypes.find(({ name }) => name === selectedType))) {
-        return 'configuration_step';
-      }
-
-      return 'application_step';
-    }
-
-    return 'types_step';
-  },
+  nextStep: activeVendor === REDHAT_VENDOR ? nextStep(selectedType) : nextStepCloud(sourceTypes),
   fields: [
     {
       component: 'description',
@@ -351,7 +329,16 @@ const summaryStep = (sourceTypes, applicationTypes, intl) => ({
   }),
 });
 
-export default (sourceTypes, applicationTypes, disableAppSelection, container, intl, selectedType, initialWizardState) => {
+export default (
+  sourceTypes,
+  applicationTypes,
+  disableAppSelection,
+  container,
+  intl,
+  selectedType,
+  initialWizardState,
+  activeVendor
+) => {
   setFirstValidated(true);
 
   return {
@@ -360,9 +347,9 @@ export default (sourceTypes, applicationTypes, disableAppSelection, container, i
         component: componentTypes.WIZARD,
         name: 'wizard',
         className: 'sources',
-        title: wizardTitle(),
+        title: wizardTitle(activeVendor),
         inModal: true,
-        description: wizardDescription(),
+        description: wizardDescription(activeVendor),
         buttonLabels: {
           submit: intl.formatMessage({
             id: 'sources.add',
@@ -386,13 +373,15 @@ export default (sourceTypes, applicationTypes, disableAppSelection, container, i
         initialState: initialWizardState,
         crossroads: ['application.application_type_id', 'source_type', 'auth_select', 'source.app_creation_workflow'],
         fields: [
-          nameStep(intl, selectedType, sourceTypes),
-          !selectedType && getActiveVendor() === REDHAT_VENDOR
-            ? typesStep(sourceTypes, applicationTypes, disableAppSelection, intl)
-            : cloudTypesStep(sourceTypes, applicationTypes, intl),
+          ...(!selectedType
+            ? activeVendor === REDHAT_VENDOR
+              ? [typesStep(sourceTypes, applicationTypes, disableAppSelection, intl)]
+              : [cloudTypesStep(sourceTypes, applicationTypes, intl)]
+            : []),
+          nameStep(intl, selectedType, sourceTypes, activeVendor),
           configurationStep(intl, sourceTypes),
           applicationsStep(applicationTypes, intl),
-          applicationStep(applicationTypes, intl),
+          applicationStep(applicationTypes, intl, activeVendor),
           ...schemaBuilder(sourceTypes, applicationTypes),
           summaryStep(sourceTypes, applicationTypes, intl),
         ],

--- a/src/components/addSourceWizard/compileAllApplicationComboOptions.js
+++ b/src/components/addSourceWizard/compileAllApplicationComboOptions.js
@@ -4,7 +4,7 @@ import { NO_APPLICATION_VALUE } from './stringConstants';
 
 import { Label } from '@patternfly/react-core';
 import SubWatchDescription from './descriptions/SubWatchDescription';
-import { CLOUD_METER_APP_NAME, COST_MANAGEMENT_APP_NAME, getActiveVendor, REDHAT_VENDOR } from '../../utilities/constants';
+import { CLOUD_METER_APP_NAME, COST_MANAGEMENT_APP_NAME, REDHAT_VENDOR } from '../../utilities/constants';
 
 export const descriptionMapper = (type, intl) =>
   ({
@@ -27,7 +27,7 @@ export const labelMapper = (type, intl) =>
     ),
   }[type.name]);
 
-export const compileAllApplicationComboOptions = (applicationTypes, intl) => [
+export const compileAllApplicationComboOptions = (applicationTypes, intl, activeVendor) => [
   ...applicationTypes
     .sort((a, b) => a.display_name.localeCompare(b.display_name))
     .map((t) => ({
@@ -35,7 +35,7 @@ export const compileAllApplicationComboOptions = (applicationTypes, intl) => [
       label: labelMapper(t, intl) || t.display_name,
       description: descriptionMapper(t, intl),
     })),
-  ...(getActiveVendor() !== REDHAT_VENDOR
+  ...(activeVendor !== REDHAT_VENDOR
     ? [
         {
           label: intl.formatMessage({

--- a/src/components/addSourceWizard/index.js
+++ b/src/components/addSourceWizard/index.js
@@ -11,12 +11,12 @@ import FinalWizard from './FinalWizard';
 import { wizardTitle } from './stringConstants';
 
 import isSuperKey from '../../utilities/isSuperKey';
-import { timeoutedApps } from '../../utilities/constants';
+import { CLOUD_VENDOR, REDHAT_VENDOR, timeoutedApps } from '../../utilities/constants';
 import createSuperSource from '../../api/createSuperSource';
 import { doCreateSource } from '../../api/createSource';
 import CloseModal from '../CloseModal';
 
-const prepareInitialValues = (initialValues) => ({
+const prepareInitialValues = (initialValues, activeVendor) => ({
   isSubmitted: false,
   isFinished: false,
   isErrored: false,
@@ -24,6 +24,7 @@ const prepareInitialValues = (initialValues) => ({
   values: initialValues,
   createdSource: {},
   error: undefined,
+  activeVendor,
 });
 
 const reducer = (state, { type, values, data, error, initialValues, sourceTypes, applicationTypes }) => {
@@ -66,11 +67,12 @@ const AddSourceWizard = ({
   selectedType,
   initialWizardState,
   submitCallback,
+  activeVendor: propsActiveVendor,
 }) => {
-  const [{ isErrored, isFinished, isSubmitted, values, error, isCancelling, createdSource, ...state }, dispatch] = useReducer(
-    reducer,
-    prepareInitialValues(initialValues)
-  );
+  const [
+    { isErrored, isFinished, isSubmitted, values, error, isCancelling, createdSource, activeVendor, ...state },
+    dispatch,
+  ] = useReducer(reducer, prepareInitialValues(initialValues, propsActiveVendor));
 
   const onSubmit = (formValues, sourceTypes, wizardState, applicationTypes) => {
     dispatch({ type: 'prepareSubmitState', values: formValues, sourceTypes, applicationTypes });
@@ -118,6 +120,7 @@ const AddSourceWizard = ({
           disableAppSelection={disableAppSelection}
           selectedType={selectedType}
           initialWizardState={initialWizardState}
+          activeVendor={activeVendor}
         />
       </React.Fragment>
     );
@@ -138,6 +141,7 @@ const AddSourceWizard = ({
       tryAgain={() => onSubmit(values, state.sourceTypes, undefined, state.applicationTypes)}
       afterSuccess={afterSuccess}
       sourceTypes={state.sourceTypes}
+      activeVendor={activeVendor}
     />
   );
 };
@@ -174,6 +178,7 @@ AddSourceWizard.propTypes = {
   selectedType: PropTypes.string,
   initialWizardState: PropTypes.object,
   submitCallback: PropTypes.func,
+  activeVendor: PropTypes.oneOf([REDHAT_VENDOR, CLOUD_VENDOR]),
 };
 
 AddSourceWizard.defaultProps = {

--- a/src/components/addSourceWizard/stringConstants.js
+++ b/src/components/addSourceWizard/stringConstants.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
-import { CLOUD_VENDOR, getActiveVendor } from '../../utilities/constants';
+import { CLOUD_VENDOR } from '../../utilities/constants';
 
-export const wizardDescription = () =>
-  getActiveVendor() === CLOUD_VENDOR ? (
+export const wizardDescription = (activeVendor) =>
+  activeVendor === CLOUD_VENDOR ? (
     <FormattedMessage
       id="wizard.wizardDescriptionCloud"
       defaultMessage="Register your provider to manage your Red Hat products in the cloud."
@@ -14,8 +14,8 @@ export const wizardDescription = () =>
       defaultMessage="Configure a data source to connect to your Red Hat applications."
     />
   );
-export const wizardTitle = () =>
-  getActiveVendor() === CLOUD_VENDOR ? (
+export const wizardTitle = (activeVendor) =>
+  activeVendor === CLOUD_VENDOR ? (
     <FormattedMessage id="wizard.wizardTitleCloud" defaultMessage="Add a cloud source" />
   ) : (
     <FormattedMessage id="wizard.wizardTitleRedhat" defaultMessage="Add Red Hat source" />

--- a/src/pages/Sources.js
+++ b/src/pages/Sources.js
@@ -135,7 +135,7 @@ const SourcesPage = () => {
 
   const showPaginationLoader = (!loaded || !appTypesLoaded || !sourceTypesLoaded) && !paginationClicked;
 
-  const filteredSourceTypes = sourceTypes.filter(filterVendorTypes);
+  const filteredSourceTypes = sourceTypes.filter(filterVendorTypes(activeVendor));
 
   const mainContent = () => (
     <React.Fragment>
@@ -216,7 +216,9 @@ const SourcesPage = () => {
               type: 'checkbox',
               filterValues: {
                 onChange: (_event, value) => setFilter('applications', value, dispatch),
-                items: prepareApplicationTypeSelection(appTypes?.filter(filterVendorAppTypes(filteredSourceTypes)) || []),
+                items: prepareApplicationTypeSelection(
+                  appTypes?.filter(filterVendorAppTypes(filteredSourceTypes, activeVendor)) || []
+                ),
                 value: filterValue.applications,
               },
             },
@@ -285,6 +287,7 @@ const SourcesPage = () => {
             submitCallback: (state) => checkSubmit(state, dispatch, history.push, intl, stateDispatch),
             initialValues: wizardInitialValues,
             initialWizardState: wizardInitialState,
+            activeVendor,
           }}
         />
       </Suspense>

--- a/src/test/addSourceWizard/addSourceWizard/addSourceButton.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/addSourceButton.test.js
@@ -7,13 +7,16 @@ import applicationTypes from '../helpers/applicationTypes';
 import Form from '../../../components/addSourceWizard/SourceAddModal';
 
 import mount from '../__mocks__/mount';
+import { CLOUD_VENDOR } from '../../../utilities/constants';
 
 describe('AddSourceButton', () => {
   it('opens wizard and close wizard', async () => {
     let wrapper;
 
     await act(async () => {
-      wrapper = mount(<AddSourceButton sourceTypes={sourceTypes} applicationTypes={applicationTypes} />);
+      wrapper = mount(
+        <AddSourceButton sourceTypes={sourceTypes} applicationTypes={applicationTypes} activeVendor={CLOUD_VENDOR} />
+      );
     });
     wrapper.update();
 

--- a/src/test/addSourceWizard/addSourceWizard/addSourceSchema.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/addSourceSchema.test.js
@@ -20,6 +20,7 @@ import mount from '../__mocks__/mount';
 import { NO_APPLICATION_VALUE } from '../../../components/addSourceWizard/stringConstants';
 import SubWatchDescription from '../../../components/addSourceWizard/descriptions/SubWatchDescription';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
+import SourcesFormRenderer from '../../../utilities/SourcesFormRenderer';
 
 describe('Add source schema', () => {
   const INTL = { formatMessage: ({ defaultMessage }) => defaultMessage };
@@ -100,10 +101,17 @@ describe('Add source schema', () => {
 
   describe('descriptions', () => {
     it('renders name description', () => {
-      const wrapper = mount(<NameDescription />);
+      const wrapper = mount(
+        <SourcesFormRenderer
+          onSubmit={jest.fn()}
+          initialValues={{ source_type: 'amazon' }}
+          schema={{ fields: [{ component: 'description', name: 'desc', Content: NameDescription, sourceTypes }] }}
+        />
+      );
 
       expect(wrapper.find(TextContent)).toHaveLength(1);
       expect(wrapper.find(Text)).toHaveLength(1);
+      expect(wrapper.find(Text).text()).toEqual('Enter a name for your Amazon Web Services source.');
     });
 
     it('renders summary description', () => {
@@ -190,7 +198,9 @@ describe('Add source schema', () => {
       expect(result.title).toEqual('Select source type');
 
       expect(result.fields[0].component).toEqual(componentTypes.PLAIN_TEXT);
-      expect(result.fields[0].label).toEqual('Select a cloud provider to connect to your Red Hat account.');
+      expect(result.fields[0].label).toEqual(
+        'To import data for an application, you need to connect to a data source. Start by selecting your source type.'
+      );
 
       expect(result.fields[1].name).toEqual('source_type');
       expect(result.fields[1].label).toEqual('Select a cloud provider');
@@ -199,16 +209,20 @@ describe('Add source schema', () => {
     it('red hat type selection', () => {
       const result = typesStep(sourceTypes, applicationTypes, false, INTL);
 
-      expect(result.fields).toHaveLength(2);
-      expect(result.fields[0].name).toEqual('source_type');
-      expect(result.fields[0].mutator).toEqual(undefined);
-      expect(result.fields[1].name).toEqual('application.application_type_id');
-      expect(result.fields[1].component).toEqual('enhanced-radio');
-      expect(result.fields[1].isRequired).toEqual(true);
-      expect(result.fields[1].validate).toEqual([{ type: 'required' }]);
-      expect(result.fields[1].placeholder).toEqual(undefined);
-      expect(result.fields[1].condition).toEqual({ isNotEmpty: true, when: 'source_type' });
-      expect(result.fields[1].mutator.toString()).toEqual(appMutatorRedHat(applicationTypes).toString());
+      expect(result.fields[0].component).toEqual(componentTypes.PLAIN_TEXT);
+      expect(result.fields[0].label).toEqual(
+        'To import data for an application, you need to connect to a data source. Start by selecting your source type and application.'
+      );
+      expect(result.fields).toHaveLength(3);
+      expect(result.fields[1].name).toEqual('source_type');
+      expect(result.fields[1].mutator).toEqual(undefined);
+      expect(result.fields[2].name).toEqual('application.application_type_id');
+      expect(result.fields[2].component).toEqual('enhanced-radio');
+      expect(result.fields[2].isRequired).toEqual(true);
+      expect(result.fields[2].validate).toEqual([{ type: 'required' }]);
+      expect(result.fields[2].placeholder).toEqual(undefined);
+      expect(result.fields[2].condition).toEqual({ isNotEmpty: true, when: 'source_type' });
+      expect(result.fields[2].mutator.toString()).toEqual(appMutatorRedHat(applicationTypes).toString());
     });
   });
 

--- a/src/test/addSourceWizard/addSourceWizard/addSourceSchema.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/addSourceSchema.test.js
@@ -19,7 +19,6 @@ import { Text, TextContent } from '@patternfly/react-core';
 import mount from '../__mocks__/mount';
 import { NO_APPLICATION_VALUE } from '../../../components/addSourceWizard/stringConstants';
 import SubWatchDescription from '../../../components/addSourceWizard/descriptions/SubWatchDescription';
-import { CLOUD_VENDOR, REDHAT_VENDOR } from '../../../utilities/constants';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
 
 describe('Add source schema', () => {
@@ -35,7 +34,7 @@ describe('Add source schema', () => {
     };
 
     it('returns nextstep without selected app', () => {
-      expect(nextStep(formState)).toEqual(OPENSHIFT);
+      expect(nextStep()(formState)).toEqual(OPENSHIFT);
     });
 
     it('returns nextstep with selected app', () => {
@@ -48,7 +47,7 @@ describe('Add source schema', () => {
         },
       };
 
-      expect(nextStep(formState)).toEqual(`${OPENSHIFT}-${APP_ID}`);
+      expect(nextStep()(formState)).toEqual(`${OPENSHIFT}-${APP_ID}`);
     });
 
     it('returns nextstep with empty application', () => {
@@ -59,7 +58,7 @@ describe('Add source schema', () => {
         },
       };
 
-      expect(nextStep(formState)).toEqual(OPENSHIFT);
+      expect(nextStep()(formState)).toEqual(OPENSHIFT);
     });
   });
 
@@ -186,7 +185,7 @@ describe('Add source schema', () => {
     it('cloud type selection', () => {
       const result = cloudTypesStep(sourceTypes, applicationTypes, INTL);
 
-      expect(result.fields).toHaveLength(3);
+      expect(result.fields).toHaveLength(2);
       expect(result.name).toEqual('types_step');
       expect(result.title).toEqual('Select source type');
 
@@ -200,7 +199,7 @@ describe('Add source schema', () => {
     it('red hat type selection', () => {
       const result = typesStep(sourceTypes, applicationTypes, false, INTL);
 
-      expect(result.fields).toHaveLength(3);
+      expect(result.fields).toHaveLength(2);
       expect(result.fields[0].name).toEqual('source_type');
       expect(result.fields[0].mutator).toEqual(undefined);
       expect(result.fields[1].name).toEqual('application.application_type_id');
@@ -238,23 +237,7 @@ describe('Add source schema', () => {
   });
 
   describe('compileAllSourcesComboOptions', () => {
-    let tmpLocation;
-
-    beforeEach(() => {
-      tmpLocation = Object.assign({}, window.location);
-
-      delete window.location;
-
-      window.location = {};
-    });
-
-    afterEach(() => {
-      window.location = tmpLocation;
-    });
-
     it('cloud type selection', () => {
-      window.location.search = `activeVendor=${CLOUD_VENDOR}`;
-
       const mockSourceTypes = [
         { name: 'google', product_name: 'Google Cloud Provider', id: '1' },
         { name: 'aws', product_name: 'Amazon Web Services', id: '2' },
@@ -267,8 +250,6 @@ describe('Add source schema', () => {
     });
 
     it('red hat type selection - remove red hat', () => {
-      window.location.search = `activeVendor=${REDHAT_VENDOR}`;
-
       const mockSourceTypes = [
         { name: 'ops', product_name: 'Red Hat Openshift', vendor: 'Red Hat', id: '1' },
         { name: 'sat', product_name: 'Red Hat Satellite', vendor: 'Red Hat', id: '2' },

--- a/src/test/addSourceWizard/addSourceWizard/addSourceWizzard.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/addSourceWizzard.test.js
@@ -12,7 +12,7 @@ import * as dependency from '../../../api/wizardHelpers';
 import * as createSource from '../../../api/createSource';
 
 import mount from '../__mocks__/mount';
-import { CLOUD_VENDOR, REDHAT_VENDOR } from '../../../utilities/constants';
+import { ANSIBLE_TOWER_NAME, CLOUD_VENDOR, REDHAT_VENDOR } from '../../../utilities/constants';
 import SourcesFormRenderer from '../../../utilities/SourcesFormRenderer';
 import CloseModal from '../../../components/CloseModal';
 
@@ -48,7 +48,8 @@ describe('AddSourceWizard', () => {
     expect(wrapper.find(Form)).toHaveLength(1);
     expect(wrapper.find(Modal)).toHaveLength(1);
 
-    expect(wrapper.find(SourcesFormRenderer).props().schema.fields[0].fields[1].title).toEqual('Select source type');
+    expect(wrapper.find(SourcesFormRenderer).props().schema.fields[0].fields[0].title).toEqual('Select source type');
+    expect(wrapper.find(SourcesFormRenderer).props().schema.fields[0].fields[1].title).toEqual('Name source');
   });
 
   it('renders correctly without sourceTypes', async () => {
@@ -69,7 +70,6 @@ describe('AddSourceWizard', () => {
     expect.assertions(8);
 
     createSource.doCreateSource = jest.fn(() => new Promise((resolve) => setTimeout(() => resolve(SOURCE_DATA_OUT), 100)));
-    dependency.findSource = jest.fn(() => Promise.resolve({ data: { sources: [] } }));
 
     await act(async () => {
       wrapper = mount(<AddSourceWizard {...initialProps} />);
@@ -77,13 +77,7 @@ describe('AddSourceWizard', () => {
     wrapper.update();
 
     await act(async () => {
-      wrapper.find('input').instance().value = 'somename';
-      wrapper.find('input').simulate('change');
-    });
-    wrapper.update();
-
-    await act(async () => {
-      jest.advanceTimersByTime(1000);
+      wrapper.find('Tile').first().simulate('click');
     });
     wrapper.update();
 
@@ -111,11 +105,8 @@ describe('AddSourceWizard', () => {
   });
 
   it('pass created source to afterSuccess function', async () => {
-    jest.useFakeTimers();
-
     const afterSubmitMock = jest.fn();
     createSource.doCreateSource = jest.fn(() => new Promise((resolve) => resolve({ name: 'source', applications: [] })));
-    dependency.findSource = jest.fn(() => Promise.resolve({ data: { sources: [] } }));
 
     await act(async () => {
       wrapper = mount(<AddSourceWizard {...initialProps} afterSuccess={afterSubmitMock} />);
@@ -123,13 +114,7 @@ describe('AddSourceWizard', () => {
     wrapper.update();
 
     await act(async () => {
-      wrapper.find('input').instance().value = 'somename';
-      wrapper.find('input').simulate('change');
-    });
-    wrapper.update();
-
-    await act(async () => {
-      jest.advanceTimersByTime(1000);
+      wrapper.find('Tile').first().simulate('click');
     });
     wrapper.update();
 
@@ -138,22 +123,12 @@ describe('AddSourceWizard', () => {
     });
     wrapper.update();
 
-    await act(async () => {
-      jest.runAllTimers();
-    });
-    wrapper.update();
-
     expect(afterSubmitMock).toHaveBeenCalledWith({ name: 'source', applications: [] });
-
-    jest.useRealTimers();
   });
 
   it('pass created source to submitCallback function when success', async () => {
-    jest.useFakeTimers();
-
     const submitCallback = jest.fn();
     createSource.doCreateSource = jest.fn(() => new Promise((resolve) => resolve({ name: 'source', applications: [] })));
-    dependency.findSource = jest.fn(() => Promise.resolve({ data: { sources: [] } }));
 
     await act(async () => {
       wrapper = mount(<AddSourceWizard {...initialProps} submitCallback={submitCallback} />);
@@ -161,23 +136,12 @@ describe('AddSourceWizard', () => {
     wrapper.update();
 
     await act(async () => {
-      wrapper.find('input').instance().value = 'somename';
-      wrapper.find('input').simulate('change');
-    });
-    wrapper.update();
-
-    await act(async () => {
-      jest.advanceTimersByTime(1000);
+      wrapper.find('Tile').first().simulate('click');
     });
     wrapper.update();
 
     await act(async () => {
       wrapper.find('form').simulate('submit');
-    });
-    wrapper.update();
-
-    await act(async () => {
-      jest.runAllTimers();
     });
     wrapper.update();
 
@@ -186,16 +150,11 @@ describe('AddSourceWizard', () => {
       isSubmitted: true,
       sourceTypes,
     });
-
-    jest.useRealTimers();
   });
 
   it('pass values to submitCallback function when errors', async () => {
-    jest.useFakeTimers();
-
     const submitCallback = jest.fn();
     createSource.doCreateSource = jest.fn(() => new Promise((_, reject) => reject('Error - wrong name')));
-    dependency.findSource = jest.fn(() => Promise.resolve({ data: { sources: [] } }));
 
     await act(async () => {
       wrapper = mount(<AddSourceWizard {...initialProps} submitCallback={submitCallback} />);
@@ -203,13 +162,7 @@ describe('AddSourceWizard', () => {
     wrapper.update();
 
     await act(async () => {
-      wrapper.find('input').instance().value = 'somename';
-      wrapper.find('input').simulate('change');
-    });
-    wrapper.update();
-
-    await act(async () => {
-      jest.advanceTimersByTime(1000);
+      wrapper.find('Tile').first().simulate('click');
     });
     wrapper.update();
 
@@ -218,13 +171,8 @@ describe('AddSourceWizard', () => {
     });
     wrapper.update();
 
-    await act(async () => {
-      jest.runAllTimers();
-    });
-    wrapper.update();
-
     expect(submitCallback).toHaveBeenCalledWith({
-      values: { source: { name: 'somename' } },
+      values: { source_type: ANSIBLE_TOWER_NAME },
       isErrored: true,
       sourceTypes,
       error: 'Error - wrong name',
@@ -232,17 +180,11 @@ describe('AddSourceWizard', () => {
       // the state is not included
       wizardState: expect.any(Function),
     });
-
-    jest.useRealTimers();
   });
 
   it('pass values to onClose function', async () => {
-    jest.useFakeTimers();
-
     const CANCEL_BUTTON_INDEX = 3;
-    const NAME = 'name';
     const onClose = jest.fn();
-    dependency.findSource = jest.fn(() => Promise.resolve({ data: { sources: [] } }));
 
     await act(async () => {
       wrapper = mount(<AddSourceWizard {...initialProps} onClose={onClose} />);
@@ -250,13 +192,7 @@ describe('AddSourceWizard', () => {
     wrapper.update();
 
     await act(async () => {
-      wrapper.find('input').instance().value = NAME;
-      wrapper.find('input').simulate('change');
-    });
-    wrapper.update();
-
-    await act(async () => {
-      jest.advanceTimersByTime(1000);
+      wrapper.find('Tile').first().simulate('click');
     });
     wrapper.update();
 
@@ -274,18 +210,12 @@ describe('AddSourceWizard', () => {
 
     wrapper.update();
 
-    expect(onClose).toHaveBeenCalledWith({ source: { name: NAME } });
-
-    jest.useRealTimers();
+    expect(onClose).toHaveBeenCalledWith({ source_type: ANSIBLE_TOWER_NAME });
   });
 
   it('stay on the wizard', async () => {
-    jest.useFakeTimers();
-
     const CANCEL_BUTTON_INDEX = 3;
-    const NAME = 'name';
     const onClose = jest.fn();
-    dependency.findSource = jest.fn(() => Promise.resolve({ data: { sources: [] } }));
 
     await act(async () => {
       wrapper = mount(<AddSourceWizard {...initialProps} onClose={onClose} />);
@@ -293,13 +223,7 @@ describe('AddSourceWizard', () => {
     wrapper.update();
 
     await act(async () => {
-      wrapper.find('input').instance().value = NAME;
-      wrapper.find('input').simulate('change');
-    });
-    wrapper.update();
-
-    await act(async () => {
-      jest.advanceTimersByTime(1000);
+      wrapper.find('Tile').first().simulate('click');
     });
     wrapper.update();
 
@@ -318,15 +242,10 @@ describe('AddSourceWizard', () => {
     expect(wrapper.find(CloseModal)).toHaveLength(0);
 
     expect(onClose).not.toHaveBeenCalled();
-    expect(wrapper.find('input').instance().value).toEqual(NAME);
-
-    jest.useRealTimers();
+    expect(wrapper.find('Tile').first().props().isSelected).toEqual(true);
   });
 
   it('show error step after failing the form', async () => {
-    jest.useFakeTimers();
-
-    dependency.findSource = jest.fn(() => Promise.resolve({ data: { sources: [] } }));
     const ERROR_MESSAGE = 'fail';
     createSource.doCreateSource = jest.fn(() => new Promise((_resolve, reject) => reject(ERROR_MESSAGE)));
 
@@ -336,13 +255,7 @@ describe('AddSourceWizard', () => {
     wrapper.update();
 
     await act(async () => {
-      wrapper.find('input').instance().value = 'somename';
-      wrapper.find('input').simulate('change');
-    });
-    wrapper.update();
-
-    await act(async () => {
-      jest.advanceTimersByTime(1000);
+      wrapper.find('Tile').first().simulate('click');
     });
     wrapper.update();
 
@@ -354,16 +267,12 @@ describe('AddSourceWizard', () => {
     expect(wrapper.find(FinalWizard)).toHaveLength(1);
     expect(wrapper.find(FinishedStep)).toHaveLength(0);
     expect(wrapper.find(ErroredStep)).toHaveLength(1);
-
-    jest.useRealTimers();
   });
 
   it('afterError closes wizard with no values', async () => {
     const closeCallback = jest.fn();
-    jest.useFakeTimers();
 
     createSource.doCreateSource = jest.fn(() => Promise.resolve(SOURCE_DATA_OUT));
-    dependency.findSource = jest.fn(() => Promise.resolve({ data: { sources: [] } }));
 
     await act(async () => {
       wrapper = mount(<AddSourceWizard {...initialProps} onClose={closeCallback} />);
@@ -371,13 +280,7 @@ describe('AddSourceWizard', () => {
     wrapper.update();
 
     await act(async () => {
-      wrapper.find('input').instance().value = 'somename';
-      wrapper.find('input').simulate('change');
-    });
-    wrapper.update();
-
-    await act(async () => {
-      jest.advanceTimersByTime(1000);
+      wrapper.find('Tile').first().simulate('click');
     });
     wrapper.update();
 
@@ -398,10 +301,8 @@ describe('AddSourceWizard', () => {
 
   it('afterSubmit closes wizard with values', async () => {
     const closeCallback = jest.fn();
-    jest.useFakeTimers();
 
     createSource.doCreateSource = jest.fn(() => Promise.resolve(SOURCE_DATA_OUT));
-    dependency.findSource = jest.fn(() => Promise.resolve({ data: { sources: [] } }));
 
     await act(async () => {
       wrapper = mount(<AddSourceWizard {...initialProps} onClose={closeCallback} />);
@@ -409,13 +310,7 @@ describe('AddSourceWizard', () => {
     wrapper.update();
 
     await act(async () => {
-      wrapper.find('input').instance().value = 'somename';
-      wrapper.find('input').simulate('change');
-    });
-    wrapper.update();
-
-    await act(async () => {
-      jest.advanceTimersByTime(1000);
+      wrapper.find('Tile').first().simulate('click');
     });
     wrapper.update();
 
@@ -435,10 +330,7 @@ describe('AddSourceWizard', () => {
   });
 
   it('reset - resets initialValues', async () => {
-    jest.useFakeTimers();
-
     createSource.doCreateSource = jest.fn(() => Promise.resolve(SOURCE_DATA_OUT));
-    dependency.findSource = jest.fn(() => Promise.resolve({ data: { sources: [] } }));
 
     await act(async () => {
       wrapper = mount(<AddSourceWizard {...initialProps} />);
@@ -446,13 +338,7 @@ describe('AddSourceWizard', () => {
     wrapper.update();
 
     await act(async () => {
-      wrapper.find('input').instance().value = 'somename';
-      wrapper.find('input').simulate('change');
-    });
-    wrapper.update();
-
-    await act(async () => {
-      jest.advanceTimersByTime(1000);
+      wrapper.find('Tile').first().simulate('click');
     });
     wrapper.update();
 
@@ -466,14 +352,11 @@ describe('AddSourceWizard', () => {
     });
     wrapper.update();
 
-    expect(wrapper.find('input').instance().value).toEqual('');
+    expect(wrapper.find('Tile').first().props().isSelected).toEqual(false);
   });
 
   it('tryAgain retries the request', async () => {
-    jest.useFakeTimers();
-
     createSource.doCreateSource = jest.fn(() => Promise.resolve(SOURCE_DATA_OUT));
-    dependency.findSource = jest.fn(() => Promise.resolve({ data: { sources: [] } }));
 
     await act(async () => {
       wrapper = mount(<AddSourceWizard {...initialProps} />);
@@ -481,13 +364,7 @@ describe('AddSourceWizard', () => {
     wrapper.update();
 
     await act(async () => {
-      wrapper.find('input').instance().value = 'somename';
-      wrapper.find('input').simulate('change');
-    });
-    wrapper.update();
-
-    await act(async () => {
-      jest.advanceTimersByTime(1000);
+      wrapper.find('Tile').first().simulate('click');
     });
     wrapper.update();
 
@@ -505,34 +382,18 @@ describe('AddSourceWizard', () => {
     wrapper.update();
 
     expect(createSource.doCreateSource).toHaveBeenCalledWith(
-      { source: { name: 'somename' } },
+      { source_type: ANSIBLE_TOWER_NAME },
       expect.any(Array),
       applicationTypes
     );
   });
 
   describe('different variants', () => {
-    let tmpLocation;
-
     const getNavigation = (wrapper) => wrapper.find('.pf-c-wizard__nav-item').map((item) => item.text());
 
-    beforeEach(() => {
-      tmpLocation = Object.assign({}, window.location);
-
-      delete window.location;
-
-      window.location = {};
-    });
-
-    afterEach(() => {
-      window.location = tmpLocation;
-    });
-
     it('show configuration step when selectedType is set - CLOUD', async () => {
-      window.location.search = `activeVendor=${CLOUD_VENDOR}`;
-
       await act(async () => {
-        wrapper = mount(<AddSourceWizard {...initialProps} selectedType="amazon" />);
+        wrapper = mount(<AddSourceWizard {...initialProps} selectedType="amazon" activeVendor={CLOUD_VENDOR} />);
       });
       wrapper.update();
 
@@ -540,25 +401,24 @@ describe('AddSourceWizard', () => {
     });
 
     it('show source type selection when CLOUD', async () => {
-      window.location.search = `activeVendor=${CLOUD_VENDOR}`;
-
       await act(async () => {
-        wrapper = mount(<AddSourceWizard {...initialProps} initialValues={{ source_type: 'amazon' }} />);
+        wrapper = mount(
+          <AddSourceWizard {...initialProps} initialValues={{ source_type: 'amazon' }} activeVendor={CLOUD_VENDOR} />
+        );
       });
       wrapper.update();
 
-      expect(getNavigation(wrapper)).toEqual(['Name source', 'Select source type', 'Select configuration']);
+      expect(getNavigation(wrapper)).toEqual(['Select source type', 'Name source', 'Select configuration']);
     });
 
     it('show application step when selectedType is set and configuration is selected to true', async () => {
-      window.location.search = `activeVendor=${CLOUD_VENDOR}`;
-
       await act(async () => {
         wrapper = mount(
           <AddSourceWizard
             {...initialProps}
             selectedType="amazon"
             initialValues={{ source: { app_creation_workflow: 'account_authorization' } }}
+            activeVendor={CLOUD_VENDOR}
           />
         );
       });
@@ -568,14 +428,13 @@ describe('AddSourceWizard', () => {
     });
 
     it('show application step when selectedType is set and configuration is selected to false', async () => {
-      window.location.search = `activeVendor=${CLOUD_VENDOR}`;
-
       await act(async () => {
         wrapper = mount(
           <AddSourceWizard
             {...initialProps}
             selectedType="amazon"
             initialValues={{ source: { app_creation_workflow: 'manual_configuration' } }}
+            activeVendor={CLOUD_VENDOR}
           />
         );
       });
@@ -585,10 +444,8 @@ describe('AddSourceWizard', () => {
     });
 
     it('show application step when selectedType is set - RED HAT', async () => {
-      window.location.search = `activeVendor=${REDHAT_VENDOR}`;
-
       await act(async () => {
-        wrapper = mount(<AddSourceWizard {...initialProps} selectedType="openshift" />);
+        wrapper = mount(<AddSourceWizard {...initialProps} selectedType="openshift" activeVendor={REDHAT_VENDOR} />);
       });
       wrapper.update();
 
@@ -602,14 +459,12 @@ describe('AddSourceWizard', () => {
     });
 
     it('show source type selection when REDHAT', async () => {
-      window.location.search = `activeVendor=${REDHAT_VENDOR}`;
-
       await act(async () => {
-        wrapper = mount(<AddSourceWizard {...initialProps} />);
+        wrapper = mount(<AddSourceWizard {...initialProps} activeVendor={REDHAT_VENDOR} />);
       });
       wrapper.update();
 
-      expect(getNavigation(wrapper)).toEqual(['Name source', 'Source type and application']);
+      expect(getNavigation(wrapper)).toEqual(['Source type and application', 'Name source']);
     });
   });
 

--- a/src/test/addSourceWizard/addSourceWizard/compileAllApplicationComboOptions.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/compileAllApplicationComboOptions.test.js
@@ -3,37 +3,19 @@ import { compileAllApplicationComboOptions } from '../../../components/addSource
 import { NO_APPLICATION_VALUE } from '../../../components/addSourceWizard/stringConstants';
 
 describe('compileAllApplicationComboOptions', () => {
-  let tmpLocation;
-
   const mockAppTypes = [{ name: 'app', display_name: 'Application', id: '1' }];
 
   const INTl = { formatMessage: ({ defaultMessage }) => defaultMessage };
 
-  beforeEach(() => {
-    tmpLocation = Object.assign({}, window.location);
-
-    delete window.location;
-
-    window.location = {};
-  });
-
-  afterEach(() => {
-    window.location = tmpLocation;
-  });
-
   it('cloud type selection - has none application', () => {
-    window.location.search = `activeVendor=${CLOUD_VENDOR}`;
-
-    expect(compileAllApplicationComboOptions(mockAppTypes, INTl)).toEqual([
+    expect(compileAllApplicationComboOptions(mockAppTypes, INTl, CLOUD_VENDOR)).toEqual([
       { label: 'Application', value: '1', description: undefined },
       { label: 'No application', value: NO_APPLICATION_VALUE },
     ]);
   });
 
   it('red hat type selection - is none', () => {
-    window.location.search = `activeVendor=${REDHAT_VENDOR}`;
-
-    expect(compileAllApplicationComboOptions(mockAppTypes, INTl)).toEqual([
+    expect(compileAllApplicationComboOptions(mockAppTypes, INTl, REDHAT_VENDOR)).toEqual([
       { label: 'Application', value: '1', description: undefined },
     ]);
   });

--- a/src/test/addSourceWizard/helpers/sourceTypes.js
+++ b/src/test/addSourceWizard/helpers/sourceTypes.js
@@ -89,6 +89,7 @@ const sourceTypes = [
         {
           type: 'access_key_secret_key',
           name: 'AWS Secret Key',
+          is_superkey: true,
           fields: [
             {
               component: 'text-field',

--- a/src/test/components/cloudTiles/CloudEmptyState.test.js
+++ b/src/test/components/cloudTiles/CloudEmptyState.test.js
@@ -8,7 +8,7 @@ import CloudEmptyState from '../../../components/CloudTiles/CloudEmptyState';
 import CloudTiles from '../../../components/CloudTiles/CloudTiles';
 import mockStore from '../../__mocks__/mockStore';
 import sourceTypes, { googleType } from '../../__mocks__/sourceTypesData';
-import * as constants from '../../../utilities/constants';
+import { CLOUD_VENDOR } from '../../../utilities/constants';
 
 describe('CloudEmptyState', () => {
   let wrapper;
@@ -23,9 +23,10 @@ describe('CloudEmptyState', () => {
       setSelectedType,
     };
 
-    store = mockStore({ user: { isOrgAdmin: true }, sources: { sourceTypes: [...sourceTypes.data, googleType] } });
-
-    constants.getActiveVendor = () => constants.CLOUD_VENDOR;
+    store = mockStore({
+      user: { isOrgAdmin: true },
+      sources: { sourceTypes: [...sourceTypes.data, googleType], activeVendor: CLOUD_VENDOR },
+    });
   });
 
   it('renders correctly', async () => {

--- a/src/test/components/cloudTiles/CloudTiles.test.js
+++ b/src/test/components/cloudTiles/CloudTiles.test.js
@@ -9,7 +9,7 @@ import { routes } from '../../../Routes';
 import CloudTiles from '../../../components/CloudTiles/CloudTiles';
 import mockStore from '../../__mocks__/mockStore';
 import sourceTypes, { googleType } from '../../__mocks__/sourceTypesData';
-import * as constants from '../../../utilities/constants';
+import { CLOUD_VENDOR } from '../../../utilities/constants';
 
 describe('CloudTiles', () => {
   let wrapper;
@@ -24,9 +24,10 @@ describe('CloudTiles', () => {
       setSelectedType,
     };
 
-    store = mockStore({ user: { isOrgAdmin: true }, sources: { sourceTypes: [...sourceTypes.data, googleType] } });
-
-    constants.getActiveVendor = () => constants.CLOUD_VENDOR;
+    store = mockStore({
+      user: { isOrgAdmin: true },
+      sources: { sourceTypes: [...sourceTypes.data, googleType], activeVendor: CLOUD_VENDOR },
+    });
   });
 
   it('renders correctly', async () => {
@@ -45,7 +46,10 @@ describe('CloudTiles', () => {
   });
 
   it('renders correctly when no permissions', async () => {
-    store = mockStore({ user: { isOrgAdmin: false }, sources: { sourceTypes: [...sourceTypes.data, googleType] } });
+    store = mockStore({
+      user: { isOrgAdmin: false },
+      sources: { sourceTypes: [...sourceTypes.data, googleType], activeVendor: CLOUD_VENDOR },
+    });
 
     await act(async () => {
       wrapper = mount(componentWrapperIntl(<CloudTiles {...initialProps} />, store));

--- a/src/test/components/redhatTiles/RedHatEmptyState.test.js
+++ b/src/test/components/redhatTiles/RedHatEmptyState.test.js
@@ -8,7 +8,7 @@ import mockStore from '../../__mocks__/mockStore';
 import RedHatEmptyState from '../../../components/RedHatTiles/RedHatEmptyState';
 import RedHatTiles from '../../../components/RedHatTiles/RedHatTiles';
 import sourceTypes from '../../__mocks__/sourceTypesData';
-import * as constants from '../../../utilities/constants';
+import { REDHAT_VENDOR } from '../../../utilities/constants';
 
 describe('RedhatEmptyState', () => {
   let wrapper;
@@ -23,9 +23,7 @@ describe('RedhatEmptyState', () => {
       setSelectedType,
     };
 
-    store = mockStore({ user: { isOrgAdmin: true }, sources: { sourceTypes: sourceTypes.data } });
-
-    constants.getActiveVendor = () => constants.REDHAT_VENDOR;
+    store = mockStore({ user: { isOrgAdmin: true }, sources: { sourceTypes: sourceTypes.data }, activeVendor: REDHAT_VENDOR });
   });
 
   it('renders correctly', async () => {

--- a/src/test/components/redhatTiles/RedHatTiles.test.js
+++ b/src/test/components/redhatTiles/RedHatTiles.test.js
@@ -9,7 +9,7 @@ import { routes } from '../../../Routes';
 import mockStore from '../../__mocks__/mockStore';
 import RedHatTiles from '../../../components/RedHatTiles/RedHatTiles';
 import sourceTypes from '../../__mocks__/sourceTypesData';
-import * as constants from '../../../utilities/constants';
+import { REDHAT_VENDOR } from '../../../utilities/constants';
 
 describe('RedhatTiles', () => {
   let wrapper;
@@ -24,9 +24,10 @@ describe('RedhatTiles', () => {
       setSelectedType,
     };
 
-    store = mockStore({ user: { isOrgAdmin: true }, sources: { sourceTypes: sourceTypes.data } });
-
-    constants.getActiveVendor = () => constants.REDHAT_VENDOR;
+    store = mockStore({
+      user: { isOrgAdmin: true },
+      sources: { sourceTypes: sourceTypes.data, activeVendor: REDHAT_VENDOR },
+    });
   });
 
   it('renders correctly', async () => {

--- a/src/test/utilities/filterApps.spec.js
+++ b/src/test/utilities/filterApps.spec.js
@@ -12,8 +12,6 @@ describe('filterApps', () => {
   });
 
   describe('vendor filter', () => {
-    let tmpLocation;
-
     const sourceTypesVendors = [
       { id: '1', name: 'azure', vendor: 'Microsoft' },
       { id: '2', name: 'aws', vendor: 'amazon' },
@@ -28,22 +26,8 @@ describe('filterApps', () => {
       { id: '1', name: 'remediations', supported_source_types: ['openshift'] },
     ];
 
-    beforeEach(() => {
-      tmpLocation = Object.assign({}, window.location);
-
-      delete window.location;
-
-      window.location = {};
-    });
-
-    afterEach(() => {
-      window.location = tmpLocation;
-    });
-
     it('filters CLOUD source types', () => {
-      window.location.search = `activeVendor=${CLOUD_VENDOR}`;
-
-      expect(appTypes.filter(filterVendorAppTypes(sourceTypesVendors))).toEqual([
+      expect(appTypes.filter(filterVendorAppTypes(sourceTypesVendors, CLOUD_VENDOR))).toEqual([
         { id: '123', name: 'cost', supported_source_types: ['aws'] },
         { id: '13', name: 'sub watch', supported_source_types: ['azure'] },
         { id: '9089', name: 'topology', supported_source_types: ['openshift', 'vmware'] },
@@ -57,9 +41,7 @@ describe('filterApps', () => {
         { id: '4', name: 'vmware', vendor: 'vmware' },
       ];
 
-      window.location.search = `activeVendor=${CLOUD_VENDOR}`;
-
-      expect(appTypes.filter(filterVendorAppTypes(onlyCloudTypes))).toEqual([
+      expect(appTypes.filter(filterVendorAppTypes(onlyCloudTypes, CLOUD_VENDOR))).toEqual([
         { id: '123', name: 'cost', supported_source_types: ['aws'] },
         { id: '13', name: 'sub watch', supported_source_types: ['azure'] },
         { id: '9089', name: 'topology', supported_source_types: ['openshift', 'vmware'] },
@@ -67,9 +49,7 @@ describe('filterApps', () => {
     });
 
     it('filters RED HAT source types', () => {
-      window.location.search = `activeVendor=${REDHAT_VENDOR}`;
-
-      expect(appTypes.filter(filterVendorAppTypes(sourceTypesVendors))).toEqual([
+      expect(appTypes.filter(filterVendorAppTypes(sourceTypesVendors, REDHAT_VENDOR))).toEqual([
         { id: '9089', name: 'topology', supported_source_types: ['openshift', 'vmware'] },
         { id: '1', name: 'remediations', supported_source_types: ['openshift'] },
       ]);

--- a/src/test/utilities/filterTypes.spec.js
+++ b/src/test/utilities/filterTypes.spec.js
@@ -16,8 +16,6 @@ describe('filterTypes', () => {
   });
 
   describe('vendor filter', () => {
-    let tmpLocation;
-
     const sourceTypesVendors = [
       { id: '1', name: 'azure', vendor: 'Microsoft' },
       { id: '2', name: 'aws', vendor: 'amazon' },
@@ -25,22 +23,8 @@ describe('filterTypes', () => {
       { id: '4', name: 'vmware', vendor: 'vmware' },
     ];
 
-    beforeEach(() => {
-      tmpLocation = Object.assign({}, window.location);
-
-      delete window.location;
-
-      window.location = {};
-    });
-
-    afterEach(() => {
-      window.location = tmpLocation;
-    });
-
     it('filters CLOUD source types', () => {
-      window.location.search = `activeVendor=${CLOUD_VENDOR}`;
-
-      expect(sourceTypesVendors.filter(filterVendorTypes)).toEqual([
+      expect(sourceTypesVendors.filter(filterVendorTypes(CLOUD_VENDOR))).toEqual([
         { id: '1', name: 'azure', vendor: 'Microsoft' },
         { id: '2', name: 'aws', vendor: 'amazon' },
         { id: '4', name: 'vmware', vendor: 'vmware' },
@@ -48,9 +32,9 @@ describe('filterTypes', () => {
     });
 
     it('filters RED HAT source types', () => {
-      window.location.search = `activeVendor=${REDHAT_VENDOR}`;
-
-      expect(sourceTypesVendors.filter(filterVendorTypes)).toEqual([{ id: '3', name: 'openshift', vendor: 'Red Hat' }]);
+      expect(sourceTypesVendors.filter(filterVendorTypes(REDHAT_VENDOR))).toEqual([
+        { id: '3', name: 'openshift', vendor: 'Red Hat' },
+      ]);
     });
   });
 });

--- a/src/utilities/filterApps.js
+++ b/src/utilities/filterApps.js
@@ -1,16 +1,12 @@
-import { CLOUD_VENDOR, getActiveVendor, REDHAT_VENDOR, TOPOLOGY_INV_NAME } from './constants';
+import { CLOUD_VENDOR, REDHAT_VENDOR, TOPOLOGY_INV_NAME } from './constants';
 
 const filterApps = (type) => type.name !== TOPOLOGY_INV_NAME;
 
-export const filterVendorAppTypes = (sourceTypes) => {
-  const activeVendor = getActiveVendor();
-
-  return ({ supported_source_types }) =>
-    supported_source_types.find((type) =>
-      activeVendor === CLOUD_VENDOR
-        ? (sourceTypes.find(({ name }) => type === name)?.vendor || REDHAT_VENDOR) !== REDHAT_VENDOR
-        : sourceTypes.find(({ name }) => type === name)?.vendor === REDHAT_VENDOR
-    );
-};
+export const filterVendorAppTypes = (sourceTypes, activeVendor) => ({ supported_source_types }) =>
+  supported_source_types.find((type) =>
+    activeVendor === CLOUD_VENDOR
+      ? (sourceTypes.find(({ name }) => type === name)?.vendor || REDHAT_VENDOR) !== REDHAT_VENDOR
+      : sourceTypes.find(({ name }) => type === name)?.vendor === REDHAT_VENDOR
+  );
 
 export default filterApps;

--- a/src/utilities/filterTypes.js
+++ b/src/utilities/filterTypes.js
@@ -1,8 +1,8 @@
-import { CLOUD_VENDOR, getActiveVendor, REDHAT_VENDOR } from './constants';
+import { CLOUD_VENDOR, REDHAT_VENDOR } from './constants';
 
 const filterTypes = (type) => type.schema?.authentication && type.schema?.endpoint;
 
-export const filterVendorTypes = ({ vendor, name }) =>
-  getActiveVendor() === CLOUD_VENDOR ? vendor !== REDHAT_VENDOR : vendor === REDHAT_VENDOR && name !== 'satellite';
+export const filterVendorTypes = (activeVendor) => ({ vendor, name }) =>
+  activeVendor === CLOUD_VENDOR ? vendor !== REDHAT_VENDOR : vendor === REDHAT_VENDOR && name !== 'satellite';
 
 export default filterTypes;

--- a/src/utilities/isSuperKey.js
+++ b/src/utilities/isSuperKey.js
@@ -1,3 +1,3 @@
-const isSuperKey = (source) => source.app_creation_workflow === 'account_authorization';
+const isSuperKey = (source) => source?.app_creation_workflow === 'account_authorization';
 
 export default isSuperKey;


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-12978

- also changed that the wizard is taking activeVendor property from redux, not from the url

From empty state AWS

![Screenshot 2021-03-17 at 8 53 13](https://user-images.githubusercontent.com/32869456/111449357-9c365e00-870f-11eb-9dcc-27a7ba7952a5.png)

From table cloud super key source

![Screenshot 2021-03-17 at 16 09 21](https://user-images.githubusercontent.com/32869456/111492148-b76b9280-873c-11eb-8f6f-950c8022844e.png)

From table cloud no super key source

![Screenshot 2021-03-17 at 8 52 03](https://user-images.githubusercontent.com/32869456/111449362-9e002180-870f-11eb-9856-7ee4f0136547.png)

From empty state red hat

![Screenshot 2021-03-17 at 8 51 37](https://user-images.githubusercontent.com/32869456/111449364-9e002180-870f-11eb-9435-19da6c368db2.png)

From table red hat
![Screenshot 2021-03-17 at 16 14 58](https://user-images.githubusercontent.com/32869456/111492159-b9355600-873c-11eb-8ce5-c1ac9283b620.png)

Name description

![Screenshot 2021-03-17 at 16 20 14](https://user-images.githubusercontent.com/32869456/111492156-b89cbf80-873c-11eb-8d94-58fad21f751c.png)

