### PR TITLE
Do not append cluster identifier anymore

### DIFF
--- a/src/components/SourceEditForm/parser/application.js
+++ b/src/components/SourceEditForm/parser/application.js
@@ -1,7 +1,4 @@
-import React from 'react';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
-import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
-import { FormattedMessage } from 'react-intl';
 import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 
 import { authenticationFields } from './authentication';
@@ -12,19 +9,6 @@ export const APP_NAMES = {
   COST_MANAGAMENT: '/insights/platform/cost-management',
   CLOUD_METER: '/insights/platform/cloud-meter',
 };
-
-export const appendClusterIdentifier = (sourceType) =>
-  sourceType.name === 'openshift'
-    ? [
-        {
-          name: 'source.source_ref',
-          label: <FormattedMessage id="sources.clusterIdentifier" defaultMessage="Cluster identifier" />,
-          isRequired: true,
-          validate: [{ type: validatorTypes.REQUIRED }],
-          component: componentTypes.TEXT_FIELD,
-        },
-      ]
-    : [];
 
 const createOneAppFields = (appType, sourceType, app) => [
   {
@@ -42,7 +26,6 @@ const createOneAppFields = (appType, sourceType, app) => [
     appType?.name,
     app.id
   ),
-  ...(appType?.name === APP_NAMES.COST_MANAGAMENT ? appendClusterIdentifier(sourceType) : []),
 ];
 
 export const applicationsFields = (applications, sourceType, appTypes) => [

--- a/src/test/components/sourceEditForm/parser/application.test.js
+++ b/src/test/components/sourceEditForm/parser/application.test.js
@@ -1,8 +1,8 @@
-import { componentTypes, validatorTypes } from '@data-driven-forms/react-form-renderer';
+import { componentTypes } from '@data-driven-forms/react-form-renderer';
 import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 
 import ResourcesEmptyState from '../../../../components/SourceDetail/ResourcesEmptyState';
-import { applicationsFields, appendClusterIdentifier } from '../../../../components/SourceEditForm/parser/application';
+import { applicationsFields } from '../../../../components/SourceEditForm/parser/application';
 import EditAlert from '../../../../components/SourceEditForm/parser/EditAlert';
 import { applicationTypesData, COSTMANAGEMENT_APP, CATALOG_APP } from '../../../__mocks__/applicationTypesData';
 
@@ -245,29 +245,5 @@ describe('application edit form parser', () => {
     const result = applicationsFields(APPLICATIONS, SOURCE_TYPE, APP_TYPES);
 
     expect(result).toEqual(EXPECTED_RESULT);
-  });
-});
-
-describe('helpers', () => {
-  describe('appendClusterIdentifier', () => {
-    const SOURCE_TYPE = { name: 'openshift' };
-
-    it('returns cluster identifier field when type is openshift', () => {
-      expect(appendClusterIdentifier(SOURCE_TYPE)).toEqual([
-        {
-          name: 'source.source_ref',
-          label: expect.any(Object),
-          isRequired: true,
-          validate: [{ type: validatorTypes.REQUIRED }],
-          component: componentTypes.TEXT_FIELD,
-        },
-      ]);
-    });
-
-    it('dont return cluster identifier field when type is not openshift', () => {
-      const AWS_SOURCE_TYPE = { name: 'aws' };
-
-      expect(appendClusterIdentifier(AWS_SOURCE_TYPE)).toEqual([]);
-    });
   });
 });

--- a/src/test/components/sourceEditForm/parser/applicationTrueData.test.js
+++ b/src/test/components/sourceEditForm/parser/applicationTrueData.test.js
@@ -1,0 +1,56 @@
+import { applicationsFields } from '../../../../components/SourceEditForm/parser/application';
+import EditAlert from '../../../../components/SourceEditForm/parser/EditAlert';
+import applicationTypes, { COST_MANAGEMENT_APP } from '../../../addSourceWizard/helpers/applicationTypes';
+import { OPENSHIFT_TYPE } from '../../../addSourceWizard/helpers/sourceTypes';
+
+describe('application parser - true data', () => {
+  it('google + OCP', () => {
+    const schema = applicationsFields(
+      [{ id: '3789', application_type_id: COST_MANAGEMENT_APP.id, authentications: [{ id: '123', authtype: 'token' }] }],
+      OPENSHIFT_TYPE,
+      applicationTypes
+    );
+
+    expect(schema).toEqual([
+      {
+        component: 'tabs',
+        fields: [
+          {
+            fields: [
+              {
+                Content: EditAlert,
+                component: 'description',
+                condition: { isNotEmpty: true, when: expect.any(Function) },
+                name: 'messages.3789',
+              },
+              [
+                {
+                  component: 'text-field',
+                  hideField: true,
+                  initialValue: 'token',
+                  initializeOnMount: true,
+                  name: 'authentications.a123.authtype',
+                },
+                {
+                  component: 'text-field',
+                  isRequired: true,
+                  label: expect.anything(),
+                  name: 'source.source_ref',
+                  stepKey: 'usageCollector',
+                  validate: [
+                    { type: 'required' },
+                    { message: expect.anything(), pattern: /^[A-Za-z0-9]+[A-Za-z0-9_-]*$/, type: 'pattern' },
+                  ],
+                },
+              ],
+            ],
+            name: '2',
+            title: 'Cost Management',
+          },
+        ],
+        isBox: true,
+        name: 'app-tabs',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
Due to historical reasons, cluster identifier was appended "manually" in the edit form generator, however, it's not required anymore.

**Before**

![Screenshot 2021-05-13 at 10 00 14](https://user-images.githubusercontent.com/32869456/118097008-655c8b80-b3d2-11eb-91bf-514d161710c5.png)

**After**

![Screenshot 2021-05-13 at 9 59 53](https://user-images.githubusercontent.com/32869456/118097021-67bee580-b3d2-11eb-8459-24345d0ee661.png)