### PR TITLE
Ignore empty auth type in api calls

### DIFF
--- a/src/api/createSource.js
+++ b/src/api/createSource.js
@@ -4,6 +4,7 @@ import { getSourcesApi } from './entities';
 import { checkAppAvailability } from './getApplicationStatus';
 import checkSourceStatus from './checkSourceStatus';
 import { NO_APPLICATION_VALUE } from '../components/addSourceWizard/stringConstants';
+import emptyAuthType from '../components/addSourceWizard/emptyAuthType';
 
 export const parseUrl = (url) => {
   if (!url) {
@@ -66,7 +67,7 @@ export const doCreateSource = async (formData, timetoutedApps = [], applicationT
       });
     }
 
-    if (formData.authentication) {
+    if (formData.authentication && formData.authentication.authtype !== emptyAuthType.type) {
       payload.authentications.push({
         ...formData.authentication,
         resource_type: hasEndpoint ? 'endpoint' : hasApplication ? 'application' : 'source',

--- a/src/api/doAttachApp.js
+++ b/src/api/doAttachApp.js
@@ -9,6 +9,7 @@ import { urlOrHost } from './doUpdateSource';
 import { checkAppAvailability } from '../api/getApplicationStatus';
 import handleError from '../api/handleError';
 import { timeoutedApps } from '../utilities/constants';
+import emptyAuthType from '../components/addSourceWizard/emptyAuthType';
 
 // modification of https://stackoverflow.com/a/38340374
 export const removeEmpty = (obj) => {
@@ -115,7 +116,11 @@ export const doAttachApp = async (values, formApi, authenticationInitialValues, 
 
     let authenticationDataOut;
 
-    if (filteredValues.authentication && !isEmpty(filteredValues.authentication)) {
+    if (
+      filteredValues.authentication &&
+      !isEmpty(filteredValues.authentication) &&
+      filteredValues.authentication.authtype !== emptyAuthType.type
+    ) {
       if (selectedAuthId) {
         authenticationDataOut = await getSourcesApi().updateAuthentication(selectedAuthId, filteredValues.authentication);
       } else {

--- a/src/test/api/doAttachApp.test.js
+++ b/src/test/api/doAttachApp.test.js
@@ -1,6 +1,7 @@
 import { doAttachApp, removeEmpty } from '../../api/doAttachApp';
 import * as api from '../../api/entities';
 import * as appStatus from '../..//api/getApplicationStatus';
+import emptyAuthType from '../../components/addSourceWizard/emptyAuthType';
 
 const prepareFormApi = (values) => ({
   getState: () => ({
@@ -562,6 +563,38 @@ describe('doAttachApp', () => {
       resource_type: 'Application',
       source_id: SOURCE_ID,
     });
+    expect(endpointCreate).not.toHaveBeenCalled();
+    expect(appCreate).not.toHaveBeenCalled();
+    expect(createAuthApp).not.toHaveBeenCalled();
+    expect(mockAppStatus).toHaveBeenCalledWith(ENDPOINT_ID, undefined, undefined, 'getEndpoint', expect.any(Date));
+    expect(appDelete).not.toHaveBeenCalled();
+  });
+
+  it('ignore empty auth type', async () => {
+    INITIAL_VALUES = {
+      source: {
+        id: SOURCE_ID,
+      },
+      endpoint: {
+        id: ENDPOINT_ID,
+      },
+    };
+
+    FORM_API = prepareFormApi(INITIAL_VALUES);
+
+    VALUES = {
+      authentication: {
+        password: 'pepa',
+        authtype: emptyAuthType.type,
+      },
+    };
+
+    await doAttachApp(VALUES, FORM_API, AUTHENTICATION_INIT, INITIAL_VALUES);
+
+    expect(sourceUpdate).not.toHaveBeenCalled();
+    expect(authUpdate).not.toHaveBeenCalled();
+    expect(endpointUpdate).not.toHaveBeenCalledWith();
+    expect(authCreate).not.toHaveBeenCalledWith();
     expect(endpointCreate).not.toHaveBeenCalled();
     expect(appCreate).not.toHaveBeenCalled();
     expect(createAuthApp).not.toHaveBeenCalled();


### PR DESCRIPTION
follow up of https://github.com/RedHatInsights/sources-ui/pull/649 

Empty auth type was also sent to API 😬 