### PR TITLE
Add key to sources table to always rerender rows

### DIFF
--- a/src/components/SourcesTable/SourcesTable.js
+++ b/src/components/SourcesTable/SourcesTable.js
@@ -55,13 +55,14 @@ export const prepareColumnsCells = (columns) =>
       ...(column.sortable && { transforms: [sortable, wrappable] }),
     }));
 
-const reducer = (state, payload) => ({ ...state, ...payload });
+const reducer = (state, payload) => ({ ...state, ...payload, key: state.key + 1 });
 
 const initialState = (columns) => ({
   rows: [],
   sortBy: {},
   isLoaded: false,
   cells: prepareColumnsCells(columns),
+  key: 0,
 });
 
 export const actionResolver = (intl, push, hasWritePermissions, dispatch) => (rowData) => {
@@ -225,6 +226,7 @@ const SourcesTable = () => {
         index: state.cells.map((cell) => (cell.hidden ? 'hidden' : cell.value)).indexOf(sortBy),
         direction: sortDirection,
       }}
+      key={state.key}
       rows={shownRows}
       cells={state.cells}
       actionResolver={loaded && numberOfEntities > 0 ? actionResolver(intl, push, writePermissions, reduxDispatch) : undefined}


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-18419

- there is some issue within React/PF that does not correctly rerender the table when entities are being changed, to fix this issue, let's use a key that is always updated when entities are changed

**Before**

![Kapture 2022-03-15 at 12 32 20](https://user-images.githubusercontent.com/32869456/158368938-ec8ed6a3-2dba-4cc6-a448-e131f504162c.gif)

**After**

![Kapture 2022-03-15 at 12 30 43](https://user-images.githubusercontent.com/32869456/158368986-8a25bec1-64b5-4b09-8a1a-d6f7db83906f.gif)


