### PR TITLE
Block direct access to paused source actions

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -36,11 +36,13 @@ export const routes = {
     path: '/sources/detail/:id/add_app/:app_type_id',
     redirectNoId: true,
     writeAccess: true,
+    noPaused: true,
   },
   sourcesDetailRemoveApp: {
     path: '/sources/detail/:id/remove_app/:app_id',
     redirectNoId: true,
     writeAccess: true,
+    noPaused: true,
   },
   sourcesDetailEditCredentials: {
     path: '/sources/detail/:id/edit_credentials',

--- a/src/components/CustomRoute/CustomRoute.js
+++ b/src/components/CustomRoute/CustomRoute.js
@@ -2,9 +2,10 @@ import React from 'react';
 import { Route } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
-import RedirectNoWriteAccess from '../RedirectNoWriteAccess/RedirectNoWriteAccess';
 import { useSource } from '../../hooks/useSource';
+import RedirectNoWriteAccess from '../RedirectNoWriteAccess/RedirectNoWriteAccess';
 import RedirectNoId from '../RedirectNoId/RedirectNoId';
+import RedirectNoPaused from '../RedirectNoPaused/RedirectNoPaused';
 
 const CustomRouteInternal = ({ route, children }) => {
   const source = route.redirectNoId && useSource();
@@ -15,6 +16,7 @@ const CustomRouteInternal = ({ route, children }) => {
 
   return (
     <React.Fragment>
+      {route.noPaused && <RedirectNoPaused />}
       {route.writeAccess && <RedirectNoWriteAccess />}
       {children}
     </React.Fragment>
@@ -26,6 +28,7 @@ CustomRouteInternal.propTypes = {
     path: PropTypes.string.isRequired,
     redirectNoId: PropTypes.bool,
     writeAccess: PropTypes.bool,
+    noPaused: PropTypes.bool,
   }).isRequired,
   children: PropTypes.node.isRequired,
 };
@@ -43,6 +46,7 @@ CustomRoute.propTypes = {
     path: PropTypes.string.isRequired,
     redirectNoId: PropTypes.bool,
     writeAccess: PropTypes.bool,
+    noPaused: PropTypes.bool,
   }).isRequired,
   componentProps: PropTypes.any,
   Component: PropTypes.oneOfType([PropTypes.func, PropTypes.object]).isRequired,

--- a/src/components/RedirectNoPaused/RedirectNoPaused.js
+++ b/src/components/RedirectNoPaused/RedirectNoPaused.js
@@ -1,0 +1,40 @@
+import React, { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { Redirect } from 'react-router-dom';
+import { useIntl } from 'react-intl';
+
+import { addMessage } from '../../redux/sources/actions';
+import { replaceRouteId, routes } from '../../Routes';
+import { useSource } from '../../hooks/useSource';
+
+const RedirectNoPaused = () => {
+  const intl = useIntl();
+  const source = useSource();
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (source.paused_at) {
+      dispatch(
+        addMessage({
+          title: intl.formatMessage({
+            id: 'sources.sourcePausedRedirect',
+            defaultMessage: 'Source is paused',
+          }),
+          variant: 'danger',
+          description: intl.formatMessage({
+            id: 'sources.sourcePausedRedirectDescription',
+            defaultMessage: 'You cannot perform this action on a paused source.',
+          }),
+        })
+      );
+    }
+  }, [source.paused_at]);
+
+  if (source.paused_at) {
+    return <Redirect to={replaceRouteId(routes.sourcesDetail.path, source.id)} />;
+  }
+
+  return null;
+};
+
+export default RedirectNoPaused;

--- a/src/test/components/customRoute/CustomRoute.test.js
+++ b/src/test/components/customRoute/CustomRoute.test.js
@@ -5,6 +5,7 @@ import { componentWrapperIntl } from '../../../utilities/testsHelpers';
 import CustomRoute from '../../../components/CustomRoute/CustomRoute';
 import RedirectNoWriteAccess from '../../../components/RedirectNoWriteAccess/RedirectNoWriteAccess';
 import * as RedirectNoId from '../../../components/RedirectNoId/RedirectNoId';
+import * as RedirectNoPaused from '../../../components/RedirectNoPaused/RedirectNoPaused';
 import * as useSource from '../../../hooks/useSource';
 import mockStore from '../../__mocks__/mockStore';
 
@@ -90,5 +91,20 @@ describe('CustomRoute', () => {
 
     expect(wrapper.find(RedirectNoId.default)).toHaveLength(1);
     expect(useSource.useSource).toHaveBeenCalled();
+  });
+
+  it('renders RedirectNoPaused when no paused set', () => {
+    useSource.useSource = jest.fn().mockImplementation(() => ({ paused_at: 'today' }));
+    RedirectNoPaused.default = () => <h1>Redirect no paused mock</h1>;
+
+    route = {
+      ...route,
+      noPaused: true,
+    };
+
+    const wrapper = mount(componentWrapperIntl(<CustomRoute exact route={route} Component={PokusComponent} />, store, ['/path']));
+
+    expect(wrapper.find(PokusComponent)).toHaveLength(1);
+    expect(wrapper.find(RedirectNoPaused.default)).toHaveLength(1);
   });
 });

--- a/src/test/components/redirectNoPaused/RedirectNoPaused.test.js
+++ b/src/test/components/redirectNoPaused/RedirectNoPaused.test.js
@@ -1,0 +1,68 @@
+import { Route, MemoryRouter } from 'react-router-dom';
+import { mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
+
+import { componentWrapperIntl } from '../../../utilities/testsHelpers';
+import RedirectNoPaused from '../../../components/RedirectNoPaused/RedirectNoPaused';
+import * as actions from '../../../redux/sources/actions';
+import { routes, replaceRouteId } from '../../../Routes';
+import mockStore from '../../__mocks__/mockStore';
+
+describe('RedirectNoPaused', () => {
+  let initialStore;
+  let initialEntry;
+
+  const sourceId = '123';
+
+  const wasRedirectedToDetail = (wrapper) =>
+    wrapper.find(MemoryRouter).instance().history.location.pathname === replaceRouteId(routes.sourcesDetail.path, sourceId);
+
+  beforeEach(() => {
+    initialEntry = [replaceRouteId(routes.sourcesDetailRemoveApp.path, sourceId).replace(':app_id', '546')];
+
+    actions.addMessage = jest.fn().mockImplementation(() => ({ type: 'ADD_MESSAGE' }));
+  });
+
+  it('Renders null if source is not paused', () => {
+    initialStore = mockStore({
+      sources: { entities: [{ id: sourceId, paused_at: null }] },
+    });
+
+    const wrapper = mount(
+      componentWrapperIntl(
+        <Route path={routes.sourcesDetailRemoveApp.path} render={(...args) => <RedirectNoPaused {...args} />} />,
+        initialStore,
+        initialEntry
+      )
+    );
+
+    expect(wrapper.html()).toEqual('');
+    expect(wasRedirectedToDetail(wrapper)).toEqual(false);
+  });
+
+  it('Redirect to source detail when source is paused', async () => {
+    let wrapper;
+
+    initialStore = mockStore({
+      sources: { entities: [{ id: sourceId, paused_at: 'today' }] },
+    });
+
+    await act(async () => {
+      wrapper = mount(
+        componentWrapperIntl(
+          <Route path={routes.sourcesDetailRemoveApp.path} render={(...args) => <RedirectNoPaused {...args} />} />,
+          initialStore,
+          initialEntry
+        )
+      );
+    });
+
+    expect(actions.addMessage).toHaveBeenCalledWith({
+      description: 'You cannot perform this action on a paused source.',
+      title: 'Source is paused',
+      variant: 'danger',
+    });
+
+    expect(wasRedirectedToDetail(wrapper)).toEqual(true);
+  });
+});

--- a/src/test/pages/Detail.test.js
+++ b/src/test/pages/Detail.test.js
@@ -8,6 +8,7 @@ import Detail from '../../pages/Detail';
 import { DetailLoader } from '../../components/SourcesTable/loaders';
 import * as RedirectNoId from '../../components/RedirectNoId/RedirectNoId';
 import * as RedirectNoWriteAccess from '../../components/RedirectNoWriteAccess/RedirectNoWriteAccess';
+import * as RedirectNoPaused from '../../components/RedirectNoPaused/RedirectNoPaused';
 import CustomRoute from '../../components/CustomRoute/CustomRoute';
 import * as ApplicationResourcesCard from '../../components/SourceDetail/ApplicationResourcesCard';
 import * as ApplicationsCard from '../../components/SourceDetail/ApplicationsCard';
@@ -86,6 +87,7 @@ describe('SourceDetail', () => {
   ApplicationResourcesCard.default = () => <span>ResourcesCard</span>;
   RedirectNoId.default = () => <span>Mock redirect</span>;
   RedirectNoWriteAccess.default = () => <span>Mock redirect</span>;
+  RedirectNoPaused.default = () => <span>Mock redirect</span>;
 
   it('renders loading', async () => {
     RedirectNoId.default = () => <span>Mock redirect</span>;
@@ -208,6 +210,7 @@ describe('SourceDetail', () => {
 
         expect(wrapper.find(SourceRemoveModal.default)).toHaveLength(1);
         expect(wrapper.find(RedirectNoWriteAccess.default)).toHaveLength(1);
+        expect(wrapper.find(RedirectNoPaused.default)).toHaveLength(0);
       });
 
       it('routes to rename source', async () => {
@@ -226,6 +229,7 @@ describe('SourceDetail', () => {
 
         expect(wrapper.find(SourceRenameModal.default)).toHaveLength(1);
         expect(wrapper.find(RedirectNoWriteAccess.default)).toHaveLength(1);
+        expect(wrapper.find(RedirectNoPaused.default)).toHaveLength(0);
       });
 
       it('routes to add app', async () => {
@@ -244,6 +248,7 @@ describe('SourceDetail', () => {
 
         expect(wrapper.find(AddApplication.default)).toHaveLength(1);
         expect(wrapper.find(RedirectNoWriteAccess.default)).toHaveLength(1);
+        expect(wrapper.find(RedirectNoPaused.default)).toHaveLength(1);
       });
 
       it('routes to remove app', async () => {
@@ -262,6 +267,7 @@ describe('SourceDetail', () => {
 
         expect(wrapper.find(RemoveAppModal.default)).toHaveLength(1);
         expect(wrapper.find(RedirectNoWriteAccess.default)).toHaveLength(1);
+        expect(wrapper.find(RedirectNoPaused.default)).toHaveLength(1);
       });
 
       it('routes to credentials form', async () => {
@@ -280,6 +286,7 @@ describe('SourceDetail', () => {
 
         expect(wrapper.find(CredentialsForm.default)).toHaveLength(1);
         expect(wrapper.find(RedirectNoWriteAccess.default)).toHaveLength(1);
+        expect(wrapper.find(RedirectNoPaused.default)).toHaveLength(0);
       });
     });
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-14495

This blocks add_app / remove_app pages when the parent source is paused.

**After**

![Screenshot 2021-06-02 at 13 29 00](https://user-images.githubusercontent.com/32869456/120475922-46865f00-c3aa-11eb-879e-3291c4f9eec0.png)
