### PR TITLE
Update RTL User Event to v14

### DIFF
--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -32,6 +32,6 @@ global.innerWidth = 1080;
 
 Element.prototype.scrollTo = () => {};
 
-global.mockApi = (data, timeout = 60) =>
+global.mockApi = (data, timeout = 200) =>
   jest.fn().mockImplementation(() => new Promise((resolve) => setTimeout(() => resolve(data), timeout)));
-global.mockApiError = (data, timeout = 60) => jest.fn(() => new Promise((_, reject) => setTimeout(() => reject(data), timeout)));
+global.mockApiError = (data, timeout = 200) => jest.fn(() => new Promise((_, reject) => setTimeout(() => reject(data), timeout)));

--- a/config/setupTests.js
+++ b/config/setupTests.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 import React from 'react';
 import 'whatwg-fetch'; // fetch for Nodejs
 import '@testing-library/jest-dom/extend-expect';
@@ -30,3 +31,7 @@ global.insights = {
 global.innerWidth = 1080;
 
 Element.prototype.scrollTo = () => {};
+
+global.mockApi = (data, timeout = 60) =>
+  jest.fn().mockImplementation(() => new Promise((resolve) => setTimeout(() => resolve(data), timeout)));
+global.mockApiError = (data, timeout = 60) => jest.fn(() => new Promise((_, reject) => setTimeout(() => reject(data), timeout)));

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "@testing-library/dom": "^8.13.0",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^12.1.4",
-        "@testing-library/user-event": "^13.5.0",
+        "@testing-library/user-event": "^14.0.4",
         "axios-mock-adapter": "^1.20.0",
         "eslint": "^8.12.0",
         "eslint-config-prettier": "^8.5.0",
@@ -3596,15 +3596,12 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
-      "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.0.4.tgz",
+      "integrity": "sha512-VBZe5lcUsmrQyOwIFvqOxLBoaTw1/Qy4Ek+VgmFYs719bs2SxUp42vbsb7ATlQDkHdj4OIQlucfpwxe5WoG1jA==",
       "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
       "engines": {
-        "node": ">=10",
+        "node": ">=12",
         "npm": ">=6"
       },
       "peerDependencies": {
@@ -6385,9 +6382,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.105",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.105.tgz",
-      "integrity": "sha512-6w2bmoQBSUgCQjbSjiVv9IS1lXwW2aQABlUJ1vlE8Vci/sVXxUNQrHLQa5N1ioc82Py+a36DlUA5KvrAlHMMeA==",
+      "version": "1.4.106",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.106.tgz",
+      "integrity": "sha512-ZYfpVLULm67K7CaaGP7DmjyeMY4naxsbTy+syVVxT6QHI1Ww8XbJjmr9fDckrhq44WzCrcC5kH3zGpdusxwwqg==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -18672,13 +18669,11 @@
       }
     },
     "@testing-library/user-event": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
-      "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.0.4.tgz",
+      "integrity": "sha512-VBZe5lcUsmrQyOwIFvqOxLBoaTw1/Qy4Ek+VgmFYs719bs2SxUp42vbsb7ATlQDkHdj4OIQlucfpwxe5WoG1jA==",
       "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.12.5"
-      }
+      "requires": {}
     },
     "@tootallnate/once": {
       "version": "1.1.2",
@@ -20902,9 +20897,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.105",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.105.tgz",
-      "integrity": "sha512-6w2bmoQBSUgCQjbSjiVv9IS1lXwW2aQABlUJ1vlE8Vci/sVXxUNQrHLQa5N1ioc82Py+a36DlUA5KvrAlHMMeA==",
+      "version": "1.4.106",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.106.tgz",
+      "integrity": "sha512-ZYfpVLULm67K7CaaGP7DmjyeMY4naxsbTy+syVVxT6QHI1Ww8XbJjmr9fDckrhq44WzCrcC5kH3zGpdusxwwqg==",
       "dev": true
     },
     "emittery": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@testing-library/dom": "^8.13.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^12.1.4",
-    "@testing-library/user-event": "^13.5.0",
+    "@testing-library/user-event": "^14.0.4",
     "axios-mock-adapter": "^1.20.0",
     "eslint": "^8.12.0",
     "eslint-config-prettier": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
       "<rootDir>/config/setupTests.js"
     ],
     "roots": [
-      "<rootDir>/src/"
+      "<rootDir>/src/",
+      "<rootDir>/src/test"
     ],
     "moduleNameMapper": {
       "\\.(css|scss)$": "identity-obj-proxy"

--- a/src/marketplace/tests/.eslintrc
+++ b/src/marketplace/tests/.eslintrc
@@ -9,7 +9,9 @@
     "beforeAll": true,
     "describe": true,
     "expect": true,
-    "it": true
+    "it": true,
+    "mockApi": true,
+    "mockApiError": true
   },
   "rules": {
     "react/prop-types": "off",

--- a/src/marketplace/tests/RecommendedServices.test.js
+++ b/src/marketplace/tests/RecommendedServices.test.js
@@ -50,7 +50,7 @@ describe('<RecommendedServices />', () => {
       render(<RecommendedServices />);
       await waitFor(() => expect(screen.getByText('See more databases')).toBeInTheDocument());
 
-      userEvent.click(screen.getByText('See more databases'));
+      await userEvent.click(screen.getByText('See more databases'));
 
       expect(screen.getAllByRole('progressbar')).toHaveLength(6);
 
@@ -66,13 +66,13 @@ describe('<RecommendedServices />', () => {
 
       expect(within(screen.getByRole('dialog')).getAllByText('Add')).toHaveLength(4);
 
-      userEvent.click(screen.getByText('Filter by product type'));
+      await userEvent.click(screen.getByText('Filter by product type'));
 
       categories.map((category) => {
         expect(within(screen.getByRole('listbox')).getAllByText(category.display_name)).toBeTruthy();
       });
 
-      userEvent.click(screen.getByLabelText('Close'));
+      await userEvent.click(screen.getByLabelText('Close'));
 
       expect(() => screen.getByRole('dialog')).toThrow();
     });
@@ -80,22 +80,22 @@ describe('<RecommendedServices />', () => {
     it('change perPage', async () => {
       render(<RecommendedServices />);
       await waitFor(() => expect(screen.getByText('See more databases')).toBeInTheDocument());
-      userEvent.click(screen.getByText('See more databases'));
+      await userEvent.click(screen.getByText('See more databases'));
 
       await waitFor(() => expect(screen.getByText('Filter by product type')).toBeInTheDocument());
 
-      userEvent.click(screen.getByLabelText('Items per page'));
+      await userEvent.click(screen.getByLabelText('Items per page'));
 
       expect(screen.getByText('10 per page')).toHaveAttribute('class', 'pf-m-selected pf-c-options-menu__menu-item');
       expect(screen.getByText('20 per page')).toHaveAttribute('class', 'pf-c-options-menu__menu-item');
 
-      userEvent.click(screen.getByText('20 per page'));
+      await userEvent.click(screen.getByText('20 per page'));
 
       expect(screen.getAllByRole('progressbar')).toHaveLength(6);
       await waitFor(() => expect(screen.getAllByRole('progressbar')).toHaveLength(4));
       expect(api.getProducts).toHaveBeenLastCalledWith({ page: 1, perPage: 20 });
 
-      userEvent.click(screen.getByLabelText('Items per page'));
+      await userEvent.click(screen.getByLabelText('Items per page'));
 
       expect(screen.getByText('10 per page')).toHaveAttribute('class', 'pf-c-options-menu__menu-item');
       expect(screen.getByText('20 per page')).toHaveAttribute('class', 'pf-m-selected pf-c-options-menu__menu-item');
@@ -114,11 +114,11 @@ describe('<RecommendedServices />', () => {
 
       render(<RecommendedServices />);
       await waitFor(() => expect(screen.getByText('See more databases')).toBeInTheDocument());
-      userEvent.click(screen.getByText('See more databases'));
+      await userEvent.click(screen.getByText('See more databases'));
       await waitFor(() => expect(screen.getByText('Filter by product type')).toBeInTheDocument());
 
       expect(screen.getByTestId('pagination')).toHaveTextContent('1 - 10 of 11 1 - 10 of 11');
-      userEvent.click(screen.getByLabelText('Go to next page'));
+      await userEvent.click(screen.getByLabelText('Go to next page'));
 
       expect(screen.getAllByRole('progressbar')).toHaveLength(6);
       await waitFor(() => expect(screen.getAllByRole('progressbar')).toHaveLength(6));

--- a/src/marketplace/tests/RecommendedServices.test.js
+++ b/src/marketplace/tests/RecommendedServices.test.js
@@ -12,8 +12,8 @@ describe('<RecommendedServices />', () => {
   const mongoProduct = products[1];
 
   beforeEach(() => {
-    api.getProducts = jest.fn().mockResolvedValue({ data: products, meta: { count: products.length } });
-    api.getCategories = jest.fn().mockResolvedValue({ data: categories });
+    api.getProducts = mockApi({ data: products, meta: { count: products.length } });
+    api.getCategories = mockApi({ data: categories });
   });
 
   it('renders page and loads data', async () => {
@@ -102,7 +102,7 @@ describe('<RecommendedServices />', () => {
     });
 
     it('change page', async () => {
-      api.getProducts = jest.fn().mockResolvedValue({
+      api.getProducts = mockApi({
         data: [...Array(11)].map((_, index) => ({
           ...crunchyProduct,
           id: index,

--- a/src/test/.eslintrc
+++ b/src/test/.eslintrc
@@ -9,7 +9,9 @@
     "beforeAll": true,
     "describe": true,
     "expect": true,
-    "it": true
+    "it": true,
+    "mockApi": true,
+    "mockApiError": true
   },
   "rules": {
     "react/prop-types": "off",

--- a/src/test/__mocks__/@patternfly/react-core.js
+++ b/src/test/__mocks__/@patternfly/react-core.js
@@ -1,0 +1,32 @@
+// Simple override to PF Tooltip to enable its testing
+export const Tooltip = ({ children, content }) => {
+  const [visible, setVisible] = React.useState();
+
+  if (visible) {
+    return (
+      <div onMouseLeave={() => setVisible(false)}>
+        {children}
+        <span data-testid="tooltip" hidden={true}>
+          {content}
+        </span>
+      </div>
+    );
+  }
+
+  const trigger = () => setVisible(true);
+
+  return (
+    <div onMouseOver={trigger} onClick={trigger}>
+      {children}
+    </div>
+  );
+};
+
+const lib = jest.requireActual('@patternfly/react-core');
+
+const pf = {
+  ...lib,
+  Tooltip,
+};
+
+module.exports = pf;

--- a/src/test/addSourceWizard/addSourceWizard/addSourceButton.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/addSourceButton.test.js
@@ -13,11 +13,11 @@ describe('AddSourceButton', () => {
   it('opens wizard and close wizard', async () => {
     render(<AddSourceButton sourceTypes={sourceTypes} applicationTypes={applicationTypes} activeVendor={CLOUD_VENDOR} />);
 
-    userEvent.click(screen.getByText('Add Red Hat source'));
+    await userEvent.click(screen.getByText('Add Red Hat source'));
 
     await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
 
-    userEvent.click(screen.getAllByRole('button')[0]);
+    await userEvent.click(screen.getAllByRole('button')[0]);
 
     expect(() => screen.getByRole('dialog')).toThrow();
   });

--- a/src/test/addSourceWizard/addSourceWizard/addSourceButton.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/addSourceButton.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { AddSourceButton } from '../../../components/addSourceWizard/';
@@ -15,7 +15,7 @@ describe('AddSourceButton', () => {
 
     await userEvent.click(screen.getByText('Add Red Hat source'));
 
-    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+    expect(screen.getAllByRole('dialog')).toBeTruthy();
 
     await userEvent.click(screen.getAllByRole('button')[0]);
 

--- a/src/test/addSourceWizard/addSourceWizard/addSourceWizzard.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/addSourceWizzard.test.js
@@ -56,7 +56,7 @@ describe('AddSourceWizard', () => {
 
     await waitFor(() => expect(screen.getByText('Select source type', { selector: 'button' })).toBeInTheDocument());
 
-    userEvent.click(screen.getByText('OpenShift Container Platform'));
+    await userEvent.click(screen.getByText('OpenShift Container Platform'));
     container.getElementsByTagName('form')[0].submit();
 
     expect(screen.getByText('Validating credentials')).toBeInTheDocument();
@@ -74,7 +74,7 @@ describe('AddSourceWizard', () => {
 
     await waitFor(() => expect(screen.getByText('Select source type', { selector: 'button' })).toBeInTheDocument());
 
-    userEvent.click(screen.getByText('OpenShift Container Platform'));
+    await userEvent.click(screen.getByText('OpenShift Container Platform'));
     container.getElementsByTagName('form')[0].submit();
     await waitFor(() => expect(() => screen.getByText('Validating credentials')).toThrow());
 
@@ -89,7 +89,7 @@ describe('AddSourceWizard', () => {
 
     await waitFor(() => expect(screen.getByText('Select source type', { selector: 'button' })).toBeInTheDocument());
 
-    userEvent.click(screen.getByText('OpenShift Container Platform'));
+    await userEvent.click(screen.getByText('OpenShift Container Platform'));
     container.getElementsByTagName('form')[0].submit();
 
     await waitFor(() => expect(() => screen.getByText('Validating credentials')).toThrow());
@@ -109,7 +109,7 @@ describe('AddSourceWizard', () => {
 
     await waitFor(() => expect(screen.getByText('Select source type', { selector: 'button' })).toBeInTheDocument());
 
-    userEvent.click(screen.getByText('OpenShift Container Platform'));
+    await userEvent.click(screen.getByText('OpenShift Container Platform'));
     container.getElementsByTagName('form')[0].submit();
 
     await waitFor(() => expect(() => screen.getByText('Validating credentials')).toThrow());
@@ -131,11 +131,11 @@ describe('AddSourceWizard', () => {
 
     await waitFor(() => expect(screen.getByText('Select source type', { selector: 'button' })).toBeInTheDocument());
 
-    userEvent.click(screen.getByText('OpenShift Container Platform'));
-    userEvent.click(screen.getByLabelText('Close wizard'));
+    await userEvent.click(screen.getByText('OpenShift Container Platform'));
+    await userEvent.click(screen.getByLabelText('Close wizard'));
 
     expect(screen.getByText('Exit source creation?')).toBeInTheDocument();
-    userEvent.click(screen.getByText('Exit'));
+    await userEvent.click(screen.getByText('Exit'));
     expect(onClose).toHaveBeenCalledWith({ source_type: OPENSHIFT_NAME });
   });
 
@@ -146,9 +146,9 @@ describe('AddSourceWizard', () => {
 
     await waitFor(() => expect(screen.getByText('Select source type', { selector: 'button' })).toBeInTheDocument());
 
-    userEvent.click(screen.getByText('OpenShift Container Platform'));
-    userEvent.click(screen.getByLabelText('Close wizard'));
-    userEvent.click(screen.getByText('Stay'));
+    await userEvent.click(screen.getByText('OpenShift Container Platform'));
+    await userEvent.click(screen.getByLabelText('Close wizard'));
+    await userEvent.click(screen.getByText('Stay'));
 
     expect(onClose).not.toHaveBeenCalled();
     expect(screen.getByText('OpenShift Container Platform').closest('.pf-m-selected')).toBeInTheDocument();
@@ -162,7 +162,7 @@ describe('AddSourceWizard', () => {
 
     await waitFor(() => expect(screen.getByText('Select source type', { selector: 'button' })).toBeInTheDocument());
 
-    userEvent.click(screen.getByText('OpenShift Container Platform'));
+    await userEvent.click(screen.getByText('OpenShift Container Platform'));
     container.getElementsByTagName('form')[0].submit();
 
     await waitFor(() => expect(() => screen.getByText('Validating credentials')).toThrow());
@@ -184,14 +184,14 @@ describe('AddSourceWizard', () => {
 
     await waitFor(() => expect(screen.getByText('Select source type', { selector: 'button' })).toBeInTheDocument());
 
-    userEvent.click(screen.getByText('OpenShift Container Platform'));
+    await userEvent.click(screen.getByText('OpenShift Container Platform'));
     container.getElementsByTagName('form')[0].submit();
 
     await waitFor(() => expect(() => screen.getByText('Validating credentials')).toThrow());
 
     expect(closeCallback).not.toHaveBeenCalled();
 
-    userEvent.click(screen.getByLabelText('Close'));
+    await userEvent.click(screen.getByLabelText('Close'));
 
     expect(closeCallback).toHaveBeenCalledWith({});
   });
@@ -205,14 +205,14 @@ describe('AddSourceWizard', () => {
 
     await waitFor(() => expect(screen.getByText('Select source type', { selector: 'button' })).toBeInTheDocument());
 
-    userEvent.click(screen.getByText('OpenShift Container Platform'));
+    await userEvent.click(screen.getByText('OpenShift Container Platform'));
     container.getElementsByTagName('form')[0].submit();
 
     await waitFor(() => expect(() => screen.getByText('Validating credentials')).toThrow());
 
     expect(closeCallback).not.toHaveBeenCalled();
 
-    userEvent.click(screen.getByLabelText('Close'));
+    await userEvent.click(screen.getByLabelText('Close'));
 
     await waitFor(() => expect(closeCallback).toHaveBeenCalledWith(undefined, SOURCE_DATA_OUT));
   });
@@ -224,12 +224,12 @@ describe('AddSourceWizard', () => {
 
     await waitFor(() => expect(screen.getByText('Select source type', { selector: 'button' })).toBeInTheDocument());
 
-    userEvent.click(screen.getByText('OpenShift Container Platform'));
+    await userEvent.click(screen.getByText('OpenShift Container Platform'));
     container.getElementsByTagName('form')[0].submit();
 
     await waitFor(() => expect(() => screen.getByText('Validating credentials')).toThrow());
 
-    userEvent.click(screen.getByText('Add another source'));
+    await userEvent.click(screen.getByText('Add another source'));
 
     await waitFor(() => expect(() => screen.getByText('OpenShift Container Platform').closest('.pf-m-selected')).toThrow());
   });
@@ -241,14 +241,14 @@ describe('AddSourceWizard', () => {
 
     await waitFor(() => expect(screen.getByText('Select source type', { selector: 'button' })).toBeInTheDocument());
 
-    userEvent.click(screen.getByText('OpenShift Container Platform'));
+    await userEvent.click(screen.getByText('OpenShift Container Platform'));
     container.getElementsByTagName('form')[0].submit();
 
     await waitFor(() => expect(() => screen.getByText('Validating credentials')).toThrow());
     createSource.doCreateSource.mockClear();
     expect(createSource.doCreateSource).not.toHaveBeenCalled();
 
-    userEvent.click(screen.getByText('Retry'));
+    await userEvent.click(screen.getByText('Retry'));
 
     await waitFor(() =>
       expect(createSource.doCreateSource).toHaveBeenCalledWith(

--- a/src/test/addSourceWizard/addSourceWizard/addSourceWizzard.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/addSourceWizzard.test.js
@@ -231,7 +231,7 @@ describe('AddSourceWizard', () => {
 
     await userEvent.click(screen.getByText('Add another source'));
 
-    await waitFor(() => expect(() => screen.getByText('OpenShift Container Platform').closest('.pf-m-selected')).toThrow());
+    expect(screen.getByText('OpenShift Container Platform').closest('.pf-m-selected')).toBeNull();
   });
 
   it('tryAgain retries the request', async () => {

--- a/src/test/addSourceWizard/addSourceWizard/finalWizard.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/finalWizard.test.js
@@ -89,10 +89,10 @@ describe('Final wizard', () => {
     expect(screen.getByText('Configuration successful')).toBeInTheDocument();
   });
 
-  it('calls reset', () => {
+  it('calls reset', async () => {
     render(<FinalWizard {...initialProps} isFinished={true} hideSourcesButton={true} />);
 
-    userEvent.click(screen.getByText('Add another source'));
+    await userEvent.click(screen.getByText('Add another source'));
 
     expect(initialProps.reset).toHaveBeenCalled();
   });
@@ -114,7 +114,7 @@ describe('Final wizard', () => {
 
     expect(tryAgain).not.toHaveBeenCalled();
 
-    userEvent.click(screen.getByText('Retry'));
+    await userEvent.click(screen.getByText('Retry'));
 
     expect(tryAgain).toHaveBeenCalled();
   });
@@ -146,7 +146,7 @@ describe('Final wizard', () => {
     expect(screen.getByText('Configuration unsuccessful')).toBeInTheDocument();
     expect(screen.getByText(ERROR_MSG)).toBeInTheDocument();
 
-    userEvent.click(screen.getByText('Remove source'));
+    await userEvent.click(screen.getByText('Remove source'));
     await waitFor(() => expect(deleteSource).toHaveBeenCalledWith(id));
 
     expect(screen.getByText('Removing successful')).toBeInTheDocument();
@@ -181,7 +181,7 @@ describe('Final wizard', () => {
     expect(screen.getByText('Configuration unsuccessful')).toBeInTheDocument();
     expect(screen.getByText(ERROR_MSG)).toBeInTheDocument();
 
-    userEvent.click(screen.getByText('Remove source'));
+    await userEvent.click(screen.getByText('Remove source'));
 
     await waitFor(() => expect(deleteSource).toHaveBeenCalledWith(id));
     expect(afterSuccess).toHaveBeenCalled();
@@ -214,7 +214,7 @@ describe('Final wizard', () => {
     expect(screen.getByText('Configuration unsuccessful')).toBeInTheDocument();
     expect(screen.getByText(ERROR_MSG)).toBeInTheDocument();
 
-    userEvent.click(screen.getByText('Remove source'));
+    await userEvent.click(screen.getByText('Remove source'));
 
     await waitFor(() => expect(deleteSource).toHaveBeenCalledWith(id));
 
@@ -244,7 +244,7 @@ describe('Final wizard', () => {
     expect(screen.getByText('Configuration unsuccessful')).toBeInTheDocument();
     expect(screen.getByText(ERROR_MSG)).toBeInTheDocument();
 
-    userEvent.click(screen.getByText('Edit source'));
+    await userEvent.click(screen.getByText('Edit source'));
 
     expect(screen.getByTestId('location-display').textContent).toEqual(replaceRouteId(routes.sourcesDetail.path, id));
   });

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/ibm_cost.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/ibm_cost.test.js
@@ -9,6 +9,9 @@ import * as Pf from '@patternfly/react-core/dist/js/components/ClipboardCopy/Cli
 
 import RendererContext from '@data-driven-forms/react-form-renderer/renderer-context';
 
+// Custom Mock Module have issues with ClipBoard
+jest.mock('@patternfly/react-core', () => jest.requireActual('@patternfly/react-core'));
+
 describe('Cost Management IBM steps', () => {
   it('Enteprise ID', async () => {
     await act(async () => {

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/ibm_cost.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/ibm_cost.test.js
@@ -47,7 +47,7 @@ describe('Cost Management IBM steps', () => {
     );
   });
 
-  it('Configure service', () => {
+  it('Configure service', async () => {
     const copySpy = jest.spyOn(Pf, 'clipboardCopyFunc').mockImplementation(() => null);
 
     render(
@@ -75,7 +75,7 @@ ibmcloud iam service-policy-create "service-id" --service-name globalcatalog  --
 
     expect(screen.getByLabelText('Commands to create policies.')).toHaveValue(value);
 
-    userEvent.click(screen.getByLabelText('Copy to clipboard'));
+    await userEvent.click(screen.getByLabelText('Copy to clipboard'));
 
     expect(copySpy).toHaveBeenCalledWith(expect.any(Object), value);
 

--- a/src/test/addSourceWizard/addSourceWizard/sourceAddModal.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/sourceAddModal.test.js
@@ -82,7 +82,7 @@ describe('sourceAddModal', () => {
 
     expect(onCancel).not.toHaveBeenCalled();
 
-    userEvent.click(screen.getAllByText('Cancel')[0]);
+    await userEvent.click(screen.getAllByText('Cancel')[0]);
 
     expect(onCancel).toHaveBeenCalledWith();
 

--- a/src/test/addSourceWizard/addSourceWizard/sourceAddModal.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/sourceAddModal.test.js
@@ -69,9 +69,7 @@ describe('sourceAddModal', () => {
   it('clicks on onCancel when loading', async () => {
     const onCancel = jest.fn();
 
-    dependency.doLoadSourceTypes = jest
-      .fn()
-      .mockImplementation(() => new Promise((resolve) => setTimeout(() => resolve({ sourceTypes }), 100)));
+    dependency.doLoadSourceTypes = mockApi({ sourceTypes });
     dependency.doLoadApplicationTypes = jest
       .fn()
       .mockImplementation(() => new Promise((resolve) => resolve({ applicationTypes })));

--- a/src/test/addSourceWizard/addSourceWizard/steps.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/steps.test.js
@@ -46,10 +46,10 @@ describe('Steps components', () => {
       expect(() => screen.getByRole('link')).toThrow();
     });
 
-    it('calls onClose function', () => {
+    it('calls onClose function', async () => {
       render(<FinishedStep {...initialProps} />);
 
-      userEvent.click(screen.getByText('Go back to my application'));
+      await userEvent.click(screen.getByText('Go back to my application'));
 
       expect(spyFunction).toHaveBeenCalled();
     });
@@ -72,10 +72,10 @@ describe('Steps components', () => {
       expect(screen.getAllByRole('button')).toHaveLength(1);
     });
 
-    it('calls onClose function', () => {
+    it('calls onClose function', async () => {
       render(<LoadingStep {...initialProps} />);
 
-      userEvent.click(screen.getByText('Cancel'));
+      await userEvent.click(screen.getByText('Cancel'));
 
       expect(spyFunction).toHaveBeenCalled();
     });
@@ -109,18 +109,18 @@ describe('Steps components', () => {
       expect(screen.getByText(ERROR_MESSAGE)).toBeInTheDocument();
     });
 
-    it('calls onClose function', () => {
+    it('calls onClose function', async () => {
       render(<ErroredStep {...initialProps} />);
 
-      userEvent.click(screen.getByText('Go back to my application'));
+      await userEvent.click(screen.getByText('Go back to my application'));
 
       expect(spyFunction).toHaveBeenCalled();
     });
 
-    it('calls primaryAction function', () => {
+    it('calls primaryAction function', async () => {
       render(<ErroredStep {...initialProps} primaryAction={spyFunctionSecond} />);
 
-      userEvent.click(screen.getByText('Go back to my application'));
+      await userEvent.click(screen.getByText('Go back to my application'));
 
       expect(spyFunctionSecond).toHaveBeenCalled();
     });
@@ -155,10 +155,10 @@ describe('Steps components', () => {
       expect(screen.getAllByRole('button')).toHaveLength(2);
     });
 
-    it('calls onClose function', () => {
+    it('calls onClose function', async () => {
       render(<TimeoutStep {...initialProps} />);
 
-      userEvent.click(screen.getByText('go back'));
+      await userEvent.click(screen.getByText('go back'));
 
       expect(spyFunction).toHaveBeenCalled();
     });
@@ -187,10 +187,10 @@ describe('Steps components', () => {
       ]);
     });
 
-    it('calls onClose function', () => {
+    it('calls onClose function', async () => {
       render(<AmazonFinishedStep {...initialProps} />);
 
-      userEvent.click(screen.getByText('Exit'));
+      await userEvent.click(screen.getByText('Exit'));
 
       expect(spyFunction).toHaveBeenCalled();
     });

--- a/src/test/addSourceWizard/addSourceWizard/validatorReset.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/validatorReset.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import FormRenderer from '@data-driven-forms/react-form-renderer/form-renderer';

--- a/src/test/addSourceWizard/addSourceWizard/validatorReset.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/validatorReset.test.js
@@ -42,24 +42,25 @@ describe('validatorReset', () => {
       />
     );
 
-    userEvent.type(screen.getByRole('textbox'), 'true');
+    await userEvent.type(screen.getByRole('textbox'), 'true');
 
     await act(async () => {
       jest.advanceTimersByTime(1);
     });
 
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({ show: 'true', reset: '1' });
     onSubmit.mockClear();
 
-    userEvent.type(screen.getByRole('textbox'), '{selectall}{backspace}false');
+    await userEvent.clear(screen.getByRole('textbox'));
+    await userEvent.type(screen.getByRole('textbox'), 'false');
 
     await act(async () => {
       jest.advanceTimersByTime(1);
     });
 
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({ show: 'false', reset: '' });
     onSubmit.mockClear();

--- a/src/test/addSourceWizard/addSourceWizard/validatorReset.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/validatorReset.test.js
@@ -11,8 +11,6 @@ import ValidatorReset from '../../../components/addSourceWizard/ValidatorReset';
 
 describe('validatorReset', () => {
   it('sets value on timeout after mount and remove value after unmnout', async () => {
-    jest.useFakeTimers();
-
     const onSubmit = jest.fn();
 
     render(
@@ -43,11 +41,6 @@ describe('validatorReset', () => {
     );
 
     await userEvent.type(screen.getByRole('textbox'), 'true');
-
-    await act(async () => {
-      jest.advanceTimersByTime(1);
-    });
-
     await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({ show: 'true', reset: '1' });
@@ -56,15 +49,8 @@ describe('validatorReset', () => {
     await userEvent.clear(screen.getByRole('textbox'));
     await userEvent.type(screen.getByRole('textbox'), 'false');
 
-    await act(async () => {
-      jest.advanceTimersByTime(1);
-    });
-
     await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({ show: 'false', reset: '' });
-    onSubmit.mockClear();
-
-    jest.useRealTimers();
   });
 });

--- a/src/test/components/Authentication.test.js
+++ b/src/test/components/Authentication.test.js
@@ -101,23 +101,23 @@ describe('Authentication test', () => {
     expect(screen.getByRole('textbox')).toHaveValue('•••••••••••••');
   });
 
-  it('renders not editing', () => {
+  it('renders not editing', async () => {
     render(componentWrapperIntl(<SourcesFormRenderer {...initialProps} />));
 
     expect(screen.getByRole('textbox')).toBeRequired();
 
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).not.toHaveBeenCalled();
 
-    userEvent.type(screen.getByRole('textbox'), 's');
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.type(screen.getByRole('textbox'), 's');
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).not.toHaveBeenCalled();
 
-    userEvent.type(screen.getByRole('textbox'), 'ome-value');
+    await userEvent.type(screen.getByRole('textbox'), 'ome-value');
 
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({
       authentication: {
@@ -142,11 +142,11 @@ describe('Authentication test', () => {
 
     expect(screen.getByRole('textbox')).toHaveValue('•••••••••••••');
 
-    userEvent.click(screen.getByRole('textbox'));
+    await userEvent.click(screen.getByRole('textbox'));
 
     expect(screen.getByRole('textbox')).toHaveValue('');
 
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({
       authentication: {
@@ -155,8 +155,8 @@ describe('Authentication test', () => {
     });
     onSubmit.mockClear();
 
-    userEvent.type(screen.getByRole('textbox'), 's');
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.type(screen.getByRole('textbox'), 's');
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).not.toHaveBeenCalled();
   });
@@ -178,12 +178,12 @@ describe('Authentication test', () => {
 
     expect(screen.getByRole('textbox')).toHaveValue('•••••••••••••');
 
-    userEvent.click(screen.getByRole('textbox'));
+    await userEvent.click(screen.getByRole('textbox'));
 
     expect(screen.getByRole('textbox')).toHaveValue('');
 
-    userEvent.type(screen.getByRole('textbox'), 's');
-    userEvent.click(screen.getByText('Reset'));
+    await userEvent.type(screen.getByRole('textbox'), 's');
+    await userEvent.click(screen.getByText('Reset'));
 
     expect(screen.getByRole('textbox')).toHaveValue('•••••••••••••');
   });
@@ -214,7 +214,7 @@ describe('Authentication test', () => {
     expect(screen.getByRole('textbox')).toHaveValue('•••••••••••••');
     expect(screen.getByRole('textbox')).toBeDisabled();
 
-    userEvent.click(screen.getByRole('textbox'));
+    await userEvent.click(screen.getByRole('textbox'));
 
     expect(screen.getByRole('textbox')).toHaveValue('•••••••••••••');
     expect(screen.getByRole('textbox')).toBeDisabled();

--- a/src/test/components/TabNavigation.test.js
+++ b/src/test/components/TabNavigation.test.js
@@ -51,13 +51,13 @@ describe('TabNavigation', () => {
 
     expect(actions.setActiveVendor).not.toHaveBeenCalled();
 
-    userEvent.click(screen.getByText('Cloud sources'));
+    await userEvent.click(screen.getByText('Cloud sources'));
 
     expect(actions.setActiveVendor).toHaveBeenCalledWith(CLOUD_VENDOR);
 
     actions.setActiveVendor.mockClear();
 
-    userEvent.click(screen.getByText('Red Hat sources'));
+    await userEvent.click(screen.getByText('Red Hat sources'));
 
     expect(actions.setActiveVendor).toHaveBeenCalledWith(REDHAT_VENDOR);
   });

--- a/src/test/components/addApplication/AddApplication.test.js
+++ b/src/test/components/addApplication/AddApplication.test.js
@@ -285,7 +285,7 @@ describe('AddApplication', () => {
     });
 
     it('closes immedietaly when no value is filled', async () => {
-      userEvent.click(screen.getByLabelText('Close wizard'));
+      await userEvent.click(screen.getByLabelText('Close wizard'));
 
       await waitFor(() =>
         expect(screen.getByTestId('location-display').textContent).toEqual(
@@ -297,9 +297,10 @@ describe('AddApplication', () => {
     it('opens a modal on cancel and closes the wizard', async () => {
       const value = 'SOURCE_REF_CHANGED';
 
-      userEvent.type(screen.getByRole('textbox', { name: 'Receptor ID' }), `{selectall}{backspace}${value}`);
-      userEvent.click(screen.getByLabelText('Close wizard'));
-      userEvent.click(screen.getByText('Exit'));
+      await userEvent.clear(screen.getByRole('textbox', { name: 'Receptor ID' }));
+      await userEvent.type(screen.getByRole('textbox', { name: 'Receptor ID' }), value);
+      await userEvent.click(screen.getByLabelText('Close wizard'));
+      await userEvent.click(screen.getByText('Exit'));
 
       await waitFor(() =>
         expect(screen.getByTestId('location-display').textContent).toEqual(
@@ -311,9 +312,10 @@ describe('AddApplication', () => {
     it('opens a modal on cancel and stay on the wizard', async () => {
       const value = 'SOURCE_REF_CHANGED';
 
-      userEvent.type(screen.getByRole('textbox', { name: 'Receptor ID' }), `{selectall}{backspace}${value}`);
-      userEvent.click(screen.getByLabelText('Close wizard'));
-      userEvent.click(screen.getByText('Stay'));
+      await userEvent.clear(screen.getByRole('textbox', { name: 'Receptor ID' }));
+      await userEvent.type(screen.getByRole('textbox', { name: 'Receptor ID' }), value);
+      await userEvent.click(screen.getByLabelText('Close wizard'));
+      await userEvent.click(screen.getByText('Stay'));
 
       expect(() => screen.getByText('Stay')).toThrow();
       expect(screen.getByRole('textbox', { name: 'Receptor ID' })).toHaveValue(value);
@@ -385,13 +387,14 @@ describe('AddApplication', () => {
 
       expect(screen.getAllByRole('radio')).toHaveLength(2);
 
-      userEvent.click(screen.getAllByRole('radio')[1]);
-      userEvent.click(screen.getByText('Next'));
+      await userEvent.click(screen.getAllByRole('radio')[1]);
+      await userEvent.click(screen.getByText('Next'));
 
       const value = 'SOURCE_REF_CHANGED';
 
-      userEvent.type(screen.getByRole('textbox', { name: 'Receptor ID' }), `{selectall}{backspace}${value}`);
-      userEvent.click(screen.getByText('Next'));
+      await userEvent.clear(screen.getByRole('textbox', { name: 'Receptor ID' }));
+      await userEvent.type(screen.getByRole('textbox', { name: 'Receptor ID' }), value);
+      await userEvent.click(screen.getByText('Next'));
 
       entities.doLoadEntities = jest
         .fn()
@@ -402,7 +405,7 @@ describe('AddApplication', () => {
         })
       );
 
-      userEvent.click(screen.getByText('Add'));
+      await userEvent.click(screen.getByText('Add'));
 
       expect(screen.getByText('Validating credentials')).toBeInTheDocument();
 
@@ -480,7 +483,7 @@ describe('AddApplication', () => {
         )
       );
 
-      userEvent.click(screen.getByText('Add'));
+      await userEvent.click(screen.getByText('Add'));
 
       const formValues = {
         application: {
@@ -536,7 +539,7 @@ describe('AddApplication', () => {
         )
       );
 
-      userEvent.click(screen.getByText('Add'));
+      await userEvent.click(screen.getByText('Add'));
 
       const formValues = {
         application: {
@@ -586,7 +589,7 @@ describe('AddApplication', () => {
         )
       );
 
-      userEvent.click(screen.getByText('Add'));
+      await userEvent.click(screen.getByText('Add'));
 
       await waitFor(() => expect(screen.getByText('Configuration in progress')).toBeInTheDocument());
       expect(
@@ -620,7 +623,7 @@ describe('AddApplication', () => {
         )
       );
 
-      userEvent.click(screen.getByText('Add'));
+      await userEvent.click(screen.getByText('Add'));
 
       await waitFor(() => expect(screen.getByText('Configuration in progress')).toBeInTheDocument());
       expect(
@@ -657,7 +660,7 @@ describe('AddApplication', () => {
         )
       );
 
-      userEvent.click(screen.getByText('Add'));
+      await userEvent.click(screen.getByText('Add'));
 
       await waitFor(() => expect(attachSource.doAttachApp).toHaveBeenCalled());
 
@@ -665,7 +668,7 @@ describe('AddApplication', () => {
       expect(screen.getByText('Edit source')).toBeInTheDocument();
       expect(screen.getByText('Remove application')).toBeInTheDocument();
 
-      userEvent.click(screen.getByText('Edit source'));
+      await userEvent.click(screen.getByText('Edit source'));
 
       await waitFor(() =>
         expect(screen.getByTestId('location-display').textContent).toEqual(replaceRouteId(routes.sourcesDetail.path, source.id))
@@ -702,7 +705,7 @@ describe('AddApplication', () => {
         )
       );
 
-      userEvent.click(screen.getByText('Add'));
+      await userEvent.click(screen.getByText('Add'));
 
       await waitFor(() => expect(attachSource.doAttachApp).toHaveBeenCalled());
 
@@ -714,7 +717,7 @@ describe('AddApplication', () => {
 
       expect(removeAppSubmit.default).not.toHaveBeenCalled();
 
-      userEvent.click(screen.getByText('Remove application'));
+      await userEvent.click(screen.getByText('Remove application'));
 
       await waitFor(() =>
         expect(removeAppSubmit.default).toHaveBeenCalledWith(
@@ -740,7 +743,7 @@ describe('AddApplication', () => {
         )
       );
 
-      userEvent.click(screen.getByText('Add'));
+      await userEvent.click(screen.getByText('Add'));
 
       const formValues = {
         application: {
@@ -778,7 +781,7 @@ describe('AddApplication', () => {
         )
       );
 
-      userEvent.click(screen.getByText('Add'));
+      await userEvent.click(screen.getByText('Add'));
 
       const formValues = {
         application: {
@@ -803,7 +806,7 @@ describe('AddApplication', () => {
         })
       );
 
-      userEvent.click(screen.getByText('Retry'));
+      await userEvent.click(screen.getByText('Retry'));
 
       await waitFor(() => expect(screen.getByText('Configuration successful')).toBeInTheDocument());
     });

--- a/src/test/components/addApplication/AddApplication.test.js
+++ b/src/test/components/addApplication/AddApplication.test.js
@@ -399,11 +399,9 @@ describe('AddApplication', () => {
       entities.doLoadEntities = jest
         .fn()
         .mockImplementation(() => Promise.resolve({ sources: [], sources_aggregate: { aggregate: { total_count: 0 } } }));
-      attachSource.doAttachApp = jest.fn().mockImplementation(() =>
-        Promise.resolve({
-          availability_status: 'available',
-        })
-      );
+      attachSource.doAttachApp = mockApi({
+        availability_status: 'available',
+      });
 
       await userEvent.click(screen.getByText('Add'));
 

--- a/src/test/components/addApplication/RemoveAppModal.test.js
+++ b/src/test/components/addApplication/RemoveAppModal.test.js
@@ -155,7 +155,7 @@ describe('RemoveAppModal', () => {
       )
     );
 
-    userEvent.click(screen.getByText('Cancel'));
+    await userEvent.click(screen.getByText('Cancel'));
 
     expect(screen.getByTestId('location-display').textContent).toEqual(replaceRouteId(routes.sourcesDetail.path, SOURCE_ID));
   });
@@ -171,7 +171,7 @@ describe('RemoveAppModal', () => {
       )
     );
 
-    userEvent.click(screen.getByText('Remove'));
+    await userEvent.click(screen.getByText('Remove'));
 
     await waitFor(() => expect(actions.removeApplication).toHaveBeenCalledWith(APP_ID, SOURCE_ID, SUCCESS_MSG, ERROR_MSG));
   });

--- a/src/test/components/closeModal.test.js
+++ b/src/test/components/closeModal.test.js
@@ -51,23 +51,23 @@ describe('CloseModal', () => {
     expect(screen.getByLabelText('Exclamation icon')).toBeInTheDocument();
   });
 
-  it('calls onExit', () => {
+  it('calls onExit', async () => {
     render(<CloseModal {...initialProps} />);
 
-    userEvent.click(screen.getByText('Exit'));
+    await userEvent.click(screen.getByText('Exit'));
 
     expect(onExit).toHaveBeenCalled();
   });
 
-  it('calls onStay', () => {
+  it('calls onStay', async () => {
     render(<CloseModal {...initialProps} />);
 
-    userEvent.click(screen.getByLabelText('Close'));
+    await userEvent.click(screen.getByLabelText('Close'));
 
     expect(onStay).toHaveBeenCalled();
     onStay.mockClear();
 
-    userEvent.click(screen.getByText('Stay'));
+    await userEvent.click(screen.getByText('Stay'));
 
     expect(onStay).toHaveBeenCalled();
     onStay.mockClear();

--- a/src/test/components/cloudTiles/CloudCards.test.js
+++ b/src/test/components/cloudTiles/CloudCards.test.js
@@ -73,7 +73,7 @@ describe('CloudCards', () => {
 
     expect(screen.getByText('Use gold images')).toBeInTheDocument();
 
-    userEvent.click(screen.getByRole('button'));
+    await userEvent.click(screen.getByRole('button'));
 
     expect(() => screen.getByText('Use gold images')).toThrow();
 
@@ -81,7 +81,7 @@ describe('CloudCards', () => {
       [CLOUD_CARDS_KEY]: 'false',
     });
 
-    userEvent.click(screen.getByRole('button'));
+    await userEvent.click(screen.getByRole('button'));
 
     expect(screen.getByText('Use gold images')).toBeInTheDocument();
     expect(localStorage).toEqual({

--- a/src/test/components/cloudTiles/CloudTiles.test.js
+++ b/src/test/components/cloudTiles/CloudTiles.test.js
@@ -56,7 +56,7 @@ describe('CloudTiles', () => {
     ]);
     expect(container.getElementsByTagName('img')).toHaveLength(4);
 
-    userEvent.click(screen.getByText('Google Cloud'));
+    await userEvent.click(screen.getByText('Google Cloud'));
 
     await waitFor(() =>
       expect(
@@ -70,7 +70,7 @@ describe('CloudTiles', () => {
   it('sets amazon', async () => {
     render(componentWrapperIntl(<CloudTiles {...initialProps} />, store));
 
-    userEvent.click(screen.getByText('Amazon Web Services'));
+    await userEvent.click(screen.getByText('Amazon Web Services'));
 
     expect(screen.getByTestId('location-display').textContent).toEqual(routes.sourcesNew.path);
     expect(setSelectedType).toHaveBeenCalledWith('amazon');
@@ -79,7 +79,7 @@ describe('CloudTiles', () => {
   it('sets gcp', async () => {
     render(componentWrapperIntl(<CloudTiles {...initialProps} />, store));
 
-    userEvent.click(screen.getByText('Google Cloud'));
+    await userEvent.click(screen.getByText('Google Cloud'));
 
     expect(screen.getByTestId('location-display').textContent).toEqual(routes.sourcesNew.path);
     expect(setSelectedType).toHaveBeenCalledWith('google');
@@ -88,7 +88,7 @@ describe('CloudTiles', () => {
   it('sets azure', async () => {
     render(componentWrapperIntl(<CloudTiles {...initialProps} />, store));
 
-    userEvent.click(screen.getByText('Microsoft Azure'));
+    await userEvent.click(screen.getByText('Microsoft Azure'));
 
     expect(screen.getByTestId('location-display').textContent).toEqual(routes.sourcesNew.path);
     expect(setSelectedType).toHaveBeenCalledWith('azure');
@@ -97,7 +97,7 @@ describe('CloudTiles', () => {
   it('sets ibm', async () => {
     render(componentWrapperIntl(<CloudTiles {...initialProps} />, store));
 
-    userEvent.click(screen.getByText('IBM Cloud'));
+    await userEvent.click(screen.getByText('IBM Cloud'));
 
     expect(screen.getByTestId('location-display').textContent).toEqual(routes.sourcesNew.path);
     expect(setSelectedType).toHaveBeenCalledWith('ibm');

--- a/src/test/components/credentialsForm/credentialsForm.test.js
+++ b/src/test/components/credentialsForm/credentialsForm.test.js
@@ -119,7 +119,7 @@ describe('CredentialsForm', () => {
 
     await waitFor(() => expect(() => screen.getByRole('progressbar')).toThrow());
 
-    userEvent.click(screen.getByLabelText('Close'));
+    await userEvent.click(screen.getByLabelText('Close'));
 
     expect(screen.getByTestId('location-display').textContent).toEqual(replaceRouteId(routes.sourcesDetail.path, sourceId));
   });
@@ -135,7 +135,7 @@ describe('CredentialsForm', () => {
 
     await waitFor(() => expect(() => screen.getByRole('progressbar')).toThrow());
 
-    userEvent.click(screen.getByText('Cancel'));
+    await userEvent.click(screen.getByText('Cancel'));
 
     expect(screen.getByTestId('location-display').textContent).toEqual(replaceRouteId(routes.sourcesDetail.path, sourceId));
   });
@@ -160,12 +160,13 @@ describe('CredentialsForm', () => {
 
     await waitFor(() => expect(() => screen.getByRole('progressbar')).toThrow());
 
-    userEvent.type(screen.getAllByRole('textbox')[0], '{selectall}{backspace}newname');
+    await userEvent.clear(screen.getAllByRole('textbox')[0]);
+    await userEvent.type(screen.getAllByRole('textbox')[0], 'newname');
 
     expect(updateAuthentication).not.toHaveBeenCalled();
     expect(actions.addMessage).not.toHaveBeenCalled();
 
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(screen.getByTestId('location-display').textContent).toEqual(replaceRouteId(routes.sourcesDetail.path, sourceId));
     expect(updateAuthentication).toHaveBeenCalledWith('auth-id', { username: 'newname' });
@@ -199,12 +200,13 @@ describe('CredentialsForm', () => {
     );
     await waitFor(() => expect(() => screen.getByRole('progressbar')).toThrow());
 
-    userEvent.type(screen.getAllByRole('textbox')[0], '{selectall}{backspace}newname');
+    await userEvent.clear(screen.getAllByRole('textbox')[0]);
+    await userEvent.type(screen.getAllByRole('textbox')[0], 'newname');
 
     expect(updateAuthentication).not.toHaveBeenCalled();
     expect(actions.addMessage).not.toHaveBeenCalled();
 
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(screen.getByTestId('location-display').textContent).toEqual(replaceRouteId(routes.sourcesDetail.path, sourceId));
     expect(updateAuthentication).toHaveBeenCalledWith('auth-id', { username: 'newname' });

--- a/src/test/components/credentialsForm/credentialsForm.test.js
+++ b/src/test/components/credentialsForm/credentialsForm.test.js
@@ -141,7 +141,7 @@ describe('CredentialsForm', () => {
   });
 
   it('submit - success', async () => {
-    const updateAuthentication = jest.fn().mockImplementation(() => new Promise((resolve) => setTimeout(() => resolve(), 100)));
+    const updateAuthentication = mockApi();
 
     api.getSourcesApi = () => ({
       listSourceAuthentications,
@@ -182,7 +182,7 @@ describe('CredentialsForm', () => {
   });
 
   it('submit - fail', async () => {
-    const updateAuthentication = jest.fn().mockRejectedValue();
+    const updateAuthentication = mockApiError();
 
     api.getSourcesApi = () => ({
       listSourceAuthentications,

--- a/src/test/components/credentialsForm/modalFormTemplate.test.js
+++ b/src/test/components/credentialsForm/modalFormTemplate.test.js
@@ -51,9 +51,9 @@ describe('modalFormTemplate', () => {
   it('submits', async () => {
     expect(submit).not.toHaveBeenCalled();
 
-    userEvent.type(screen.getByRole('textbox'), 'something');
+    await userEvent.type(screen.getByRole('textbox'), 'something');
 
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(submit).toHaveBeenCalled();
   });
@@ -61,7 +61,7 @@ describe('modalFormTemplate', () => {
   it('cancels', async () => {
     expect(cancel).not.toHaveBeenCalled();
 
-    userEvent.click(screen.getByText('Cancel'));
+    await userEvent.click(screen.getByText('Cancel'));
 
     expect(cancel).toHaveBeenCalled();
   });

--- a/src/test/components/formComponents/authSelect.test.js
+++ b/src/test/components/formComponents/authSelect.test.js
@@ -42,7 +42,7 @@ describe('AuthSelect component', () => {
     expect(screen.getByText('Test').closest('.pf-c-radio')).toBeInTheDocument();
   });
 
-  it('renders correctly when disableAuthType', () => {
+  it('renders correctly when disableAuthType', async () => {
     initialProps = {
       ...initialProps,
       schema: {
@@ -60,20 +60,20 @@ describe('AuthSelect component', () => {
     expect(screen.getByRole('radio')).toBeDisabled();
   });
 
-  it('calls onChange correctly', () => {
+  it('calls onChange correctly', async () => {
     render(<FormRenderer {...initialProps} />);
 
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({});
 
-    userEvent.click(screen.getByRole('radio'));
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getByRole('radio'));
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({});
   });
 
-  it('reset the value when unsupported auth type for application is selected', () => {
+  it('reset the value when unsupported auth type for application is selected', async () => {
     initialProps = {
       ...initialProps,
       schema: {
@@ -88,7 +88,7 @@ describe('AuthSelect component', () => {
 
     render(<FormRenderer {...initialProps} initialValues={{ 'auth-select': 'access_key_secret_key' }} />);
 
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({});
   });

--- a/src/test/components/formComponents/authentication.test.js
+++ b/src/test/components/formComponents/authentication.test.js
@@ -99,25 +99,25 @@ describe('Authentication test', () => {
     expect(screen.getByRole('textbox')).toHaveAttribute('name', 'authentication.password');
   });
 
-  it('renders not editing', () => {
+  it('renders not editing', async () => {
     render(<SourcesFormRenderer {...initialProps} />);
 
     expect(screen.getByRole('textbox')).toHaveAttribute('name', 'authentication.password');
     expect(screen.getByText('*')).toBeInTheDocument();
     expect(() => screen.getByText('Changing this resets your current API key.')).toThrow();
 
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).not.toHaveBeenCalled();
 
-    userEvent.type(screen.getByRole('textbox'), 's'); // too short
+    await userEvent.type(screen.getByRole('textbox'), 's'); // too short
 
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).not.toHaveBeenCalled();
 
-    userEvent.type(screen.getByRole('textbox'), 'ome-value'); // too short
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.type(screen.getByRole('textbox'), 'ome-value'); // too short
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({
       authentication: {
@@ -126,7 +126,7 @@ describe('Authentication test', () => {
     });
   });
 
-  it('renders editing and removes required validator (min length still works)', () => {
+  it('renders editing and removes required validator (min length still works)', async () => {
     render(
       <SourcesFormRenderer
         {...initialProps}
@@ -142,7 +142,7 @@ describe('Authentication test', () => {
     expect(() => screen.getByText('*')).toThrow();
     expect(screen.getByText('Changing this resets your current API key.')).toBeInTheDocument();
 
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({
       authentication: {
@@ -151,8 +151,9 @@ describe('Authentication test', () => {
     });
     onSubmit.mockClear();
 
-    userEvent.type(screen.getByRole('textbox'), '{selectall}{backspace}s'); // too short
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.clear(screen.getByRole('textbox'));
+    await userEvent.type(screen.getByRole('textbox'), 's'); // too short
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).not.toHaveBeenCalled();
   });

--- a/src/test/components/formComponents/cardSelect.test.js
+++ b/src/test/components/formComponents/cardSelect.test.js
@@ -159,20 +159,20 @@ describe('CardSelect component', () => {
     expect(screen.getByLabelText('openshift-icon')).toBeInTheDocument();
   });
 
-  it('should set default value', () => {
+  it('should set default value', async () => {
     render(<FormRenderer {...initialProps} initialValues={{ 'card-select': 'ops' }} />);
 
-    userEvent.click(screen.getByText('openshift'));
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getByText('openshift'));
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({});
   });
 
-  it('should clicked single select', () => {
+  it('should clicked single select', async () => {
     render(<FormRenderer {...initialProps} />);
 
-    userEvent.click(screen.getByText('openshift'));
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getByText('openshift'));
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({
       pre: 'filled',
@@ -180,13 +180,13 @@ describe('CardSelect component', () => {
     });
   });
 
-  it('should change by pressing enter single select', () => {
+  it('should change by pressing enter single select', async () => {
     render(<FormRenderer {...initialProps} />);
 
     const preventDefaultMock = jest.fn();
 
-    userEvent.tab();
-    userEvent.tab();
+    await userEvent.tab();
+    await userEvent.tab();
 
     expect(screen.getByText('aws').closest('.pf-c-tile')).toHaveFocus();
 
@@ -201,7 +201,7 @@ describe('CardSelect component', () => {
 
     expect(preventDefaultMock).toHaveBeenCalled();
 
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({
       pre: 'filled',
@@ -210,27 +210,27 @@ describe('CardSelect component', () => {
 
     // unselect
     fireEvent(screen.getByText('aws').closest('.pf-c-tile'), myEvent);
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({
       pre: 'filled',
     });
   });
 
-  it('should not change by pressing shift single select', () => {
+  it('should not change by pressing shift single select', async () => {
     render(<FormRenderer {...initialProps} />);
 
-    userEvent.tab();
-    userEvent.tab();
-    userEvent.keyboard('{Shift}');
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.tab();
+    await userEvent.tab();
+    await userEvent.keyboard('{Shift}');
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({
       pre: 'filled',
     });
   });
 
-  it('should not clicked disabled', () => {
+  it('should not clicked disabled', async () => {
     initialProps = {
       ...initialProps,
       schema: {
@@ -245,16 +245,16 @@ describe('CardSelect component', () => {
 
     render(<FormRenderer {...initialProps} />);
 
-    userEvent.click(screen.getByText('openshift'));
+    await userEvent.click(screen.getByText('openshift'));
 
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({
       pre: 'filled',
     });
   });
 
-  it('should clicked multiSelect select', () => {
+  it('should clicked multiSelect select', async () => {
     initialProps = {
       ...initialProps,
       schema: {
@@ -269,17 +269,17 @@ describe('CardSelect component', () => {
 
     render(<FormRenderer {...initialProps} />);
 
-    userEvent.click(screen.getByText('openshift'));
-    userEvent.click(screen.getByText('aws'));
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getByText('openshift'));
+    await userEvent.click(screen.getByText('aws'));
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({
       pre: 'filled',
       'card-select': ['ops', 'aws'],
     });
 
-    userEvent.click(screen.getByText('openshift'));
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getByText('openshift'));
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({
       pre: 'filled',

--- a/src/test/components/formComponents/enhancedRadio.test.js
+++ b/src/test/components/formComponents/enhancedRadio.test.js
@@ -71,7 +71,7 @@ describe('EnhancedRadio', () => {
     expect(screen.getByText('option1')).toBeInTheDocument();
     expect(screen.getByText('option2')).toBeInTheDocument();
 
-    userEvent.type(screen.getByLabelText('multiplier'), '2');
+    await userEvent.type(screen.getByLabelText('multiplier'), '2');
 
     expect(screen.getAllByRole('radio').map((r) => [r.id, r.value])).toEqual([
       ['radio-2', '2'],
@@ -103,16 +103,16 @@ describe('EnhancedRadio', () => {
       />
     );
 
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({
       radio: NO_APPLICATION_VALUE,
     });
     onSubmit.mockReset();
 
-    userEvent.type(screen.getByLabelText('source_type'), 'some-value');
+    await userEvent.type(screen.getByLabelText('source_type'), 'some-value');
 
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({
       radio: 'first-option',
@@ -165,7 +165,7 @@ describe('EnhancedRadio', () => {
       />
     );
 
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({
       radio: 'aws-option',
@@ -173,8 +173,9 @@ describe('EnhancedRadio', () => {
     });
     onSubmit.mockReset();
 
-    userEvent.type(screen.getByLabelText('source_type'), '{selectall}{backspace}some-value');
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.clear(screen.getByLabelText('source_type'));
+    await userEvent.type(screen.getByLabelText('source_type'), 'some-value');
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({
       radio: '',

--- a/src/test/components/formComponents/sourceWizardSummary.test.js
+++ b/src/test/components/formComponents/sourceWizardSummary.test.js
@@ -617,7 +617,7 @@ describe('SourceWizardSummary component', () => {
       expect(() => screen.getByText(randomLongText)).toThrow();
       expect(screen.getByText('Show more')).toBeInTheDocument();
 
-      userEvent.click(screen.getByText('Show more'));
+      await userEvent.click(screen.getByText('Show more'));
 
       await waitFor(() => expect(screen.getByText(randomLongText)).toBeInTheDocument());
     });

--- a/src/test/components/formComponents/switchGroup.test.js
+++ b/src/test/components/formComponents/switchGroup.test.js
@@ -60,7 +60,7 @@ describe('Switch group', () => {
     expect(screen.getByLabelText('App 1')).toBeChecked();
     expect(screen.getByLabelText('App 2')).toBeChecked();
 
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({ 'switch-group': ['1', '2'] });
   });
@@ -68,7 +68,7 @@ describe('Switch group', () => {
   it('do not set initial when values exist', async () => {
     render(<FormRenderer {...initialProps} initialValues={{ 'switch-group': '123' }} />);
 
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({ 'switch-group': '123' });
   });
@@ -76,26 +76,26 @@ describe('Switch group', () => {
   it('handle onChange', async () => {
     render(<FormRenderer {...initialProps} />);
 
-    userEvent.click(screen.getAllByText('App 1')[0]);
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getAllByText('App 1')[0]);
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({ 'switch-group': ['2'] });
     onSubmit.mockClear();
 
-    userEvent.click(screen.getAllByText('App 2')[0]);
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getAllByText('App 2')[0]);
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({ 'switch-group': [] });
     onSubmit.mockClear();
 
-    userEvent.click(screen.getAllByText('App 2')[0]);
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getAllByText('App 2')[0]);
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({ 'switch-group': ['2'] });
     onSubmit.mockClear();
 
-    userEvent.click(screen.getAllByText('App 1')[0]);
-    userEvent.click(screen.getByText('Submit'));
+    await userEvent.click(screen.getAllByText('App 1')[0]);
+    await userEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledWith({ 'switch-group': ['2', '1'] });
     onSubmit.mockClear();

--- a/src/test/components/formComponents/valuePopover.test.js
+++ b/src/test/components/formComponents/valuePopover.test.js
@@ -15,7 +15,7 @@ describe('ValuePopover', () => {
 
     expect(screen.getByText('Show more')).toBeInTheDocument();
 
-    userEvent.click(screen.getByText('Show more'));
+    await userEvent.click(screen.getByText('Show more'));
 
     await waitFor(() => expect(screen.getByText('Some value')).toBeInTheDocument());
     expect(screen.getByText('Some label')).toBeInTheDocument();

--- a/src/test/components/redhatTiles/RedHatTiles.test.js
+++ b/src/test/components/redhatTiles/RedHatTiles.test.js
@@ -42,7 +42,7 @@ describe('RedhatTiles', () => {
     expect(screen.getByText('OpenShift Container Platform')).toBeInTheDocument();
     expect(screen.getByAltText('red hat logo')).toBeInTheDocument();
 
-    userEvent.click(screen.getByText('OpenShift Container Platform'));
+    await userEvent.click(screen.getByText('OpenShift Container Platform'));
 
     await waitFor(() =>
       expect(
@@ -56,7 +56,7 @@ describe('RedhatTiles', () => {
   it('sets openshift', async () => {
     render(componentWrapperIntl(<RedHatTiles {...initialProps} />, store));
 
-    userEvent.click(screen.getByText('OpenShift Container Platform'));
+    await userEvent.click(screen.getByText('OpenShift Container Platform'));
 
     expect(screen.getByTestId('location-display').textContent).toEqual(routes.sourcesNew.path);
     expect(setSelectedType).toHaveBeenCalledWith('openshift');

--- a/src/test/components/sourceDetail/ApplicationKebab.test.js
+++ b/src/test/components/sourceDetail/ApplicationKebab.test.js
@@ -8,6 +8,16 @@ import { componentWrapperIntl } from '../../../utilities/testsHelpers';
 import mockStore from '../../__mocks__/mockStore';
 import ApplicationKebab from '../../../components/SourceDetail/ApplicationKebab';
 
+jest.mock('@patternfly/react-core/dist/js/components/Tooltip', () => {
+  const lib = jest.requireActual('@patternfly/react-core/dist/js/components/Tooltip');
+  const { Tooltip } = jest.requireActual('../../__mocks__/@patternfly/react-core');
+
+  return {
+    ...lib,
+    Tooltip,
+  };
+});
+
 describe('ApplicationKebab', () => {
   let store;
 

--- a/src/test/components/sourceDetail/ApplicationKebab.test.js
+++ b/src/test/components/sourceDetail/ApplicationKebab.test.js
@@ -46,7 +46,7 @@ describe('ApplicationKebab', () => {
       )
     );
 
-    userEvent.click(screen.getByLabelText('Actions'));
+    await userEvent.click(screen.getByLabelText('Actions'));
 
     expect(screen.getByText('Pause')).toBeInTheDocument();
     expect(screen.getByText('Temporarily stop this application from collecting data.')).toBeInTheDocument();
@@ -56,7 +56,7 @@ describe('ApplicationKebab', () => {
     expect(screen.getByText('Permanently stop data collection for this application.')).toBeInTheDocument();
     expect(screen.getByText('Remove').closest('.src-m-dropdown-item-disabled')).toBeInTheDocument();
 
-    userEvent.hover(screen.getByText('Remove'));
+    await userEvent.hover(screen.getByText('Remove'));
 
     const tooltipText =
       'To perform this action, you must be granted Sources Administrator permissions from your Organization Administrator.';
@@ -87,7 +87,7 @@ describe('ApplicationKebab', () => {
       )
     );
 
-    userEvent.click(screen.getByLabelText('Actions'));
+    await userEvent.click(screen.getByLabelText('Actions'));
 
     expect(screen.getByText('Resume')).toBeInTheDocument();
     expect(screen.getByText('Resume data collection for this application.')).toBeInTheDocument();
@@ -97,7 +97,7 @@ describe('ApplicationKebab', () => {
     expect(screen.getByText('Permanently stop data collection for this application.')).toBeInTheDocument();
     expect(screen.getByText('Remove').closest('.src-m-dropdown-item-disabled')).toBeInTheDocument();
 
-    userEvent.hover(screen.getByText('Remove'));
+    await userEvent.hover(screen.getByText('Remove'));
 
     const tooltipText =
       'To perform this action, you must be granted Sources Administrator permissions from your Organization Administrator.';
@@ -124,7 +124,7 @@ describe('ApplicationKebab', () => {
     });
 
     it('renders correctly', async () => {
-      userEvent.click(screen.getByLabelText('Actions'));
+      await userEvent.click(screen.getByLabelText('Actions'));
 
       expect(screen.getByText('Pause')).toBeInTheDocument();
       expect(screen.getByText('Temporarily stop this application from collecting data.')).toBeInTheDocument();
@@ -136,8 +136,8 @@ describe('ApplicationKebab', () => {
     });
 
     it('remove application', async () => {
-      userEvent.click(screen.getByLabelText('Actions'));
-      userEvent.click(screen.getByText('Remove'));
+      await userEvent.click(screen.getByLabelText('Actions'));
+      await userEvent.click(screen.getByText('Remove'));
 
       expect(screen.getByTestId('location-display').textContent).toEqual(
         replaceRouteId(routes.sourcesDetailRemoveApp.path, sourceId).replace(':app_id', app.id)
@@ -145,8 +145,8 @@ describe('ApplicationKebab', () => {
     });
 
     it('pause application', async () => {
-      userEvent.click(screen.getByLabelText('Actions'));
-      userEvent.click(screen.getByText('Pause'));
+      await userEvent.click(screen.getByLabelText('Actions'));
+      await userEvent.click(screen.getByText('Pause'));
 
       expect(removeApp).toHaveBeenCalled();
     });
@@ -176,7 +176,7 @@ describe('ApplicationKebab', () => {
         )
       );
 
-      userEvent.click(screen.getByLabelText('Actions'));
+      await userEvent.click(screen.getByLabelText('Actions'));
 
       expect(screen.getByText('Resume')).toBeInTheDocument();
       expect(screen.getByText('Resume data collection for this application.')).toBeInTheDocument();
@@ -186,7 +186,7 @@ describe('ApplicationKebab', () => {
       expect(screen.getByText('Permanently stop data collection for this application.')).toBeInTheDocument();
       expect(screen.getByText('Remove').closest('.src-m-dropdown-item-disabled')).toBeInTheDocument();
 
-      userEvent.hover(screen.getByText('Resume'));
+      await userEvent.hover(screen.getByText('Resume'));
 
       const tooltipText = 'You cannot perform this action on a paused source.';
 
@@ -220,7 +220,7 @@ describe('ApplicationKebab', () => {
     });
 
     it('renders correctly', async () => {
-      userEvent.click(screen.getByLabelText('Actions'));
+      await userEvent.click(screen.getByLabelText('Actions'));
 
       expect(screen.getByText('Resume')).toBeInTheDocument();
       expect(screen.getByText('Resume data collection for this application.')).toBeInTheDocument();
@@ -232,8 +232,8 @@ describe('ApplicationKebab', () => {
     });
 
     it('remove application', async () => {
-      userEvent.click(screen.getByLabelText('Actions'));
-      userEvent.click(screen.getByText('Remove'));
+      await userEvent.click(screen.getByLabelText('Actions'));
+      await userEvent.click(screen.getByText('Remove'));
 
       expect(screen.getByTestId('location-display').textContent).toEqual(
         replaceRouteId(routes.sourcesDetailRemoveApp.path, sourceId).replace(':app_id', app.id)
@@ -241,8 +241,8 @@ describe('ApplicationKebab', () => {
     });
 
     it('resume application', async () => {
-      userEvent.click(screen.getByLabelText('Actions'));
-      userEvent.click(screen.getByText('Resume'));
+      await userEvent.click(screen.getByLabelText('Actions'));
+      await userEvent.click(screen.getByText('Resume'));
 
       expect(addApp).toHaveBeenCalled();
     });

--- a/src/test/components/sourceDetail/ApplicationsCard.test.js
+++ b/src/test/components/sourceDetail/ApplicationsCard.test.js
@@ -51,7 +51,7 @@ describe('ApplicationsCard', () => {
     expect(screen.getAllByText('Subscription Watch')).toBeTruthy();
     expect(screen.getAllByRole('checkbox')[1]).toBeDisabled();
 
-    userEvent.hover(screen.getByText('Cost Management', { selector: '.pf-m-off' }));
+    await userEvent.hover(screen.getByText('Cost Management', { selector: '.pf-m-off' }));
 
     await waitFor(() =>
       expect(
@@ -146,14 +146,14 @@ describe('ApplicationsCard', () => {
 
       expect(screen.getAllByRole('checkbox')[0]).toBeChecked();
 
-      userEvent.click(screen.getAllByRole('checkbox')[0]);
+      await userEvent.click(screen.getAllByRole('checkbox')[0]);
 
       expect(screen.getAllByRole('checkbox')[0]).not.toBeChecked();
 
       expect(pauseApplication).toHaveBeenCalledWith('123');
       pauseApplication.mockClear();
 
-      userEvent.click(screen.getAllByRole('checkbox')[0]);
+      await userEvent.click(screen.getAllByRole('checkbox')[0]);
 
       expect(pauseApplication).not.toHaveBeenCalled();
       expect(actions.loadEntities).not.toHaveBeenCalled();
@@ -162,7 +162,7 @@ describe('ApplicationsCard', () => {
     });
 
     it('add application', async () => {
-      userEvent.click(screen.getAllByRole('checkbox')[1]);
+      await userEvent.click(screen.getAllByRole('checkbox')[1]);
 
       expect(screen.getByTestId('location-display').textContent).toEqual(
         replaceRouteId(routes.sourcesDetailAddApp.path, sourceId).replace(':app_type_id', SUBWATCH_APP.id)
@@ -205,14 +205,14 @@ describe('ApplicationsCard', () => {
 
       expect(screen.getAllByRole('checkbox')[0]).not.toBeChecked();
 
-      userEvent.click(screen.getAllByRole('checkbox')[0]);
+      await userEvent.click(screen.getAllByRole('checkbox')[0]);
 
       expect(screen.getAllByRole('checkbox')[0]).toBeChecked();
 
       expect(unpauseApplication).toHaveBeenCalledWith('123');
       unpauseApplication.mockClear();
 
-      userEvent.click(screen.getAllByRole('checkbox')[0]);
+      await userEvent.click(screen.getAllByRole('checkbox')[0]);
 
       expect(unpauseApplication).not.toHaveBeenCalled();
       expect(actions.loadEntities).not.toHaveBeenCalled();
@@ -259,7 +259,7 @@ describe('ApplicationsCard', () => {
         )
       );
 
-      userEvent.click(screen.getAllByRole('checkbox')[0]);
+      await userEvent.click(screen.getAllByRole('checkbox')[0]);
 
       await waitFor(() =>
         expect(actions.addMessage).toHaveBeenCalledWith({
@@ -303,8 +303,8 @@ describe('ApplicationsCard', () => {
         )
       );
 
-      userEvent.click(screen.getByLabelText('Actions'));
-      userEvent.click(screen.getByText('Resume'));
+      await userEvent.click(screen.getByLabelText('Actions'));
+      await userEvent.click(screen.getByText('Resume'));
 
       await waitFor(() => expect(unpauseApplication).toHaveBeenCalledWith('123'));
       expect(actions.addMessage).toHaveBeenCalledWith({
@@ -380,14 +380,14 @@ describe('ApplicationsCard', () => {
 
       expect(screen.getAllByRole('checkbox')[0]).not.toBeChecked();
 
-      userEvent.click(screen.getAllByRole('checkbox')[0]);
+      await userEvent.click(screen.getAllByRole('checkbox')[0]);
 
       expect(screen.getAllByRole('checkbox')[0]).toBeChecked();
 
       expect(unpauseApplication).toHaveBeenCalledWith('123');
       unpauseApplication.mockClear();
 
-      userEvent.click(screen.getAllByRole('checkbox')[0]);
+      await userEvent.click(screen.getAllByRole('checkbox')[0]);
 
       expect(unpauseApplication).not.toHaveBeenCalled();
       expect(actions.loadEntities).not.toHaveBeenCalled();
@@ -406,7 +406,7 @@ describe('ApplicationsCard', () => {
       api.doCreateApplication = jest.fn().mockImplementation(() => Promise.reject('Some backend error'));
       actions.addMessage.mockClear();
 
-      userEvent.click(screen.getAllByRole('checkbox')[1]);
+      await userEvent.click(screen.getAllByRole('checkbox')[1]);
 
       await waitFor(() =>
         expect(actions.addMessage).toHaveBeenCalledWith({
@@ -426,7 +426,7 @@ describe('ApplicationsCard', () => {
         pauseApplication,
       });
 
-      userEvent.click(screen.getAllByRole('checkbox')[0]);
+      await userEvent.click(screen.getAllByRole('checkbox')[0]);
 
       await waitFor(() =>
         expect(actions.addMessage).toHaveBeenCalledWith({
@@ -472,7 +472,7 @@ describe('ApplicationsCard', () => {
 
       actions.addMessage.mockClear();
 
-      userEvent.click(screen.getAllByRole('checkbox')[0]);
+      await userEvent.click(screen.getAllByRole('checkbox')[0]);
 
       await waitFor(() =>
         expect(actions.addMessage).toHaveBeenCalledWith({
@@ -488,7 +488,7 @@ describe('ApplicationsCard', () => {
 
       expect(screen.getAllByRole('checkbox')[1]).not.toBeChecked();
 
-      userEvent.click(screen.getAllByRole('checkbox')[1]);
+      await userEvent.click(screen.getAllByRole('checkbox')[1]);
 
       expect(screen.getAllByRole('checkbox')[1]).toBeChecked();
 
@@ -512,14 +512,14 @@ describe('ApplicationsCard', () => {
 
       actions.addMessage.mockClear();
 
-      userEvent.click(screen.getAllByRole('checkbox')[0]);
+      await userEvent.click(screen.getAllByRole('checkbox')[0]);
 
       expect(screen.getAllByRole('checkbox')[0]).not.toBeChecked();
 
       expect(pauseApplication).toHaveBeenCalledWith('123');
       pauseApplication.mockClear();
 
-      userEvent.click(screen.getAllByRole('checkbox')[0]);
+      await userEvent.click(screen.getAllByRole('checkbox')[0]);
 
       expect(pauseApplication).not.toHaveBeenCalled();
       expect(actions.loadEntities).not.toHaveBeenCalled();
@@ -542,8 +542,8 @@ describe('ApplicationsCard', () => {
         pauseApplication,
       });
 
-      userEvent.click(screen.getByLabelText('Actions'));
-      userEvent.click(screen.getByText('Pause'));
+      await userEvent.click(screen.getByLabelText('Actions'));
+      await userEvent.click(screen.getByText('Pause'));
 
       expect(pauseApplication).toHaveBeenCalled();
       await waitFor(() => expect(actions.loadEntities).toHaveBeenCalled());

--- a/src/test/components/sourceDetail/ApplicationsCard.test.js
+++ b/src/test/components/sourceDetail/ApplicationsCard.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
-import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import PlayIcon from '@patternfly/react-icons/dist/esm/icons/play-icon';

--- a/src/test/components/sourceDetail/ApplicationsCard.test.js
+++ b/src/test/components/sourceDetail/ApplicationsCard.test.js
@@ -110,7 +110,9 @@ describe('ApplicationsCard', () => {
       });
 
       actions.addMessage = jest.fn().mockImplementation(() => ({ type: 'undefined' }));
+    });
 
+    it('renders correctly', () => {
       render(
         componentWrapperIntl(
           <Route path={routes.sourcesDetail.path} render={(...args) => <ApplicationsCard {...args} />} />,
@@ -118,9 +120,7 @@ describe('ApplicationsCard', () => {
           initialEntry
         )
       );
-    });
 
-    it('renders correctly', () => {
       expect(screen.getByText('Applications')).toBeInTheDocument();
 
       expect(screen.getAllByText('Cost Management')).toBeTruthy();
@@ -137,8 +137,16 @@ describe('ApplicationsCard', () => {
     });
 
     it('pause application', async () => {
+      render(
+        componentWrapperIntl(
+          <Route path={routes.sourcesDetail.path} render={(...args) => <ApplicationsCard {...args} />} />,
+          store,
+          initialEntry
+        )
+      );
+
       actions.loadEntities = jest.fn().mockImplementation(() => ({ type: 'nonsense' }));
-      const pauseApplication = jest.fn().mockResolvedValue('ok');
+      const pauseApplication = mockApi('ok');
 
       api.getSourcesApi = () => ({
         pauseApplication,
@@ -162,6 +170,14 @@ describe('ApplicationsCard', () => {
     });
 
     it('add application', async () => {
+      render(
+        componentWrapperIntl(
+          <Route path={routes.sourcesDetail.path} render={(...args) => <ApplicationsCard {...args} />} />,
+          store,
+          initialEntry
+        )
+      );
+
       await userEvent.click(screen.getAllByRole('checkbox')[1]);
 
       expect(screen.getByTestId('location-display').textContent).toEqual(
@@ -170,8 +186,6 @@ describe('ApplicationsCard', () => {
     });
 
     it('unpause application', async () => {
-      cleanup();
-
       store = mockStore({
         sources: {
           entities: [
@@ -189,7 +203,7 @@ describe('ApplicationsCard', () => {
 
       actions.loadEntities = jest.fn().mockImplementation(() => ({ type: 'nonsense' }));
 
-      const unpauseApplication = jest.fn().mockResolvedValue('ok');
+      const unpauseApplication = mockApi('ok');
 
       api.getSourcesApi = () => ({
         unpauseApplication,
@@ -228,8 +242,6 @@ describe('ApplicationsCard', () => {
     });
 
     it('unpause application and fails', async () => {
-      cleanup();
-
       store = mockStore({
         sources: {
           entities: [
@@ -271,8 +283,6 @@ describe('ApplicationsCard', () => {
     });
 
     it('unpause application via dropdown', async () => {
-      cleanup();
-
       store = mockStore({
         sources: {
           entities: [
@@ -334,20 +344,10 @@ describe('ApplicationsCard', () => {
         user: { writePermissions: true },
       });
 
-      render(
-        componentWrapperIntl(
-          <Route path={routes.sourcesDetail.path} render={(...args) => <ApplicationsCard {...args} />} />,
-          store,
-          initialEntry
-        )
-      );
-
       actions.loadEntities = jest.fn().mockImplementation(() => ({ type: 'nonsense' }));
     });
 
     it('unpaused application and blocks clicking again', async () => {
-      cleanup();
-
       store = mockStore({
         sources: {
           entities: [
@@ -364,7 +364,7 @@ describe('ApplicationsCard', () => {
         user: { writePermissions: true },
       });
 
-      const unpauseApplication = jest.fn().mockResolvedValue('ok');
+      const unpauseApplication = mockApi('ok');
 
       api.getSourcesApi = () => ({
         unpauseApplication,
@@ -399,10 +399,18 @@ describe('ApplicationsCard', () => {
           variant: 'default',
         })
       );
-      expect(actions.loadEntities).toHaveBeenCalled();
+      await waitFor(() => expect(actions.loadEntities).toHaveBeenCalled());
     });
 
     it('adds application and fail', async () => {
+      render(
+        componentWrapperIntl(
+          <Route path={routes.sourcesDetail.path} render={(...args) => <ApplicationsCard {...args} />} />,
+          store,
+          initialEntry
+        )
+      );
+
       api.doCreateApplication = jest.fn().mockImplementation(() => Promise.reject('Some backend error'));
       actions.addMessage.mockClear();
 
@@ -418,6 +426,14 @@ describe('ApplicationsCard', () => {
     });
 
     it('pauses application and fail', async () => {
+      render(
+        componentWrapperIntl(
+          <Route path={routes.sourcesDetail.path} render={(...args) => <ApplicationsCard {...args} />} />,
+          store,
+          initialEntry
+        )
+      );
+
       const pauseApplication = jest.fn().mockImplementation(() => Promise.reject('Some backend error'));
 
       actions.addMessage.mockClear();
@@ -438,8 +454,6 @@ describe('ApplicationsCard', () => {
     });
 
     it('resumes application and fail', async () => {
-      cleanup();
-
       store = mockStore({
         sources: {
           entities: [
@@ -484,7 +498,15 @@ describe('ApplicationsCard', () => {
     });
 
     it('adds application', async () => {
-      api.doCreateApplication = jest.fn().mockResolvedValue('ok');
+      render(
+        componentWrapperIntl(
+          <Route path={routes.sourcesDetail.path} render={(...args) => <ApplicationsCard {...args} />} />,
+          store,
+          initialEntry
+        )
+      );
+
+      api.doCreateApplication = mockApi('ok');
 
       expect(screen.getAllByRole('checkbox')[1]).not.toBeChecked();
 
@@ -502,7 +524,15 @@ describe('ApplicationsCard', () => {
     });
 
     it('pause application and blocks clicking again', async () => {
-      const pauseApplication = jest.fn().mockResolvedValue('ok');
+      render(
+        componentWrapperIntl(
+          <Route path={routes.sourcesDetail.path} render={(...args) => <ApplicationsCard {...args} />} />,
+          store,
+          initialEntry
+        )
+      );
+
+      const pauseApplication = mockApi('ok');
 
       api.getSourcesApi = () => ({
         pauseApplication,
@@ -536,6 +566,14 @@ describe('ApplicationsCard', () => {
     });
 
     it('pause application via dropdown', async () => {
+      render(
+        componentWrapperIntl(
+          <Route path={routes.sourcesDetail.path} render={(...args) => <ApplicationsCard {...args} />} />,
+          store,
+          initialEntry
+        )
+      );
+
       const pauseApplication = jest.fn().mockImplementation(() => Promise.resolve('ok'));
 
       api.getSourcesApi = () => ({

--- a/src/test/components/sourceDetail/AvailabilityChecker.test.js
+++ b/src/test/components/sourceDetail/AvailabilityChecker.test.js
@@ -18,7 +18,9 @@ describe('AvailabilityChecker', () => {
 
   beforeEach(() => {
     store = mockStore({ sources: { entities: [{ id: sourceId }] } });
+  });
 
+  it('renders correctly', () => {
     render(
       componentWrapperIntl(
         <Route path={routes.sourcesDetail.path} render={(...args) => <AvailabilityChecker {...args} />} />,
@@ -26,16 +28,22 @@ describe('AvailabilityChecker', () => {
         initialEntry
       )
     );
-  });
 
-  it('renders correctly', () => {
     expect(screen.getByLabelText('Check source availability')).not.toBeDisabled();
     expect(() => screen.getByRole('progressbar')).toThrow();
     expect(screen.getByTestId('RedoIcon')).toBeInTheDocument();
   });
 
   it('checks status (click > loading > message)', async () => {
-    api.default = jest.fn().mockResolvedValue('ok');
+    render(
+      componentWrapperIntl(
+        <Route path={routes.sourcesDetail.path} render={(...args) => <AvailabilityChecker {...args} />} />,
+        store,
+        initialEntry
+      )
+    );
+
+    api.default = mockApi('ok');
     actions.addMessage = jest.fn().mockImplementation(() => ({ type: 'something' }));
 
     expect(screen.getByLabelText('Check source availability')).not.toBeDisabled();

--- a/src/test/components/sourceDetail/AvailabilityChecker.test.js
+++ b/src/test/components/sourceDetail/AvailabilityChecker.test.js
@@ -40,7 +40,7 @@ describe('AvailabilityChecker', () => {
 
     expect(screen.getByLabelText('Check source availability')).not.toBeDisabled();
 
-    userEvent.click(screen.getByLabelText('Check source availability'));
+    await userEvent.click(screen.getByLabelText('Check source availability'));
 
     expect(api.default).toHaveBeenCalledWith(sourceId);
     expect(screen.getByLabelText('Check source availability')).toBeDisabled();

--- a/src/test/components/sourceDetail/Breadcrumbs.test.js
+++ b/src/test/components/sourceDetail/Breadcrumbs.test.js
@@ -37,7 +37,7 @@ describe('Breadcrumbs', () => {
   });
 
   it('goes back to sources', async () => {
-    userEvent.click(screen.getByText('Sources'));
+    await userEvent.click(screen.getByText('Sources'));
 
     expect(screen.getByTestId('location-display').textContent).toEqual(routes.sources.path);
   });

--- a/src/test/components/sourceDetail/PauseAlert.test.js
+++ b/src/test/components/sourceDetail/PauseAlert.test.js
@@ -85,7 +85,7 @@ describe('DetailHeader', () => {
 
     actions.resumeSource = jest.fn().mockImplementation(() => ({ type: 'mock-resume-source' }));
 
-    userEvent.click(screen.getByText('Resume connection'));
+    await userEvent.click(screen.getByText('Resume connection'));
 
     await waitFor(() => expect(actions.resumeSource).toHaveBeenCalledWith(sourceId, 'Name of this source', expect.any(Object)));
 

--- a/src/test/components/sourceDetail/ResourcesTable.test.js
+++ b/src/test/components/sourceDetail/ResourcesTable.test.js
@@ -296,7 +296,7 @@ describe('ResourcesTable', () => {
     expect(screen.getByText('Cost Management').closest('.pf-m-current')).toBeInTheDocument();
     expect(screen.getByText('Subscription Watch').closest('.pf-m-current')).toBeNull();
 
-    userEvent.click(screen.getByText('Subscription Watch'));
+    await userEvent.click(screen.getByText('Subscription Watch'));
 
     expect(screen.getByText('Cost Management').closest('.pf-m-current')).toBeNull();
     expect(screen.getByText('Subscription Watch').closest('.pf-m-current')).toBeInTheDocument();

--- a/src/test/components/sourceDetail/SourceKebab.test.js
+++ b/src/test/components/sourceDetail/SourceKebab.test.js
@@ -32,7 +32,7 @@ describe('SourceKebab', () => {
       )
     );
 
-    userEvent.click(screen.getByLabelText('Actions'));
+    await userEvent.click(screen.getByLabelText('Actions'));
 
     expect(screen.getByText('Pause')).toBeInTheDocument();
     expect(screen.getByText('Temporarily disable data collection').closest('.src-m-dropdown-item-disabled')).toBeInTheDocument();
@@ -44,7 +44,7 @@ describe('SourceKebab', () => {
 
     expect(screen.getByText('Rename').closest('.src-m-dropdown-item-disabled')).toBeInTheDocument();
 
-    userEvent.hover(screen.getByText('Pause'));
+    await userEvent.hover(screen.getByText('Pause'));
 
     const tooltipText =
       'To perform this action, you must be granted Sources Administrator permissions from your Organization Administrator.';
@@ -68,7 +68,7 @@ describe('SourceKebab', () => {
       )
     );
 
-    userEvent.click(screen.getByLabelText('Actions'));
+    await userEvent.click(screen.getByLabelText('Actions'));
 
     expect(screen.getByText('Resume')).toBeInTheDocument();
     expect(screen.getByText('Unpause data collection for this source')).toBeInTheDocument();
@@ -78,7 +78,7 @@ describe('SourceKebab', () => {
 
     expect(screen.getByText('Rename')).toBeInTheDocument();
 
-    userEvent.hover(screen.getByText('Rename'));
+    await userEvent.hover(screen.getByText('Rename'));
 
     const tooltipText = 'You cannot perform this action on a paused source.';
 
@@ -101,11 +101,11 @@ describe('SourceKebab', () => {
       )
     );
 
-    userEvent.click(screen.getByLabelText('Actions'));
+    await userEvent.click(screen.getByLabelText('Actions'));
 
     actions.resumeSource = jest.fn().mockImplementation(() => ({ type: 'undefined' }));
 
-    userEvent.click(screen.getByText('Resume'));
+    await userEvent.click(screen.getByText('Resume'));
 
     expect(actions.resumeSource).toHaveBeenCalledWith(sourceId, sourceName, expect.any(Object));
   });
@@ -129,7 +129,7 @@ describe('SourceKebab', () => {
     });
 
     it('renders correctly', async () => {
-      userEvent.click(screen.getByLabelText('Actions'));
+      await userEvent.click(screen.getByLabelText('Actions'));
 
       expect(screen.getByText('Pause')).toBeInTheDocument();
       expect(screen.getByText('Temporarily disable data collection')).toBeInTheDocument();
@@ -144,8 +144,8 @@ describe('SourceKebab', () => {
     });
 
     it('remove source', async () => {
-      userEvent.click(screen.getByLabelText('Actions'));
-      userEvent.click(screen.getByText('Remove'));
+      await userEvent.click(screen.getByLabelText('Actions'));
+      await userEvent.click(screen.getByText('Remove'));
 
       expect(screen.getByTestId('location-display').textContent).toEqual(
         replaceRouteId(routes.sourcesDetailRemove.path, sourceId)
@@ -153,18 +153,18 @@ describe('SourceKebab', () => {
     });
 
     it('pause source', async () => {
-      userEvent.click(screen.getByLabelText('Actions'));
+      await userEvent.click(screen.getByLabelText('Actions'));
 
       actions.pauseSource = jest.fn().mockImplementation(() => ({ type: 'undefined' }));
 
-      userEvent.click(screen.getByText('Pause'));
+      await userEvent.click(screen.getByText('Pause'));
 
       expect(actions.pauseSource).toHaveBeenCalledWith(sourceId, sourceName, expect.any(Object));
     });
 
     it('rename source', async () => {
-      userEvent.click(screen.getByLabelText('Actions'));
-      userEvent.click(screen.getByText('Rename'));
+      await userEvent.click(screen.getByLabelText('Actions'));
+      await userEvent.click(screen.getByText('Rename'));
 
       expect(screen.getByTestId('location-display').textContent).toEqual(
         replaceRouteId(routes.sourcesDetailRename.path, sourceId)

--- a/src/test/components/sourceDetail/SourceKebab.test.js
+++ b/src/test/components/sourceDetail/SourceKebab.test.js
@@ -9,6 +9,16 @@ import SourceKebab from '../../../components/SourceDetail/SourceKebab';
 import mockStore from '../../__mocks__/mockStore';
 import * as actions from '../../../redux/sources/actions';
 
+jest.mock('@patternfly/react-core/dist/js/components/Tooltip', () => {
+  const lib = jest.requireActual('@patternfly/react-core/dist/js/components/Tooltip');
+  const { Tooltip } = jest.requireActual('../../__mocks__/@patternfly/react-core');
+
+  return {
+    ...lib,
+    Tooltip,
+  };
+});
+
 describe('SourceKebab', () => {
   let store;
 

--- a/src/test/components/sourceDetail/SourceRenameModal.test.js
+++ b/src/test/components/sourceDetail/SourceRenameModal.test.js
@@ -49,13 +49,13 @@ describe('SourceRenameModal', () => {
   });
 
   it('close on close icon', async () => {
-    userEvent.click(screen.getByLabelText('Close'));
+    await userEvent.click(screen.getByLabelText('Close'));
 
     expect(screen.getByTestId('location-display').textContent).toEqual(replaceRouteId(routes.sourcesDetail.path, sourceId));
   });
 
   it('close on cancel', async () => {
-    userEvent.click(screen.getByText('Cancel'));
+    await userEvent.click(screen.getByText('Cancel'));
 
     expect(screen.getByTestId('location-display').textContent).toEqual(replaceRouteId(routes.sourcesDetail.path, sourceId));
   });
@@ -63,8 +63,9 @@ describe('SourceRenameModal', () => {
   it('submits', async () => {
     actions.renameSource = jest.fn().mockImplementation(() => ({ type: 'something' }));
 
-    userEvent.type(screen.getByRole('textbox'), '{selectall}{backspace}new-name');
-    userEvent.click(screen.getByText('Save'));
+    await userEvent.clear(screen.getByRole('textbox'));
+    await userEvent.type(screen.getByRole('textbox'), 'new-name');
+    await userEvent.click(screen.getByText('Save'));
 
     expect(actions.renameSource).toHaveBeenCalledWith(sourceId, 'new-name', 'Renaming was unsuccessful');
     expect(screen.getByTestId('location-display').textContent).toEqual(replaceRouteId(routes.sourcesDetail.path, sourceId));

--- a/src/test/components/sourceDetail/SourceSummaryCard.test.js
+++ b/src/test/components/sourceDetail/SourceSummaryCard.test.js
@@ -161,7 +161,7 @@ describe('SourceSummaryCard', () => {
       )
     );
 
-    userEvent.click(screen.getByText('Edit credentials'));
+    await userEvent.click(screen.getByText('Edit credentials'));
 
     expect(screen.getByTestId('location-display').textContent).toEqual(
       replaceRouteId(routes.sourcesDetailEditCredentials.path, sourceId)

--- a/src/test/components/sourceEditForm/SourceEditModal.test.js
+++ b/src/test/components/sourceEditForm/SourceEditModal.test.js
@@ -161,7 +161,8 @@ describe('SourceEditModal', () => {
 
     expect(screen.getByText('This application is unavailable')).toBeInTheDocument();
 
-    userEvent.type(screen.getAllByRole('textbox')[1], '{selectall}{backspace}different-value');
+    await userEvent.clear(screen.getAllByRole('textbox')[1]);
+    await userEvent.type(screen.getAllByRole('textbox')[1], 'different-value');
 
     submit.onSubmit = jest.fn().mockImplementation((values, editing, _dispatch, source, _intl, setState) => {
       setState({
@@ -176,7 +177,7 @@ describe('SourceEditModal', () => {
       setState({ type: 'sourceChanged' });
     });
 
-    userEvent.click(screen.getByText('Save changes'));
+    await userEvent.click(screen.getByText('Save changes'));
 
     await waitFor(() => expect(screen.getByText('success title')).toBeInTheDocument());
   });
@@ -537,7 +538,7 @@ describe('SourceEditModal', () => {
 
     expect(editApi.doLoadSourceForEdit.mock.calls).toHaveLength(1);
 
-    userEvent.click(screen.getByText('Change redux source'));
+    await userEvent.click(screen.getByText('Change redux source'));
 
     await waitFor(() => expect(editApi.doLoadSourceForEdit.mock.calls).toHaveLength(2));
   });
@@ -571,7 +572,8 @@ describe('SourceEditModal', () => {
 
       await waitFor(() => expect(() => screen.getByRole('progressbar')).toThrow());
 
-      userEvent.type(screen.getAllByRole('textbox')[1], `{selectall}{backspace}${NEW_CA}`);
+      await userEvent.clear(screen.getAllByRole('textbox')[1]);
+      await userEvent.type(screen.getAllByRole('textbox')[1], NEW_CA);
     });
 
     it('calls onSubmit with values and editing object', async () => {
@@ -593,7 +595,7 @@ describe('SourceEditModal', () => {
         }, 1000);
       });
 
-      userEvent.click(screen.getByText('Save changes'));
+      await userEvent.click(screen.getByText('Save changes'));
 
       expect(screen.getByText('Validating edited source credentials')).toBeInTheDocument();
 
@@ -624,7 +626,7 @@ describe('SourceEditModal', () => {
         }, 1000);
       });
 
-      userEvent.click(screen.getByText('Save changes'));
+      await userEvent.click(screen.getByText('Save changes'));
 
       expect(screen.getByText('Validating edited source credentials')).toBeInTheDocument();
 
@@ -644,7 +646,7 @@ describe('SourceEditModal', () => {
         }, 1000);
       });
 
-      userEvent.click(screen.getByText('Save changes'));
+      await userEvent.click(screen.getByText('Save changes'));
 
       expect(screen.getByText('Validating edited source credentials')).toBeInTheDocument();
 
@@ -660,7 +662,7 @@ describe('SourceEditModal', () => {
 
       submit.onSubmit.mockReset();
 
-      userEvent.click(screen.getByText('Retry'));
+      await userEvent.click(screen.getByText('Retry'));
 
       await waitFor(() => expect(submit.onSubmit).toHaveBeenCalledWith(VALUES, EDITING, DISPATCH, SOURCE, INTL, SET_STATE));
     });

--- a/src/test/components/sourceEditForm/erroredModal.test.js
+++ b/src/test/components/sourceEditForm/erroredModal.test.js
@@ -45,7 +45,7 @@ describe('ErroredModal', () => {
   it('calls onRetry', async () => {
     expect(onRetry).not.toHaveBeenCalled();
 
-    userEvent.click(screen.getByText('Retry'));
+    await userEvent.click(screen.getByText('Retry'));
 
     expect(onRetry).toHaveBeenCalled();
   });

--- a/src/test/components/sourceRemoveModal/SourceRemoveModal.test.js
+++ b/src/test/components/sourceRemoveModal/SourceRemoveModal.test.js
@@ -46,7 +46,7 @@ describe('SourceRemoveModal', () => {
       expect(screen.getByText('Remove source and its data')).toBeDisabled();
     });
 
-    it('enables submit button', () => {
+    it('enables submit button', async () => {
       render(
         componentWrapperIntl(
           <Route path={routes.sourcesRemove.path} render={(...args) => <SourceRemoveModal {...args} />} />,
@@ -57,12 +57,12 @@ describe('SourceRemoveModal', () => {
 
       expect(screen.getByText('Remove source and its data')).toBeDisabled();
 
-      userEvent.click(screen.getByRole('checkbox'));
+      await userEvent.click(screen.getByRole('checkbox'));
 
       expect(screen.getByText('Remove source and its data')).not.toBeDisabled();
     });
 
-    it('calls submit action', () => {
+    it('calls submit action', async () => {
       actions.removeSource = jest.fn().mockImplementation(() => ({ type: 'REMOVE' }));
 
       render(
@@ -73,8 +73,8 @@ describe('SourceRemoveModal', () => {
         )
       );
 
-      userEvent.click(screen.getByRole('checkbox'));
-      userEvent.click(screen.getByText('Remove source and its data'));
+      await userEvent.click(screen.getByRole('checkbox'));
+      await userEvent.click(screen.getByText('Remove source and its data'));
 
       const source = sourcesDataGraphQl.find((s) => s.id === '14');
 

--- a/src/test/components/sourcesTable/EmptyStateTable.test.js
+++ b/src/test/components/sourcesTable/EmptyStateTable.test.js
@@ -17,12 +17,12 @@ describe('EmptyStateTable', () => {
     ).toBeInTheDocument();
   });
 
-  it('calls clear filters when click on button', () => {
+  it('calls clear filters when click on button', async () => {
     actions.clearFilters = jest.fn().mockImplementation(() => ({ type: 'cosi' }));
 
     render(componentWrapperIntl(<EmptyStateTable />));
 
-    userEvent.click(screen.getByText('Clear all filters'));
+    await userEvent.click(screen.getByText('Clear all filters'));
 
     expect(actions.clearFilters).toHaveBeenCalled();
   });

--- a/src/test/components/sourcesTable/SourcesTable.test.js
+++ b/src/test/components/sourcesTable/SourcesTable.test.js
@@ -120,11 +120,11 @@ describe('SourcesTable', () => {
 
     render(componentWrapperIntl(<SourcesTable {...initialProps} />, store));
 
-    userEvent.click(screen.getAllByLabelText('Actions')[0]);
+    await userEvent.click(screen.getAllByLabelText('Actions')[0]);
 
     expect(screen.getByText('Edit')).toHaveClass('src-m-dropdown-item-disabled');
 
-    userEvent.click(screen.getByText('Edit'));
+    await userEvent.click(screen.getByText('Edit'));
 
     await waitFor(() => expect(screen.getByText(disabledMessage(INTL))).toBeInTheDocument());
   });
@@ -205,15 +205,15 @@ describe('SourcesTable', () => {
     });
 
     it('redirect to edit', async () => {
-      userEvent.click(screen.getAllByLabelText('Actions')[0]);
-      userEvent.click(screen.getByText('Edit'));
+      await userEvent.click(screen.getAllByLabelText('Actions')[0]);
+      await userEvent.click(screen.getByText('Edit'));
       const expectedPath = replaceRouteId(routes.sourcesDetail.path, sourcesDataGraphQl[0].id);
       expect(screen.getByTestId('location-display').textContent).toEqual(expectedPath);
     });
 
     it('redirect to delete', async () => {
-      userEvent.click(screen.getAllByLabelText('Actions')[0]);
-      userEvent.click(screen.getByText('Remove'));
+      await userEvent.click(screen.getAllByLabelText('Actions')[0]);
+      await userEvent.click(screen.getByText('Remove'));
 
       const expectedPath = replaceRouteId(routes.sourcesRemove.path, sourcesDataGraphQl[0].id);
       expect(screen.getByTestId('location-display').textContent).toEqual(expectedPath);
@@ -222,8 +222,8 @@ describe('SourcesTable', () => {
     it('pause source', async () => {
       actions.pauseSource = jest.fn().mockImplementation(() => ({ type: 'undefined-pause' }));
 
-      userEvent.click(screen.getAllByLabelText('Actions')[0]);
-      userEvent.click(screen.getByText('Pause'));
+      await userEvent.click(screen.getAllByLabelText('Actions')[0]);
+      await userEvent.click(screen.getByText('Pause'));
 
       expect(actions.pauseSource).toHaveBeenCalledWith(sourcesDataGraphQl[0].id, sourcesDataGraphQl[0].name, expect.any(Object));
 
@@ -253,8 +253,8 @@ describe('SourcesTable', () => {
 
     render(componentWrapperIntl(<SourcesTable {...initialProps} />, store));
 
-    userEvent.click(screen.getAllByLabelText('Actions')[0]);
-    userEvent.click(screen.getByText('Resume'));
+    await userEvent.click(screen.getAllByLabelText('Actions')[0]);
+    await userEvent.click(screen.getByText('Resume'));
 
     expect(actions.resumeSource).toHaveBeenCalledWith(sourcesDataGraphQl[0].id, sourcesDataGraphQl[0].name, expect.any(Object));
 
@@ -277,11 +277,11 @@ describe('SourcesTable', () => {
 
     render(componentWrapperIntl(<SourcesTable {...initialProps} />, store));
 
-    userEvent.click(screen.getByText('Name'));
+    await userEvent.click(screen.getByText('Name'));
 
     expect(spy).toHaveBeenCalledWith('name', 'asc');
 
-    userEvent.click(screen.getByText('Type'));
+    await userEvent.click(screen.getByText('Type'));
 
     expect(spy).toHaveBeenCalledWith('source_type_id', 'asc');
   });

--- a/src/test/pages/Sources.test.js
+++ b/src/test/pages/Sources.test.js
@@ -190,7 +190,7 @@ describe('SourcesPage', () => {
     render(componentWrapperIntl(<SourcesPage {...initialProps} />, store));
     await waitFor(() => expect(screen.getByText('Add source')).toBeInTheDocument());
 
-    userEvent.click(screen.getByText('Amazon Web Services'));
+    await userEvent.click(screen.getByText('Amazon Web Services'));
 
     await waitFor(() => expect(screen.getByTestId('location-display').textContent).toEqual(routes.sourcesNew.path));
 
@@ -233,7 +233,7 @@ describe('SourcesPage', () => {
     render(componentWrapperIntl(<SourcesPage {...initialProps} />, store));
     await waitFor(() => expect(screen.getByText('Add source')).toBeInTheDocument());
 
-    userEvent.click(screen.getByText('OpenShift Container Platform'));
+    await userEvent.click(screen.getByText('OpenShift Container Platform'));
 
     await waitFor(() => expect(screen.getByTestId('location-display').textContent).toEqual(routes.sourcesNew.path));
 
@@ -281,7 +281,7 @@ describe('SourcesPage', () => {
     render(componentWrapperIntl(<SourcesPage {...initialProps} />, store));
     await waitFor(() => expect(screen.getByText('Add source')).toBeInTheDocument());
 
-    userEvent.click(screen.getAllByLabelText('Go to next page')[0]);
+    await userEvent.click(screen.getAllByLabelText('Go to next page')[0]);
 
     expect(screen.getAllByRole('progressbar')[0].closest('.top-pagination')).not.toBeInTheDocument();
 
@@ -321,9 +321,9 @@ describe('SourcesPage', () => {
       const { container } = render(componentWrapperIntl(<SourcesPage {...initialProps} />, store));
       await waitFor(() => expect(screen.getByText('Add source')).toBeInTheDocument());
 
-      userEvent.click(screen.getByText('Name', { selector: '.ins-c-conditional-filter__value-selector' }));
-      userEvent.click(screen.getByText('Type', { selector: 'button' }));
-      userEvent.click(screen.getByText('Filter by Type'));
+      await userEvent.click(screen.getByText('Name', { selector: '.ins-c-conditional-filter__value-selector' }));
+      await userEvent.click(screen.getByText('Type', { selector: 'button' }));
+      await userEvent.click(screen.getByText('Filter by Type'));
 
       expect([...container.getElementsByClassName('pf-c-select__menu-item')].map((e) => e.textContent)).toEqual([
         'Ansible Tower',
@@ -351,9 +351,9 @@ describe('SourcesPage', () => {
       const { container } = render(componentWrapperIntl(<SourcesPage {...initialProps} />, store));
       await waitFor(() => expect(screen.getByText('Add source')).toBeInTheDocument());
 
-      userEvent.click(screen.getByText('Name', { selector: '.ins-c-conditional-filter__value-selector' }));
-      userEvent.click(screen.getByText('Type', { selector: 'button' }));
-      userEvent.click(screen.getByText('Filter by Type'));
+      await userEvent.click(screen.getByText('Name', { selector: '.ins-c-conditional-filter__value-selector' }));
+      await userEvent.click(screen.getByText('Type', { selector: 'button' }));
+      await userEvent.click(screen.getByText('Filter by Type'));
 
       expect([...container.getElementsByClassName('pf-c-select__menu-item')].map((e) => e.textContent)).toEqual([
         'Amazon Web Services',
@@ -387,7 +387,7 @@ describe('SourcesPage', () => {
     render(componentWrapperIntl(<SourcesPage {...initialProps} />, store));
     await waitFor(() => expect(screen.getByText('Add source')).toBeInTheDocument());
 
-    userEvent.click(screen.getByText('Add source'));
+    await userEvent.click(screen.getByText('Add source'));
 
     await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
 
@@ -415,13 +415,13 @@ describe('SourcesPage', () => {
     render(componentWrapperIntl(<SourcesPage {...initialProps} />, store));
     await waitFor(() => expect(screen.getByText('Add source')).toBeInTheDocument());
 
-    userEvent.click(screen.getByText('Add source'));
+    await userEvent.click(screen.getByText('Add source'));
 
     await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
 
     expect(screen.getByTestId('location-display').textContent).toEqual(routes.sourcesNew.path);
 
-    userEvent.click(screen.getByLabelText('Close wizard'));
+    await userEvent.click(screen.getByLabelText('Close wizard'));
 
     await waitFor(() => expect(() => screen.getByRole('dialog')).toThrow());
 
@@ -441,14 +441,14 @@ describe('SourcesPage', () => {
     expect(urlQuery.parseQuery.mock.calls).toHaveLength(1);
     expect(urlQuery.updateQuery.mock.calls).toHaveLength(1);
 
-    userEvent.click(screen.getByText('Add source'));
+    await userEvent.click(screen.getByText('Add source'));
 
     await waitFor(() => expect(screen.getByText('after success')).toBeInTheDocument());
 
     expect(urlQuery.parseQuery.mock.calls).toHaveLength(1);
     expect(urlQuery.updateQuery.mock.calls).toHaveLength(2);
 
-    userEvent.click(screen.getByText('after success'));
+    await userEvent.click(screen.getByText('after success'));
 
     expect(helpers.afterSuccess).toHaveBeenCalledWith(expect.any(Function), source);
   });
@@ -482,11 +482,11 @@ describe('SourcesPage', () => {
     );
     await waitFor(() => expect(screen.getByText('Add source')).toBeInTheDocument());
 
-    userEvent.click(screen.getByText('Add source'));
+    await userEvent.click(screen.getByText('Add source'));
 
     await waitFor(() => expect(screen.getByText('submit callback')).toBeInTheDocument());
 
-    userEvent.click(screen.getByText('submit callback'));
+    await userEvent.click(screen.getByText('submit callback'));
 
     expect(checkSubmitSpy).toHaveBeenCalledWith(
       source,
@@ -501,7 +501,7 @@ describe('SourcesPage', () => {
     expect(screen.getByText('name of created source', { selector: 'b' })).toBeInTheDocument();
     expect(screen.getByText('was successfully added', { exact: false })).toBeInTheDocument();
 
-    userEvent.click(screen.getByText('View source details'));
+    await userEvent.click(screen.getByText('View source details'));
 
     await waitFor(() => expect(() => screen.getByText('Success alert:')).toThrow());
     expect(screen.getByTestId('location-display').textContent).toEqual(replaceRouteId(routes.sourcesDetail.path, '544615'));
@@ -550,11 +550,11 @@ describe('SourcesPage', () => {
     );
     await waitFor(() => expect(screen.getByText('Add source')).toBeInTheDocument());
 
-    userEvent.click(screen.getByText('Add source'));
+    await userEvent.click(screen.getByText('Add source'));
 
     await waitFor(() => expect(screen.getByText('submit callback')).toBeInTheDocument());
 
-    userEvent.click(screen.getByText('submit callback'));
+    await userEvent.click(screen.getByText('submit callback'));
 
     expect(checkSubmitSpy).toHaveBeenCalledWith(
       source,
@@ -573,7 +573,7 @@ describe('SourcesPage', () => {
       screen.getByText('Please try again. If the error persists, open a support case.', { exact: false })
     ).toBeInTheDocument();
 
-    userEvent.click(screen.getByText('Retry'));
+    await userEvent.click(screen.getByText('Retry'));
 
     await waitFor(() => expect(() => screen.getByText('Danger alert:')).toThrow());
 
@@ -581,11 +581,11 @@ describe('SourcesPage', () => {
     expect(props.initialValues).toEqual({ source: { name: 'some-name' } });
     expect(props.initialWizardState).toEqual(wizardState);
 
-    userEvent.click(screen.getByText('Close wizard'));
+    await userEvent.click(screen.getByText('Close wizard'));
 
     await waitFor(() => expect(screen.getByTestId('location-display').textContent).toEqual(routes.sources.path));
 
-    userEvent.click(screen.getByText('Add source'));
+    await userEvent.click(screen.getByText('Add source'));
 
     await waitFor(() => expect(screen.getByText('submit callback')).toBeInTheDocument());
 
@@ -616,14 +616,14 @@ describe('SourcesPage', () => {
 
     const exportButton = screen.getAllByRole('button').find((e) => e.getAttribute('data-ouia-component-id') === 'Export');
 
-    userEvent.click(exportButton);
-    userEvent.click(screen.getByText('Export to CSV'));
+    await userEvent.click(exportButton);
+    await userEvent.click(screen.getByText('Export to CSV'));
 
     expect(utilsHelpers.downloadFile).toHaveBeenCalledWith(CSV_FILE, expect.any(String), 'csv');
     utilsHelpers.downloadFile.mockClear();
 
-    userEvent.click(exportButton);
-    userEvent.click(screen.getByText('Export to JSON'));
+    await userEvent.click(exportButton);
+    await userEvent.click(screen.getByText('Export to JSON'));
 
     expect(utilsHelpers.downloadFile).toHaveBeenCalledWith(JSON_FILE_STRING, expect.any(String), 'json');
   });
@@ -637,7 +637,7 @@ describe('SourcesPage', () => {
       render(componentWrapperIntl(<SourcesPage {...initialProps} />, store));
       await waitFor(() => expect(screen.getByText('Add source')).toBeInTheDocument());
 
-      userEvent.type(screen.getByPlaceholderText('Filter by Name'), SEARCH_TERM);
+      await userEvent.type(screen.getByPlaceholderText('Filter by Name'), SEARCH_TERM);
 
       await act(async () => {
         jest.runAllTimers();
@@ -668,10 +668,10 @@ describe('SourcesPage', () => {
 
       expect(screen.getByText(SEARCH_TERM, { selector: '.pf-c-chip__text' })).toBeInTheDocument();
 
-      userEvent.click(screen.getByText('Name', { selector: '.ins-c-conditional-filter__value-selector' }));
-      userEvent.click(screen.getByText('Type', { selector: 'button' }));
-      userEvent.click(screen.getByText('Filter by Type'));
-      userEvent.click(screen.getByText('Amazon Web Services', { selector: '.pf-c-check__label' }));
+      await userEvent.click(screen.getByText('Name', { selector: '.ins-c-conditional-filter__value-selector' }));
+      await userEvent.click(screen.getByText('Type', { selector: 'button' }));
+      await userEvent.click(screen.getByText('Filter by Type'));
+      await userEvent.click(screen.getByText('Amazon Web Services', { selector: '.pf-c-check__label' }));
 
       expect(screen.getByText(SEARCH_TERM, { selector: '.pf-c-chip__text' })).toBeInTheDocument();
       expect(screen.getByText('Amazon Web Services', { selector: '.pf-c-chip__text' })).toBeInTheDocument();
@@ -687,10 +687,10 @@ describe('SourcesPage', () => {
         jest.advanceTimersByTime(500);
       });
 
-      userEvent.click(screen.getByText('Name', { selector: '.ins-c-conditional-filter__value-selector' }));
-      userEvent.click(screen.getByText('Application', { selector: 'button' }));
-      userEvent.click(screen.getByText('Filter by Application'));
-      userEvent.click(screen.getByText('Cost Management', { selector: '.pf-c-check__label' }));
+      await userEvent.click(screen.getByText('Name', { selector: '.ins-c-conditional-filter__value-selector' }));
+      await userEvent.click(screen.getByText('Application', { selector: 'button' }));
+      await userEvent.click(screen.getByText('Filter by Application'));
+      await userEvent.click(screen.getByText('Cost Management', { selector: '.pf-c-check__label' }));
 
       expect(screen.getByText(SEARCH_TERM, { selector: '.pf-c-chip__text' })).toBeInTheDocument();
       expect(screen.getByText('Cost Management', { selector: '.pf-c-chip__text' })).toBeInTheDocument();
@@ -705,10 +705,10 @@ describe('SourcesPage', () => {
       await act(async () => {
         jest.advanceTimersByTime(500);
       });
-      userEvent.click(screen.getByText('Name', { selector: '.ins-c-conditional-filter__value-selector' }));
-      userEvent.click(screen.getByText('Status', { selector: 'button' }));
-      userEvent.click(screen.getByText('Filter by Status'));
-      userEvent.click(screen.getByText('Available', { selector: '.pf-c-check__label' }));
+      await userEvent.click(screen.getByText('Name', { selector: '.ins-c-conditional-filter__value-selector' }));
+      await userEvent.click(screen.getByText('Status', { selector: 'button' }));
+      await userEvent.click(screen.getByText('Filter by Status'));
+      await userEvent.click(screen.getByText('Available', { selector: '.pf-c-check__label' }));
 
       expect(screen.getByText(SEARCH_TERM, { selector: '.pf-c-chip__text' })).toBeInTheDocument();
       expect(screen.getByText('Available', { selector: '.pf-c-chip__text' })).toBeInTheDocument();
@@ -718,7 +718,7 @@ describe('SourcesPage', () => {
         availability_status: [AVAILABLE],
       });
 
-      userEvent.click(screen.getByText('Unavailable', { selector: '.pf-c-check__label' }));
+      await userEvent.click(screen.getByText('Unavailable', { selector: '.pf-c-check__label' }));
 
       expect(screen.getByText(SEARCH_TERM, { selector: '.pf-c-chip__text' })).toBeInTheDocument();
       expect(screen.getByText('Unavailable', { selector: '.pf-c-chip__text' })).toBeInTheDocument();
@@ -728,7 +728,7 @@ describe('SourcesPage', () => {
         availability_status: [UNAVAILABLE],
       });
 
-      userEvent.click(screen.getByText('Unavailable', { selector: '.pf-c-check__label' }));
+      await userEvent.click(screen.getByText('Unavailable', { selector: '.pf-c-check__label' }));
 
       expect(screen.getByText(SEARCH_TERM, { selector: '.pf-c-chip__text' })).toBeInTheDocument();
 
@@ -747,7 +747,7 @@ describe('SourcesPage', () => {
         jest.advanceTimersByTime(500);
       });
 
-      userEvent.click(screen.getByLabelText('close'));
+      await userEvent.click(screen.getByLabelText('close'));
 
       expect(() => screen.getByText(SEARCH_TERM, { selector: '.pf-c-chip__text' })).toThrow();
       expect(screen.getByPlaceholderText('Filter by Name')).toHaveValue('');
@@ -758,7 +758,7 @@ describe('SourcesPage', () => {
         jest.advanceTimersByTime(500);
       });
 
-      userEvent.click(screen.getByText(SEARCH_TERM, { selector: '.pf-c-chip__text' }));
+      await userEvent.click(screen.getByText(SEARCH_TERM, { selector: '.pf-c-chip__text' }));
 
       expect(screen.getByText(SEARCH_TERM, { selector: '.pf-c-chip__text' })).toBeInTheDocument();
       expect(screen.getByPlaceholderText('Filter by Name')).toHaveValue(SEARCH_TERM);
@@ -769,7 +769,7 @@ describe('SourcesPage', () => {
         jest.advanceTimersByTime(500);
       });
 
-      userEvent.click(screen.getByText('Clear filters'));
+      await userEvent.click(screen.getByText('Clear filters'));
 
       expect(() => screen.getByText(SEARCH_TERM, { selector: '.pf-c-chip__text' })).toThrow();
       expect(screen.getByPlaceholderText('Filter by Name')).toHaveValue('');
@@ -787,7 +787,8 @@ describe('SourcesPage', () => {
 
       const totalNonsense = '122#$@#%#^$#@!^$#^$#^546454abcerd';
 
-      userEvent.type(screen.getByPlaceholderText('Filter by Name'), `{selectall}{backspace}${totalNonsense}`);
+      await userEvent.clear(screen.getByPlaceholderText('Filter by Name'));
+      await userEvent.type(screen.getByPlaceholderText('Filter by Name'), `${totalNonsense}`);
 
       await act(async () => {
         jest.advanceTimersByTime(500);
@@ -820,7 +821,8 @@ describe('SourcesPage', () => {
         jest.runAllTimers();
       });
 
-      userEvent.type(screen.getByPlaceholderText('Filter by Name'), `{selectall}{backspace}${SEARCH_TERM}`);
+      await userEvent.clear(screen.getByPlaceholderText('Filter by Name'));
+      await userEvent.type(screen.getByPlaceholderText('Filter by Name'), `${SEARCH_TERM}`);
 
       await act(async () => {
         jest.runAllTimers();
@@ -832,7 +834,8 @@ describe('SourcesPage', () => {
 
       const totalNonsense = '122#$@#%#^$#@!^$#^$#^546454abcerd';
 
-      userEvent.type(screen.getByPlaceholderText('Filter by Name'), `{selectall}{backspace}${totalNonsense}`);
+      await userEvent.clear(screen.getByPlaceholderText('Filter by Name'));
+      await userEvent.type(screen.getByPlaceholderText('Filter by Name'), `${totalNonsense}`);
 
       await act(async () => {
         jest.runAllTimers();
@@ -840,7 +843,7 @@ describe('SourcesPage', () => {
 
       expect(screen.getByPlaceholderText('Filter by Name')).toHaveValue(totalNonsense);
 
-      userEvent.click(screen.getByText('Clear all filters'));
+      await userEvent.click(screen.getByText('Clear all filters'));
 
       await act(async () => {
         jest.runAllTimers();
@@ -860,7 +863,8 @@ describe('SourcesPage', () => {
 
       const totalNonsense = '122#$@#%#^$#@!^$#^$#^546454abcerd';
 
-      userEvent.type(screen.getByPlaceholderText('Filter by Name'), `{selectall}{backspace}${totalNonsense}`);
+      await userEvent.clear(screen.getByPlaceholderText('Filter by Name'));
+      await userEvent.type(screen.getByPlaceholderText('Filter by Name'), `${totalNonsense}`);
 
       await act(async () => {
         jest.advanceTimersByTime(500);
@@ -875,7 +879,7 @@ describe('SourcesPage', () => {
         })
       );
 
-      userEvent.click(screen.getByText('Clear all filters'));
+      await userEvent.click(screen.getByText('Clear all filters'));
 
       await act(async () => {
         jest.runAllTimers();
@@ -904,7 +908,7 @@ describe('SourcesPage', () => {
       expect(screen.getByText('Add source')).toBeDisabled();
 
       await act(async () => {
-        userEvent.click(screen.getByText('Add source'));
+        await userEvent.click(screen.getByText('Add source'));
       });
 
       //TODO: have no idea how to trigger the tooltip
@@ -920,10 +924,10 @@ describe('SourcesPage', () => {
 
       expect(screen.getAllByLabelText('Actions')[0].closest('.pf-c-dropdown')).toHaveClass('pf-m-align-right');
 
-      userEvent.click(screen.getAllByLabelText('Actions')[0]);
+      await userEvent.click(screen.getAllByLabelText('Actions')[0]);
 
       await act(async () => {
-        userEvent.click(screen.getByText('Add source', { selector: '.pf-c-dropdown__menu-item' }));
+        await userEvent.click(screen.getByText('Add source', { selector: '.pf-c-dropdown__menu-item' }));
       });
 
       //TODO: have no idea how to trigger the tooltip

--- a/src/test/pages/Sources/helpers.test.js
+++ b/src/test/pages/Sources/helpers.test.js
@@ -334,7 +334,7 @@ describe('Source page helpers', () => {
 
       render(messageActionLinks);
 
-      userEvent.click(screen.getByText('Retry'));
+      await userEvent.click(screen.getByText('Retry'));
 
       expect(push).toHaveBeenCalledWith(routes.sourcesNew.path);
       expect(actions.removeMessage).toHaveBeenCalledWith(messageId);
@@ -371,7 +371,7 @@ describe('Source page helpers', () => {
 
       render(messageActionLinks);
 
-      userEvent.click(screen.getByText('Edit source'));
+      await userEvent.click(screen.getByText('Edit source'));
 
       expect(push).toHaveBeenCalledWith(replaceRouteId(routes.sourcesDetail.path, '1234'));
       expect(actions.removeMessage).toHaveBeenCalledWith(messageId);
@@ -474,7 +474,7 @@ describe('Source page helpers', () => {
 
       render(messageActionLinks);
 
-      userEvent.click(screen.getByText('View source details'));
+      await userEvent.click(screen.getByText('View source details'));
 
       expect(push).toHaveBeenCalledWith(replaceRouteId(routes.sourcesDetail.path, '1234'));
       expect(actions.removeMessage).toHaveBeenCalledWith(messageId);

--- a/src/test/views/formatters.test.js
+++ b/src/test/views/formatters.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import {
@@ -156,7 +156,7 @@ describe('formatters', () => {
 
       expect(screen.getByText('imported', { selector: '.pf-c-badge' })).toBeInTheDocument();
 
-      userEvent.hover(screen.getByText('imported', { selector: '.pf-c-badge' }));
+      await userEvent.hover(screen.getByText('imported', { selector: '.pf-c-badge' }));
 
       await waitFor(() =>
         expect(screen.getByText('This source can be managed from your connected CloudForms application.')).toBeInTheDocument()
@@ -182,7 +182,7 @@ describe('formatters', () => {
       ).toBeInTheDocument();
       expect(screen.getByText('1 more', { exact: false })).toBeInTheDocument();
 
-      userEvent.click(screen.getByText('1 more'));
+      await userEvent.click(screen.getByText('1 more'));
 
       expect(
         screen.getByText(applicationTypesData.data[TOPOLOGICALINVENTORY_INDEX].display_name, { exact: false })
@@ -239,7 +239,7 @@ describe('formatters', () => {
         )
       );
 
-      userEvent.click(screen.getByText('Cost Management'));
+      await userEvent.click(screen.getByText('Cost Management'));
 
       await waitFor(() => expect(screen.getByText('Everything works fine.', { exact: false })).toBeInTheDocument());
     });
@@ -266,7 +266,7 @@ describe('formatters', () => {
         )
       );
 
-      userEvent.click(screen.getByText('Cost Management'));
+      await userEvent.click(screen.getByText('Cost Management'));
 
       await waitFor(() => expect(screen.getByText(ERROR, { exact: false })).toBeInTheDocument());
     });
@@ -293,7 +293,7 @@ describe('formatters', () => {
         )
       );
 
-      userEvent.click(screen.getByText('Cost Management'));
+      await userEvent.click(screen.getByText('Cost Management'));
 
       await waitFor(() => expect(screen.getByText(ERROR, { exact: false })).toBeInTheDocument());
     });
@@ -319,7 +319,7 @@ describe('formatters', () => {
         )
       );
 
-      userEvent.click(screen.getByText('Cost Management'));
+      await userEvent.click(screen.getByText('Cost Management'));
 
       await waitFor(() =>
         expect(
@@ -351,7 +351,7 @@ describe('formatters', () => {
         )
       );
 
-      userEvent.click(screen.getByText('Cost Management'));
+      await userEvent.click(screen.getByText('Cost Management'));
 
       await waitFor(() =>
         expect(screen.getByText('Resume this application to continue data collection.', { exact: false })).toBeInTheDocument()
@@ -380,7 +380,7 @@ describe('formatters', () => {
         )
       );
 
-      userEvent.click(screen.getByText('Cost Management'));
+      await userEvent.click(screen.getByText('Cost Management'));
 
       await waitFor(() => expect(screen.getByText('Unknown error')).toBeInTheDocument());
     });
@@ -406,7 +406,7 @@ describe('formatters', () => {
         )
       );
 
-      userEvent.click(screen.getByText('Cost Management'));
+      await userEvent.click(screen.getByText('Cost Management'));
 
       await waitFor(() => expect(screen.getByText('Status has not been verified.')).toBeInTheDocument());
     });
@@ -731,7 +731,7 @@ describe('formatters', () => {
 
         expect(screen.getByText('Unknown', { exact: false, selector: '.pf-c-label__content' })).toBeInTheDocument();
 
-        userEvent.click(screen.getByText('Unknown', { exact: false, selector: '.pf-c-label__content' }));
+        await userEvent.click(screen.getByText('Unknown', { exact: false, selector: '.pf-c-label__content' }));
 
         await waitFor(() =>
           expect(
@@ -753,7 +753,7 @@ describe('formatters', () => {
 
         expect(screen.getByText('Unknown', { exact: false, selector: '.pf-c-label__content' })).toBeInTheDocument();
 
-        userEvent.click(screen.getByText('Unknown', { exact: false, selector: '.pf-c-label__content' }));
+        await userEvent.click(screen.getByText('Unknown', { exact: false, selector: '.pf-c-label__content' }));
 
         await waitFor(() =>
           expect(
@@ -1267,7 +1267,7 @@ describe('formatters', () => {
         replaceRouteId(routes.sourcesDetailEditCredentials.path, SOURCE_ID)
       );
 
-      userEvent.hover(screen.getByText('exclamation icon'));
+      await userEvent.hover(screen.getByText('exclamation icon'));
 
       await waitFor(() => expect(screen.getByText('Your username is wrong')).toBeInTheDocument());
     });
@@ -1295,7 +1295,7 @@ describe('formatters', () => {
 
       expect(screen.getByText('Edit credentials', { selector: 'button' })).toBeInTheDocument();
 
-      userEvent.hover(screen.getByText('exclamation icon'));
+      await userEvent.hover(screen.getByText('exclamation icon'));
 
       await waitFor(() => expect(screen.getByText('Edit credentials required.')).toBeInTheDocument());
     });
@@ -1323,7 +1323,7 @@ describe('formatters', () => {
       render(wrapperWithIntl(<ApplicationLabel app={app} />));
 
       expect(screen.getByText('Cost management').closest('.pf-c-label')).toHaveClass('pf-m-green');
-      userEvent.click(screen.getByText('Cost management'));
+      await userEvent.click(screen.getByText('Cost management'));
       expect(screen.getByText('pause icon')).toBeInTheDocument();
 
       await waitFor(() => expect(screen.getByText('Application paused')).toBeInTheDocument());

--- a/src/test/views/formatters.test.js
+++ b/src/test/views/formatters.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import {


### PR DESCRIPTION
https://github.com/testing-library/user-event/releases/tag/v14.0.0

- created delayed mockApi to mock timeouted apis request (should be replaced with a proper way, see [here](https://github.com/testing-library/user-event/discussions/911))
- `userEvent` should use `init()` functions

- [x] tooltip test - how to trigger a PF tooltip?

I haven't found a way to trigger the PF tooltip using the async userEvent - seems that there is some delay that together with async break it. So I wrote a simple mock of the tooltip.