### PR TITLE
Update Cost Management doc links

### DIFF
--- a/src/components/addSourceWizard/hardcodedComponents/aws/arn.js
+++ b/src/components/addSourceWizard/hardcodedComponents/aws/arn.js
@@ -23,8 +23,9 @@ import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
 
 import { HCCM_DOCS_PREFIX } from '../../stringConstants';
 
-const CREATE_S3_BUCKET = `${HCCM_DOCS_PREFIX}/html/getting_started_with_cost_management/adding_an_aws_source#creating_an_aws_s3_bucket`;
-const ENABLE_AWS_ACCOUNT = `${HCCM_DOCS_PREFIX}/html/getting_started_with_cost_management/adding_an_aws_source#enabling_aws_account_access`;
+const CREATE_S3_BUCKET = `${HCCM_DOCS_PREFIX}/html-single/getting_started_with_cost_management/index#creating-an-aws-s3-bucket_adding-aws-sources`;
+const ENABLE_AWS_ACCOUNT = `${HCCM_DOCS_PREFIX}/html-single/getting_started_with_cost_management/index#enabling-additional-aws-account-access_adding-aws-sources`;
+
 
 export const UsageDescription = () => {
   const intl = useIntl();

--- a/src/components/addSourceWizard/hardcodedComponents/azure/costManagement.js
+++ b/src/components/addSourceWizard/hardcodedComponents/azure/costManagement.js
@@ -15,9 +15,9 @@ import {
 import { HCCM_DOCS_PREFIX } from '../../stringConstants';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
 
-const CREATE_AZURE_STORAGE = `${HCCM_DOCS_PREFIX}/html/getting_started_with_cost_management/adding_an_azure_source#creating_an_azure_storage_account`;
-const AZURE_CREDS_URL = `${HCCM_DOCS_PREFIX}/html/getting_started_with_cost_management/adding_an_azure_source#configuring_azure_roles`;
-const RECURRING_TASK_URL = `${HCCM_DOCS_PREFIX}/html/getting_started_with_cost_management/adding_an_azure_source#configuring_an_azure_daily_export_schedule`;
+const CREATE_AZURE_STORAGE = `${HCCM_DOCS_PREFIX}/html-single/getting_started_with_cost_management/index#assembly-adding-azure-sources`;
+const AZURE_CREDS_URL = `${HCCM_DOCS_PREFIX}/html-single/getting_started_with_cost_management/index#configuring-azure-roles_adding-an-azure-source`;
+const RECURRING_TASK_URL = `${HCCM_DOCS_PREFIX}/html-single/getting_started_with_cost_management/index#configuring-an-azure-daily-export-schedule_adding-an-azure-source`;
 
 export const ConfigureResourceGroupAndStorageAccount = () => {
   const intl = useIntl();

--- a/src/components/addSourceWizard/hardcodedComponents/gcp/costManagement.js
+++ b/src/components/addSourceWizard/hardcodedComponents/gcp/costManagement.js
@@ -14,14 +14,14 @@ import {
   HintBody,
 } from '@patternfly/react-core';
 
+import { HCCM_DOCS_PREFIX } from '../../stringConstants';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
 
 import { getSourcesApi } from '../../../../api/entities';
 
 const b = (chunks) => <b key={`b-${chunks.length}-${Math.floor(Math.random() * 1000)}`}>{chunks}</b>;
 
-const PROJECT_LINK =
-  'https://access.redhat.com/documentation/en-us/cost_management_service/2021/html/getting_started_with_cost_management/assembly-adding-gcp-sources';
+const PROJECT_LINK = `${HCCM_DOCS_PREFIX}/html-single/getting_started_with_cost_management/index#assembly-adding-gcp-sources`;
 
 export const Project = () => {
   const intl = useIntl();

--- a/src/components/addSourceWizard/hardcodedComponents/openshift/costManagement.js
+++ b/src/components/addSourceWizard/hardcodedComponents/openshift/costManagement.js
@@ -4,7 +4,7 @@ import { HCCM_DOCS_PREFIX } from '../../stringConstants';
 
 import { Text, TextVariants, TextContent } from '@patternfly/react-core';
 
-const INSTALL_PREREQUISITE = `${HCCM_DOCS_PREFIX}/html/getting_started_with_cost_management/assembly_koku_cost_management_installing#proc_installation-overview-ocp45`;
+const INSTALL_PREREQUISITE = `${HCCM_DOCS_PREFIX}/html-single/getting_started_with_cost_management/index?lb_target=production#assembly-adding-openshift-container-platform-source`;
 
 export const ConfigureCostOperator = () => {
   const intl = useIntl();
@@ -16,10 +16,10 @@ export const ConfigureCostOperator = () => {
           {
             id: 'cost.openshift.description',
             defaultMessage:
-              'For Red Hat OpenShift Container Platform 4.5 and later, install the {operator} from the OpenShift Container Platform web console.',
+              'For Red Hat OpenShift Container Platform 4.6 and later, install the {operator} from the OpenShift Container Platform web console.',
           },
           {
-            operator: <b key="bold">koku-metrics-operator</b>,
+            operator: <b key="bold">costmanagement-metrics-operator</b>,
           }
         )}
       </Text>


### PR DESCRIPTION
This updated the Sources Wizard to reference our certified operator. In addition, Cost Management links now match the latest doc URL changes.

https://issues.redhat.com/browse/COST-1257
https://issues.redhat.com/browse/COST-1312