### PR TITLE
Fix wording for pausing fail messages

### DIFF
--- a/src/components/SourceDetail/ApplicationsCard.js
+++ b/src/components/SourceDetail/ApplicationsCard.js
@@ -19,6 +19,7 @@ import filterApps from '../../utilities/filterApps';
 import ApplicationKebab from './ApplicationKebab';
 import { ApplicationLabel } from '../../views/formatters';
 import handleError from '../../api/handleError';
+import tryAgainMessage from '../../utilities/tryAgainMessage';
 
 const initialState = {
   selectedApps: {},
@@ -90,44 +91,26 @@ const addPausedNotification = (typeId, dispatch, intl, appTypes) => {
   );
 };
 
-const addErrorNotification = (typeId, dispatch, intl, appTypes, action, error) => {
-  const appName = appTypes.find((type) => type.id === typeId)?.display_name;
-
+const addErrorNotification = (dispatch, intl, action, error) => {
   const title = {
-    remove: intl.formatMessage(
-      {
-        id: 'detail.applications.remove.error',
-        defaultMessage: '{appName} removing unsuccessful',
-      },
-      { appName }
-    ),
-    create: intl.formatMessage(
-      {
-        id: 'detail.applications.add.error',
-        defaultMessage: '{appName} adding unsuccessful',
-      },
-      { appName }
-    ),
-    pause: intl.formatMessage(
-      {
-        id: 'detail.applications.pause.error',
-        defaultMessage: '{appName} pausing unsuccessful',
-      },
-      { appName }
-    ),
-    resume: intl.formatMessage(
-      {
-        id: 'detail.applications.resume.error',
-        defaultMessage: '{appName} resuming unsuccessful',
-      },
-      { appName }
-    ),
+    create: intl.formatMessage({
+      id: 'detail.applications.add.error',
+      defaultMessage: 'Application create failed',
+    }),
+    pause: intl.formatMessage({
+      id: 'detail.applications.pause.error',
+      defaultMessage: 'Application pause failed',
+    }),
+    resume: intl.formatMessage({
+      id: 'detail.applications.resume.error',
+      defaultMessage: 'Application resume failed',
+    }),
   }[action];
 
   dispatch(
     addMessage({
       title,
-      description: handleError(error),
+      description: tryAgainMessage(intl, handleError(error)),
       variant: 'danger',
     })
   );
@@ -159,7 +142,7 @@ const ApplicationsCard = () => {
           addResumeNotification(id, dispatch, intl, appTypes);
           await dispatch(loadEntities());
         } catch (e) {
-          addErrorNotification(id, dispatch, intl, appTypes, 'resume', e);
+          addErrorNotification(dispatch, intl, 'resume', e);
         }
 
         stateDispatch({ type: 'clean', id });
@@ -175,7 +158,7 @@ const ApplicationsCard = () => {
         addPausedNotification(typeId, dispatch, intl, appTypes);
         await dispatch(loadEntities());
       } catch (e) {
-        addErrorNotification(typeId, dispatch, intl, appTypes, 'pause', e);
+        addErrorNotification(dispatch, intl, 'pause', e);
       }
 
       stateDispatch({ type: 'clean', id: typeId });
@@ -193,14 +176,14 @@ const ApplicationsCard = () => {
             addResumeNotification(id, dispatch, intl, appTypes);
             await dispatch(loadEntities());
           } catch (e) {
-            addErrorNotification(id, dispatch, intl, appTypes, 'resume', e);
+            addErrorNotification(dispatch, intl, 'resume', e);
           }
         } else {
           try {
             await doCreateApplication({ source_id: source.id, application_type_id: id });
             await dispatch(loadEntities());
           } catch (e) {
-            addErrorNotification(id, dispatch, intl, appTypes, 'create', e);
+            addErrorNotification(dispatch, intl, 'create', e);
           }
         }
 

--- a/src/redux/sources/actions.js
+++ b/src/redux/sources/actions.js
@@ -26,6 +26,7 @@ import {
 import { doLoadSourceTypes } from '../../api/source_types';
 import { bold } from '../../utilities/intlShared';
 import handleError from '../../api/handleError';
+import tryAgainMessage from '../../utilities/tryAgainMessage';
 
 export const loadEntities = (options) => (dispatch, getState) => {
   dispatch({
@@ -263,11 +264,8 @@ export const pauseSource = (sourceId, sourceName, intl) => (dispatch) => {
     .catch((error) => {
       dispatch(
         addMessage({
-          title: intl.formatMessage(
-            { id: 'source.paused.alert.error', defaultMessage: 'Source { sourceName } pausing was unsuccessful' },
-            { sourceName }
-          ),
-          description: handleError(error),
+          title: intl.formatMessage({ id: 'source.paused.alert.error', defaultMessage: 'Source pause failed' }),
+          description: tryAgainMessage(intl, handleError(error)),
           variant: 'danger',
         })
       );
@@ -297,11 +295,8 @@ export const resumeSource = (sourceId, sourceName, intl) => (dispatch) => {
     .catch((error) => {
       dispatch(
         addMessage({
-          title: intl.formatMessage(
-            { id: 'source.resume.alert.error', defaultMessage: 'Source { sourceName } resuming was unsuccessful' },
-            { sourceName }
-          ),
-          description: handleError(error),
+          title: intl.formatMessage({ id: 'source.resume.alert.error', defaultMessage: 'Source resume failed' }),
+          description: tryAgainMessage(intl, handleError(error)),
           variant: 'danger',
         })
       );

--- a/src/test/components/sourceDetail/ApplicationsCard.test.js
+++ b/src/test/components/sourceDetail/ApplicationsCard.test.js
@@ -309,8 +309,8 @@ describe('ApplicationsCard', () => {
       wrapper.update();
 
       expect(actions.addMessage).toHaveBeenCalledWith({
-        description: 'Some backend error',
-        title: 'Cost Management resuming unsuccessful',
+        description: 'Some backend error. Please try again.',
+        title: 'Application resume failed',
         variant: 'danger',
       });
     });
@@ -497,8 +497,8 @@ describe('ApplicationsCard', () => {
       wrapper.update();
 
       expect(actions.addMessage).toHaveBeenCalledWith({
-        description: 'Some backend error',
-        title: 'Subscription Watch adding unsuccessful',
+        description: 'Some backend error. Please try again.',
+        title: 'Application create failed',
         variant: 'danger',
       });
     });
@@ -521,8 +521,8 @@ describe('ApplicationsCard', () => {
       wrapper.update();
 
       expect(actions.addMessage).toHaveBeenCalledWith({
-        description: 'Some backend error',
-        title: 'Cost Management pausing unsuccessful',
+        description: 'Some backend error. Please try again.',
+        title: 'Application pause failed',
         variant: 'danger',
       });
     });
@@ -569,8 +569,8 @@ describe('ApplicationsCard', () => {
       wrapper.update();
 
       expect(actions.addMessage).toHaveBeenCalledWith({
-        description: 'Some backend error',
-        title: 'Cost Management resuming unsuccessful',
+        description: 'Some backend error. Please try again.',
+        title: 'Application resume failed',
         variant: 'danger',
       });
     });

--- a/src/test/redux/sources/actions.test.js
+++ b/src/test/redux/sources/actions.test.js
@@ -447,9 +447,9 @@ describe('redux actions', () => {
       expect(types).toEqual([ADD_NOTIFICATION]);
 
       expect(innerDispatch.mock.calls[0][0].payload).toEqual({
-        description: 'error message',
+        description: '{ error }. Please try again.',
         dismissable: true,
-        title: 'Source { sourceName } pausing was unsuccessful',
+        title: 'Source pause failed',
         variant: 'danger',
       });
     });
@@ -492,9 +492,9 @@ describe('redux actions', () => {
       expect(types).toEqual([ADD_NOTIFICATION]);
 
       expect(innerDispatch.mock.calls[0][0].payload).toEqual({
-        description: 'Some error',
+        description: '{ error }. Please try again.',
         dismissable: true,
-        title: 'Source { sourceName } resuming was unsuccessful',
+        title: 'Source resume failed',
         variant: 'danger',
       });
     });

--- a/src/utilities/tryAgainMessage.js
+++ b/src/utilities/tryAgainMessage.js
@@ -1,0 +1,10 @@
+const tryAgainMessage = (intl, error) =>
+  intl.formatMessage(
+    {
+      id: 'tryAgain.text',
+      defaultMessage: '{ error }. Please try again.',
+    },
+    { error }
+  );
+
+export default tryAgainMessage;


### PR DESCRIPTION
**Application error titles**

'Application create failed'
'Application pause failed'
'Application resume failed'

**Source error titles**

'Source pause failed'
'Source resume failed'

**Description error format**

'{error}. Please try again.'

**Example**

![Screenshot 2021-06-02 at 16 28 46](https://user-images.githubusercontent.com/32869456/120498614-a5a29e80-c3bf-11eb-957d-2d6824a9fe31.png)

cc @beccaglass