### PR TITLE
Remove unnecessary afterEach clear ups

### DIFF
--- a/src/test/addSourceWizard/addSourceWizard/sourceAddModal.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/sourceAddModal.test.js
@@ -28,10 +28,6 @@ describe('sourceAddModal', () => {
     };
   });
 
-  afterEach(() => {
-    spyFunction.mockReset();
-  });
-
   it('renders correctly with sourceTypes and applicationTypes', async () => {
     await act(async () => {
       wrapper = mount(<AddSourceWizard {...initialProps} sourceTypes={sourceTypes} applicationTypes={applicationTypes} />);

--- a/src/test/addSourceWizard/addSourceWizard/steps.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/steps.test.js
@@ -33,11 +33,6 @@ describe('Steps components', () => {
     spyFunctionSecond = jest.fn();
   });
 
-  afterEach(() => {
-    spyFunction.mockReset();
-    spyFunctionSecond.mockReset();
-  });
-
   describe('FinishedStep', () => {
     beforeEach(() => {
       initialProps = {

--- a/src/test/components/addApplication/WizardBody.test.js
+++ b/src/test/components/addApplication/WizardBody.test.js
@@ -18,10 +18,6 @@ describe('AddApplication wizard - ErroredStep', () => {
     };
   });
 
-  afterEach(() => {
-    goToSources.mockReset();
-  });
-
   it('renders correctly', () => {
     const wrapper = mount(componentWrapperIntl(<WizardBodyAttach {...initialProps} />));
 

--- a/src/test/components/formComponents/description.test.js
+++ b/src/test/components/formComponents/description.test.js
@@ -22,10 +22,6 @@ describe('Description component', () => {
       };
     });
 
-    afterEach(() => {
-      getStateSpy.mockReset();
-    });
-
     it('content', () => {
       const wrapper = mount(<Description {...initialProps} />);
       expect(wrapper.find(Content)).toHaveLength(1);

--- a/src/test/redux/sources/actions.test.js
+++ b/src/test/redux/sources/actions.test.js
@@ -34,10 +34,6 @@ describe('redux actions', () => {
     dispatch = jest.fn().mockImplementation((x) => x);
   });
 
-  afterEach(() => {
-    dispatch.mockReset();
-  });
-
   it('undoValues creates an object', () => {
     const SOURCE = { name: 'Stuart' };
     expect(addHiddenSource(SOURCE)).toEqual(


### PR DESCRIPTION
Functions are created in beforeEach, no need to clear them