### PR TITLE
Use category instead of vendor in source types

### DIFF
--- a/doc/url-query.md
+++ b/doc/url-query.md
@@ -10,7 +10,8 @@
     - [filter[availability_status]](#filteravailability_status)
   - [Custom attributes](#custom-attributes)
     - [sort_by[]](#sort_by)
-    - [activeVendor](#activevendor)
+    - [category](#category)
+    - [activeVendor [DEPRECATED]](#activevendor-deprecated)
     - [type](#type)
     - [application](#application)
 
@@ -86,13 +87,21 @@ Following attributes are using similar but modified API structure.
 sort_by[]=created_at:desc
 ```
 
-### activeVendor
+### category
 
 Two options: `Cloud` | `Red Hat`
 
 `Cloud` shows table for cloud providers (Amazon, Google, Azure, ...).
 
 `Red Hat` shows all Red Hat types (Openshift, Satellite, ...).
+
+```
+category=Red%20Hat
+```
+
+### activeVendor [DEPRECATED]
+
+See [Category](#activevendor-deprecated) above. This option is **deprecated** and it stays to keep backwards compatibility.
 
 ```
 activeVendor=Red%20Hat

--- a/src/api/entities.js
+++ b/src/api/entities.js
@@ -96,7 +96,7 @@ export const sorting = (sortBy, sortDirection) => {
   return `sort_by: { name: "${sortBy}", direction: ${sortDirection} }`;
 };
 
-export const filtering = (filterValue = {}, activeVendor) => {
+export const filtering = (filterValue = {}, category) => {
   let filterQueries = [];
 
   if (filterValue.name) {
@@ -117,12 +117,12 @@ export const filtering = (filterValue = {}, activeVendor) => {
     );
   }
 
-  if (activeVendor === CLOUD_VENDOR) {
-    filterQueries.push(`{ name: "source_type.vendor", operation: "not_eq", value: "Red Hat" }`);
+  if (category === CLOUD_VENDOR) {
+    filterQueries.push(`{ name: "source_type.category", operation: "eq", value: "Cloud" }`);
   }
 
-  if (activeVendor === REDHAT_VENDOR) {
-    filterQueries.push(`{ name: "source_type.vendor", operation: "eq", value: "Red Hat" }`);
+  if (category === REDHAT_VENDOR) {
+    filterQueries.push(`{ name: "source_type.category", operation: "eq", value: "Red Hat" }`);
   }
 
   const status = filterValue.availability_status?.[0];
@@ -161,8 +161,8 @@ export const graphQlAttributes = `
     endpoints { id, scheme, host, port, path, receptor_node, role, certificate_authority, verify_ssl, availability_status_error, availability_status, authentications { authtype, availability_status, availability_status_error } }
 `;
 
-export const doLoadEntities = ({ pageSize, pageNumber, sortBy, sortDirection, filterValue, activeVendor }) => {
-  const filter = filtering(filterValue, activeVendor);
+export const doLoadEntities = ({ pageSize, pageNumber, sortBy, sortDirection, filterValue, activeCategory }) => {
+  const filter = filtering(filterValue, activeCategory);
 
   const filterSection = [pagination(pageSize, pageNumber), sorting(sortBy, sortDirection), filter].join(',');
 
@@ -185,7 +185,7 @@ export const doDeleteApplication = (appId, errorMessage) =>
       throw { error: { title: errorMessage, detail } };
     });
 
-export const restFilterGenerator = (filterValue = {}, activeVendor) => {
+export const restFilterGenerator = (filterValue = {}, category) => {
   let filterQueries = [];
 
   if (filterValue.name) {
@@ -200,12 +200,12 @@ export const restFilterGenerator = (filterValue = {}, activeVendor) => {
     filterValue.applications.map((id) => filterQueries.push(`filter[applications][application_type_id][eq][]=${id}`));
   }
 
-  if (activeVendor === CLOUD_VENDOR) {
-    filterQueries.push(`filter[source_type][vendor][not_eq]=Red Hat`);
+  if (category === CLOUD_VENDOR) {
+    filterQueries.push(`filter[source_type][category]=Cloud`);
   }
 
-  if (activeVendor === REDHAT_VENDOR) {
-    filterQueries.push('filter[source_type][vendor]=Red Hat');
+  if (category === REDHAT_VENDOR) {
+    filterQueries.push('filter[source_type][category]=Red Hat');
   }
 
   const status = filterValue.availability_status?.[0];

--- a/src/components/TabNavigation.js
+++ b/src/components/TabNavigation.js
@@ -6,16 +6,16 @@ import { Tabs, Tab, TabTitleIcon, TabTitleText } from '@patternfly/react-core';
 import RedhatIcon from '@patternfly/react-icons/dist/esm/icons/redhat-icon';
 import CloudIcon from '@patternfly/react-icons/dist/esm/icons/cloud-icon';
 
-import { setActiveVendor } from '../redux/sources/actions';
+import { setActiveCategory } from '../redux/sources/actions';
 import { CLOUD_VENDOR, REDHAT_VENDOR } from '../utilities/constants';
 
 const TabNavigation = () => {
   const intl = useIntl();
   const dispatch = useDispatch();
-  const activeVendor = useSelector(({ sources }) => sources.activeVendor);
+  const activeCategory = useSelector(({ sources }) => sources.activeCategory);
 
   return (
-    <Tabs activeKey={activeVendor} onSelect={(_e, key) => dispatch(setActiveVendor(key))} className="pf-u-mt-md">
+    <Tabs activeKey={activeCategory} onSelect={(_e, key) => dispatch(setActiveCategory(key))} className="pf-u-mt-md">
       <Tab
         eventKey={CLOUD_VENDOR}
         title={

--- a/src/components/TilesShared/TilesArray.js
+++ b/src/components/TilesShared/TilesArray.js
@@ -11,7 +11,7 @@ import { filterVendorTypes } from '../../utilities/filterTypes';
 
 const TilesArray = ({ setSelectedType, mapper }) => {
   const sourceTypes = useSelector(({ sources }) => sources.sourceTypes, shallowEqual);
-  const activeVendor = useSelector(({ sources }) => sources.activeVendor);
+  const activeCategory = useSelector(({ sources }) => sources.activeCategory);
 
   const { push } = useHistory();
   const hasWritePermissions = useHasWritePermissions();
@@ -24,7 +24,7 @@ const TilesArray = ({ setSelectedType, mapper }) => {
   const TileComponent = hasWritePermissions ? Tile : DisabledTile;
 
   return sourceTypes
-    .filter(filterVendorTypes(activeVendor))
+    .filter(filterVendorTypes(activeCategory))
     .sort((a, b) => a.product_name.localeCompare(b.product_name))
     .map(({ name }) => mapper(name, openWizard, TileComponent));
 };

--- a/src/components/addSourceWizard/FinalWizard.js
+++ b/src/components/addSourceWizard/FinalWizard.js
@@ -29,7 +29,7 @@ const FinalWizard = ({
   tryAgain,
   afterSuccess,
   sourceTypes,
-  activeVendor,
+  activeCategory,
 }) => {
   const [isDeletingSource, setIsDeleting] = useState();
   const [isAfterDeletion, setDeleted] = useState();
@@ -177,8 +177,8 @@ const FinalWizard = ({
       className="sources"
       isOpen={true}
       onClose={isFinished ? afterSubmit : afterError}
-      title={wizardTitle(activeVendor)}
-      description={wizardDescription(activeVendor)}
+      title={wizardTitle(activeCategory)}
+      description={wizardDescription(activeCategory)}
       steps={[
         {
           name: 'Finish',
@@ -209,7 +209,7 @@ FinalWizard.propTypes = {
       name: PropTypes.string.isRequired,
     })
   ),
-  activeVendor: PropTypes.string,
+  activeCategory: PropTypes.string,
 };
 
 export default FinalWizard;

--- a/src/components/addSourceWizard/SourceAddModal.js
+++ b/src/components/addSourceWizard/SourceAddModal.js
@@ -23,21 +23,21 @@ const initialValues = {
 
 const reducer = (
   state,
-  { type, sourceTypes, applicationTypes, container, disableAppSelection, intl, selectedType, initialWizardState, activeVendor }
+  { type, sourceTypes, applicationTypes, container, disableAppSelection, intl, selectedType, initialWizardState, activeCategory }
 ) => {
   switch (type) {
     case 'loaded':
       return {
         ...state,
         schema: createSchema(
-          sourceTypes.filter(filterTypes).filter(filterVendorTypes(activeVendor)),
-          applicationTypes.filter(filterApps).filter(filterVendorAppTypes(sourceTypes, activeVendor)),
+          sourceTypes.filter(filterTypes).filter(filterVendorTypes(activeCategory)),
+          applicationTypes.filter(filterApps).filter(filterVendorAppTypes(sourceTypes, activeCategory)),
           disableAppSelection,
           container,
           intl,
           selectedType,
           initialWizardState,
-          activeVendor
+          activeCategory
         ),
         isLoading: false,
         sourceTypes,
@@ -58,7 +58,7 @@ const SourceAddModal = ({
   onSubmit,
   selectedType,
   initialWizardState,
-  activeVendor,
+  activeCategory,
 }) => {
   const [{ schema, sourceTypes: stateSourceTypes, applicationTypes: stateApplicationTypes, isLoading }, dispatch] = useReducer(
     reducer,
@@ -94,7 +94,7 @@ const SourceAddModal = ({
           intl,
           selectedType,
           initialWizardState,
-          activeVendor,
+          activeCategory,
         });
       }
     });
@@ -114,8 +114,8 @@ const SourceAddModal = ({
         className="sources"
         isOpen={true}
         onClose={onCancel}
-        title={wizardTitle(activeVendor)}
-        description={wizardDescription(activeVendor)}
+        title={wizardTitle(activeCategory)}
+        description={wizardDescription(activeCategory)}
         steps={[
           {
             name: 'Loading',
@@ -171,7 +171,7 @@ SourceAddModal.propTypes = {
   isCancelling: PropTypes.bool,
   selectedType: PropTypes.string,
   initialWizardState: PropTypes.object,
-  activeVendor: PropTypes.string,
+  activeCategory: PropTypes.string,
 };
 
 SourceAddModal.defaultProps = {

--- a/src/components/addSourceWizard/SourceAddSchema.js
+++ b/src/components/addSourceWizard/SourceAddSchema.js
@@ -59,7 +59,7 @@ export const compileAllSourcesComboOptions = (sourceTypes) => [
   ...sourceTypes
     .map((type) => ({
       ...type,
-      product_name: type.vendor === 'Red Hat' ? type.product_name.replace('Red Hat ', '') : type.product_name,
+      product_name: type.category === 'Red Hat' ? type.product_name.replace('Red Hat ', '') : type.product_name,
     }))
     .sort((a, b) => a.product_name.localeCompare(b.product_name))
     .map((t) => ({
@@ -100,7 +100,7 @@ export const iconMapper = (sourceTypes) => (name) => {
     <img
       src={shortIcons[name] || sourceType.icon_url}
       alt={sourceType.product_name}
-      className={`src-c-wizard__icon ${sourceType.vendor === 'Red Hat' ? 'redhat-icon' : 'pf-u-mb-sm'}`}
+      className={`src-c-wizard__icon ${sourceType.category === 'Red Hat' ? 'redhat-icon' : 'pf-u-mb-sm'}`}
     />
   );
 
@@ -165,7 +165,7 @@ const redhatTypes = ({ intl, sourceTypes, applicationTypes, disableAppSelection 
   },
 ];
 
-export const applicationStep = (applicationTypes, intl, activeVendor) => ({
+export const applicationStep = (applicationTypes, intl, activeCategory) => ({
   name: 'application_step',
   title: intl.formatMessage({
     id: 'wizard.selectApplication',
@@ -185,7 +185,7 @@ export const applicationStep = (applicationTypes, intl, activeVendor) => ({
     {
       component: 'enhanced-radio',
       name: 'application.application_type_id',
-      options: compileAllApplicationComboOptions(applicationTypes, intl, activeVendor),
+      options: compileAllApplicationComboOptions(applicationTypes, intl, activeCategory),
       mutator: appMutatorRedHat(applicationTypes),
       menuIsPortal: true,
     },
@@ -270,13 +270,13 @@ NameDescription.propTypes = {
   sourceTypes: PropTypes.array,
 };
 
-const nameStep = (intl, selectedType, sourceTypes, activeVendor) => ({
+const nameStep = (intl, selectedType, sourceTypes, activeCategory) => ({
   title: intl.formatMessage({
     id: 'wizard.nameSource',
     defaultMessage: 'Name source',
   }),
   name: 'name_step',
-  nextStep: activeVendor === REDHAT_VENDOR ? nextStep(selectedType) : nextStepCloud(sourceTypes),
+  nextStep: activeCategory === REDHAT_VENDOR ? nextStep(selectedType) : nextStepCloud(sourceTypes),
   fields: [
     {
       component: 'description',
@@ -355,7 +355,7 @@ export default (
   intl,
   selectedType,
   initialWizardState,
-  activeVendor
+  activeCategory
 ) => {
   setFirstValidated(true);
 
@@ -365,9 +365,9 @@ export default (
         component: componentTypes.WIZARD,
         name: 'wizard',
         className: 'sources',
-        title: wizardTitle(activeVendor),
+        title: wizardTitle(activeCategory),
         inModal: true,
-        description: wizardDescription(activeVendor),
+        description: wizardDescription(activeCategory),
         buttonLabels: {
           submit: intl.formatMessage({
             id: 'sources.add',
@@ -396,14 +396,14 @@ export default (
         crossroads: ['application.application_type_id', 'source_type', 'auth_select', 'source.app_creation_workflow'],
         fields: [
           ...(!selectedType
-            ? activeVendor === REDHAT_VENDOR
+            ? activeCategory === REDHAT_VENDOR
               ? [typesStep(sourceTypes, applicationTypes, disableAppSelection, intl)]
               : [cloudTypesStep(sourceTypes, applicationTypes, intl)]
             : []),
-          nameStep(intl, selectedType, sourceTypes, activeVendor),
+          nameStep(intl, selectedType, sourceTypes, activeCategory),
           configurationStep(intl, sourceTypes),
           applicationsStep(applicationTypes, intl),
-          applicationStep(applicationTypes, intl, activeVendor),
+          applicationStep(applicationTypes, intl, activeCategory),
           ...schemaBuilder(sourceTypes, applicationTypes),
           summaryStep(sourceTypes, applicationTypes, intl),
         ],

--- a/src/components/addSourceWizard/compileAllApplicationComboOptions.js
+++ b/src/components/addSourceWizard/compileAllApplicationComboOptions.js
@@ -27,7 +27,7 @@ export const labelMapper = (type, intl) =>
     ),
   }[type.name]);
 
-export const compileAllApplicationComboOptions = (applicationTypes, intl, activeVendor) => [
+export const compileAllApplicationComboOptions = (applicationTypes, intl, activeCategory) => [
   ...applicationTypes
     .sort((a, b) => a.display_name.localeCompare(b.display_name))
     .map((t) => ({
@@ -35,7 +35,7 @@ export const compileAllApplicationComboOptions = (applicationTypes, intl, active
       label: labelMapper(t, intl) || t.display_name,
       description: descriptionMapper(t, intl),
     })),
-  ...(activeVendor !== REDHAT_VENDOR
+  ...(activeCategory !== REDHAT_VENDOR
     ? [
         {
           label: intl.formatMessage({

--- a/src/components/addSourceWizard/index.js
+++ b/src/components/addSourceWizard/index.js
@@ -16,7 +16,7 @@ import createSuperSource from '../../api/createSuperSource';
 import { doCreateSource } from '../../api/createSource';
 import CloseModal from '../CloseModal';
 
-const prepareInitialValues = (initialValues, activeVendor) => ({
+const prepareInitialValues = (initialValues, activeCategory) => ({
   isSubmitted: false,
   isFinished: false,
   isErrored: false,
@@ -24,13 +24,13 @@ const prepareInitialValues = (initialValues, activeVendor) => ({
   values: initialValues,
   createdSource: {},
   error: undefined,
-  activeVendor,
+  activeCategory,
 });
 
 const reducer = (state, { type, values, data, error, initialValues, sourceTypes, applicationTypes }) => {
   switch (type) {
     case 'reset':
-      return prepareInitialValues(initialValues);
+      return prepareInitialValues(initialValues, state.activeCategory);
     case 'prepareSubmitState':
       return {
         ...state,
@@ -67,10 +67,10 @@ const AddSourceWizard = ({
   selectedType,
   initialWizardState,
   submitCallback,
-  activeVendor: propsActiveVendor,
+  activeCategory: propsActiveCategory,
 }) => {
-  const [{ isErrored, isFinished, isSubmitted, values, error, isCancelling, createdSource, activeVendor, ...state }, dispatch] =
-    useReducer(reducer, prepareInitialValues(initialValues, propsActiveVendor));
+  const [{ isErrored, isFinished, isSubmitted, values, error, isCancelling, createdSource, activeCategory, ...state }, dispatch] =
+    useReducer(reducer, prepareInitialValues(initialValues, propsActiveCategory));
 
   const onSubmit = (formValues, sourceTypes, wizardState, applicationTypes) => {
     dispatch({ type: 'prepareSubmitState', values: formValues, sourceTypes, applicationTypes });
@@ -118,7 +118,7 @@ const AddSourceWizard = ({
           disableAppSelection={disableAppSelection}
           selectedType={selectedType}
           initialWizardState={initialWizardState}
-          activeVendor={activeVendor}
+          activeCategory={activeCategory}
         />
       </React.Fragment>
     );
@@ -139,7 +139,7 @@ const AddSourceWizard = ({
       tryAgain={() => onSubmit(values, state.sourceTypes, undefined, state.applicationTypes)}
       afterSuccess={afterSuccess}
       sourceTypes={state.sourceTypes}
-      activeVendor={activeVendor}
+      activeCategory={activeCategory}
     />
   );
 };
@@ -176,7 +176,7 @@ AddSourceWizard.propTypes = {
   selectedType: PropTypes.string,
   initialWizardState: PropTypes.object,
   submitCallback: PropTypes.func,
-  activeVendor: PropTypes.oneOf([REDHAT_VENDOR, CLOUD_VENDOR]),
+  activeCategory: PropTypes.oneOf([REDHAT_VENDOR, CLOUD_VENDOR]),
 };
 
 AddSourceWizard.defaultProps = {

--- a/src/components/addSourceWizard/stringConstants.js
+++ b/src/components/addSourceWizard/stringConstants.js
@@ -2,8 +2,8 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { CLOUD_VENDOR } from '../../utilities/constants';
 
-export const wizardDescription = (activeVendor) =>
-  activeVendor === CLOUD_VENDOR ? (
+export const wizardDescription = (activeCategory) =>
+  activeCategory === CLOUD_VENDOR ? (
     <FormattedMessage
       id="wizard.wizardDescriptionCloud"
       defaultMessage="Register your provider to manage your Red Hat products in the cloud."
@@ -14,8 +14,8 @@ export const wizardDescription = (activeVendor) =>
       defaultMessage="Configure a data source to connect to your Red Hat applications."
     />
   );
-export const wizardTitle = (activeVendor) =>
-  activeVendor === CLOUD_VENDOR ? (
+export const wizardTitle = (activeCategory) =>
+  activeCategory === CLOUD_VENDOR ? (
     <FormattedMessage id="wizard.wizardTitleCloud" defaultMessage="Add a cloud source" />
   ) : (
     <FormattedMessage id="wizard.wizardTitleRedhat" defaultMessage="Add Red Hat source" />

--- a/src/pages/Sources.js
+++ b/src/pages/Sources.js
@@ -97,7 +97,7 @@ const SourcesPage = () => {
     paginationClicked,
     appTypesLoaded,
     sourceTypesLoaded,
-    activeVendor,
+    activeCategory,
     entities,
   } = sources;
 
@@ -142,7 +142,7 @@ const SourcesPage = () => {
 
   const showPaginationLoader = (!loaded || !appTypesLoaded || !sourceTypesLoaded) && !paginationClicked;
 
-  const filteredSourceTypes = sourceTypes.filter(filterVendorTypes(activeVendor, true));
+  const filteredSourceTypes = sourceTypes.filter(filterVendorTypes(activeCategory, true));
 
   const addSourceText = intl.formatMessage({
     id: 'sources.addSource',
@@ -242,7 +242,7 @@ const SourcesPage = () => {
               filterValues: {
                 onChange: (_event, value) => setFilter('applications', value, dispatch),
                 items: prepareApplicationTypeSelection(
-                  appTypes?.filter(filterVendorAppTypes(filteredSourceTypes, activeVendor)) || []
+                  appTypes?.filter(filterVendorAppTypes(filteredSourceTypes, activeCategory)) || []
                 ),
                 value: filterValue.applications,
               },
@@ -297,7 +297,7 @@ const SourcesPage = () => {
       .filter(Boolean).length > 0;
 
   const showEmptyState = loaded && numberOfEntities === 0 && !hasSomeFilter;
-  const showInfoCards = activeVendor === CLOUD_VENDOR && !showEmptyState;
+  const showInfoCards = activeCategory === CLOUD_VENDOR && !showEmptyState;
 
   const setSelectedType = (selectedType) => stateDispatch({ type: 'setSelectedType', selectedType });
 
@@ -323,7 +323,7 @@ const SourcesPage = () => {
             submitCallback: (state) => checkSubmit(state, dispatch, history.push, intl, stateDispatch),
             initialValues: wizardInitialValues,
             initialWizardState: wizardInitialState,
-            activeVendor,
+            activeCategory,
           }}
         />
       </Suspense>
@@ -331,10 +331,10 @@ const SourcesPage = () => {
       <Section type="content">
         {showInfoCards && <CloudCards />}
         {fetchingError && <ErrorState />}
-        {!fetchingError && showEmptyState && activeVendor === CLOUD_VENDOR && (
+        {!fetchingError && showEmptyState && activeCategory === CLOUD_VENDOR && (
           <CloudEmptyState setSelectedType={setSelectedType} />
         )}
-        {!fetchingError && showEmptyState && activeVendor === REDHAT_VENDOR && (
+        {!fetchingError && showEmptyState && activeCategory === REDHAT_VENDOR && (
           <RedHatEmptyState setSelectedType={setSelectedType} />
         )}
         {!fetchingError && !showEmptyState && mainContent()}

--- a/src/redux/sources/actionTypes.js
+++ b/src/redux/sources/actionTypes.js
@@ -24,4 +24,4 @@ export const ADD_APP_TO_SOURCE = 'ADD_APP_TO_SOURCE';
 export const SET_COUNT = 'SET_COUNT';
 export const ADD_HIDDEN_SOURCE = 'ADD_HIDDEN_SOURCE';
 export const CLEAR_FILTERS = 'CLEAR_FILTERS';
-export const SET_VENDOR = 'SET_VENDOR';
+export const SET_CATEGORY = 'SET_CATEGORY';

--- a/src/redux/sources/actions.js
+++ b/src/redux/sources/actions.js
@@ -12,7 +12,7 @@ import {
   ADD_APP_TO_SOURCE,
   ADD_HIDDEN_SOURCE,
   CLEAR_FILTERS,
-  SET_VENDOR,
+  SET_CATEGORY,
 } from './actionTypes';
 import { doLoadAppTypes, doRemoveSource, doLoadEntities, doDeleteApplication, getSourcesApi } from '../../api/entities';
 import { doLoadSourceTypes } from '../../api/source_types';
@@ -26,7 +26,7 @@ export const loadEntities = (options) => (dispatch, getState) => {
     options: typeof options === 'function' ? options(getState) : options,
   });
 
-  const { pageSize, pageNumber, sortBy, sortDirection, filterValue, activeVendor } = getState().sources;
+  const { pageSize, pageNumber, sortBy, sortDirection, filterValue, activeCategory } = getState().sources;
 
   return doLoadEntities({
     pageSize,
@@ -34,7 +34,7 @@ export const loadEntities = (options) => (dispatch, getState) => {
     sortBy,
     sortDirection,
     filterValue,
-    activeVendor,
+    activeCategory,
   })
     .then(({ sources, meta }) =>
       dispatch({
@@ -218,10 +218,10 @@ export const renameSource = (id, name, errorTitle) => (dispatch, getState) => {
     );
 };
 
-export const setActiveVendor = (vendor) => (dispatch) => {
+export const setActiveCategory = (category) => (dispatch) => {
   dispatch({
-    type: SET_VENDOR,
-    payload: { vendor },
+    type: SET_CATEGORY,
+    payload: { category },
   });
 
   return dispatch(loadEntities());

--- a/src/redux/sources/reducer.js
+++ b/src/redux/sources/reducer.js
@@ -7,7 +7,7 @@ import {
   SET_COUNT,
   ADD_HIDDEN_SOURCE,
   CLEAR_FILTERS,
-  SET_VENDOR,
+  SET_CATEGORY,
 } from './actionTypes';
 import { CLOUD_VENDOR } from '../../utilities/constants';
 
@@ -23,7 +23,7 @@ export const defaultSourcesState = {
   sortBy: 'created_at',
   sortDirection: 'desc',
   removingSources: [],
-  activeVendor: CLOUD_VENDOR,
+  activeCategory: CLOUD_VENDOR,
   appTypes: [],
   sourceTypes: [],
 };
@@ -209,14 +209,14 @@ export const sourceRenamePending = (state, { payload: { id, name } }) => ({
   ),
 });
 
-const setVendor = (state, { payload: { vendor } }) => ({
+const setCategory = (state, { payload: { category } }) => ({
   ...state,
   filterValue: {
     ...state.filterValue,
     source_type_id: [],
     applications: [],
   },
-  activeVendor: vendor,
+  activeCategory: category,
 });
 
 export default {
@@ -246,5 +246,5 @@ export default {
   [SET_COUNT]: setCount,
   [ADD_HIDDEN_SOURCE]: addHiddenSource,
   [CLEAR_FILTERS]: clearFilters,
-  [SET_VENDOR]: setVendor,
+  [SET_CATEGORY]: setCategory,
 };

--- a/src/test/__mocks__/sourceTypesData.js
+++ b/src/test/__mocks__/sourceTypesData.js
@@ -78,6 +78,7 @@ export const sourceTypesData = {
       },
       updated_at: '2019-12-03T13:56:50Z',
       vendor: 'Red Hat',
+      category: 'Red Hat',
     },
     {
       created_at: '2019-03-26T14:05:45Z',
@@ -201,6 +202,7 @@ export const sourceTypesData = {
       },
       updated_at: '2019-12-16T14:47:40Z',
       vendor: 'Amazon',
+      category: 'Cloud',
     },
     {
       created_at: '2019-04-05T17:54:38Z',
@@ -284,6 +286,7 @@ export const sourceTypesData = {
       },
       updated_at: '2019-11-22T15:26:18Z',
       vendor: 'Red Hat',
+      category: 'Red Hat',
     },
     {
       created_at: '2019-07-16T13:52:12Z',
@@ -293,6 +296,7 @@ export const sourceTypesData = {
       product_name: 'VMware vSphere',
       updated_at: '2019-08-30T13:52:33Z',
       vendor: 'VMware',
+      category: 'Cloud',
     },
     {
       created_at: '2019-07-16T13:52:12Z',
@@ -302,6 +306,7 @@ export const sourceTypesData = {
       product_name: 'Red Hat Virtualization',
       updated_at: '2019-07-16T13:52:12Z',
       vendor: 'Red Hat',
+      category: 'Red Hat',
     },
     {
       created_at: '2019-07-16T13:52:12Z',
@@ -310,6 +315,7 @@ export const sourceTypesData = {
       product_name: 'Red Hat OpenStack',
       updated_at: '2019-07-16T13:52:12Z',
       vendor: 'Red Hat',
+      category: 'Red Hat',
     },
     {
       created_at: '2019-07-16T13:52:12Z',
@@ -318,6 +324,7 @@ export const sourceTypesData = {
       product_name: 'Red Hat CloudForms',
       updated_at: '2019-07-16T13:52:12Z',
       vendor: 'Red Hat',
+      category: 'Red Hat',
     },
     {
       created_at: '2019-08-19T14:53:02Z',
@@ -389,6 +396,7 @@ export const sourceTypesData = {
       },
       updated_at: '2019-12-11T12:57:43Z',
       vendor: 'Azure',
+      category: 'Cloud',
     },
     {
       created_at: '2019-11-08T14:43:11Z',
@@ -443,6 +451,7 @@ export const sourceTypesData = {
       },
       updated_at: '2019-12-12T20:01:44Z',
       vendor: 'Red Hat',
+      category: 'Red Hat',
     },
   ],
 };
@@ -504,6 +513,7 @@ export const googleType = {
   },
   updated_at: '2021-01-22T16:53:04Z',
   vendor: 'Google',
+  category: 'Cloud',
 };
 
 export const ibmType = {
@@ -513,6 +523,7 @@ export const ibmType = {
   name: 'ibm',
   product_name: 'IBM Cloud',
   vendor: 'IBM',
+  category: 'Cloud',
   schema: {
     authentication: [
       {

--- a/src/test/addSourceWizard/addSourceWizard/addSourceButton.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/addSourceButton.test.js
@@ -11,7 +11,7 @@ import { CLOUD_VENDOR } from '../../../utilities/constants';
 
 describe('AddSourceButton', () => {
   it('opens wizard and close wizard', async () => {
-    render(<AddSourceButton sourceTypes={sourceTypes} applicationTypes={applicationTypes} activeVendor={CLOUD_VENDOR} />);
+    render(<AddSourceButton sourceTypes={sourceTypes} applicationTypes={applicationTypes} activeCategory={CLOUD_VENDOR} />);
 
     await userEvent.click(screen.getByText('Add Red Hat source'));
 

--- a/src/test/addSourceWizard/addSourceWizard/addSourceSchema.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/addSourceSchema.test.js
@@ -223,8 +223,8 @@ describe('Add source schema', () => {
 
     it('red hat type selection - remove red hat', () => {
       const mockSourceTypes = [
-        { name: 'ops', product_name: 'Red Hat Openshift', vendor: 'Red Hat', id: '1' },
-        { name: 'sat', product_name: 'Red Hat Satellite', vendor: 'Red Hat', id: '2' },
+        { name: 'ops', product_name: 'Red Hat Openshift', vendor: 'Red Hat', category: 'Red Hat', id: '1' },
+        { name: 'sat', product_name: 'Red Hat Satellite', vendor: 'Red Hat', category: 'Red Hat', id: '2' },
       ];
 
       expect(compileAllSourcesComboOptions(mockSourceTypes)).toEqual([

--- a/src/test/addSourceWizard/addSourceWizard/addSourceWizzard.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/addSourceWizzard.test.js
@@ -10,7 +10,7 @@ import * as dependency from '../../../api/wizardHelpers';
 import * as createSource from '../../../api/createSource';
 
 import render from '../__mocks__/render';
-import { OPENSHIFT_NAME, CLOUD_VENDOR, REDHAT_VENDOR } from '../../../utilities/constants';
+import { CLOUD_VENDOR, REDHAT_VENDOR, GOOGLE_NAME } from '../../../utilities/constants';
 
 describe('AddSourceWizard', () => {
   let initialProps;
@@ -22,6 +22,7 @@ describe('AddSourceWizard', () => {
       sourceTypes,
       applicationTypes,
       onClose: jest.fn(),
+      activeCategory: CLOUD_VENDOR,
     };
 
     SOURCE_DATA_OUT = {
@@ -56,7 +57,7 @@ describe('AddSourceWizard', () => {
 
     await waitFor(() => expect(screen.getByText('Select source type', { selector: 'button' })).toBeInTheDocument());
 
-    await userEvent.click(screen.getByText('OpenShift Container Platform'));
+    await userEvent.click(screen.getByText('Google Cloud'));
     container.getElementsByTagName('form')[0].submit();
 
     expect(screen.getByText('Validating credentials')).toBeInTheDocument();
@@ -74,7 +75,7 @@ describe('AddSourceWizard', () => {
 
     await waitFor(() => expect(screen.getByText('Select source type', { selector: 'button' })).toBeInTheDocument());
 
-    await userEvent.click(screen.getByText('OpenShift Container Platform'));
+    await userEvent.click(screen.getByText('Google Cloud'));
     container.getElementsByTagName('form')[0].submit();
     await waitFor(() => expect(() => screen.getByText('Validating credentials')).toThrow());
 
@@ -89,7 +90,7 @@ describe('AddSourceWizard', () => {
 
     await waitFor(() => expect(screen.getByText('Select source type', { selector: 'button' })).toBeInTheDocument());
 
-    await userEvent.click(screen.getByText('OpenShift Container Platform'));
+    await userEvent.click(screen.getByText('Google Cloud'));
     container.getElementsByTagName('form')[0].submit();
 
     await waitFor(() => expect(() => screen.getByText('Validating credentials')).toThrow());
@@ -109,12 +110,12 @@ describe('AddSourceWizard', () => {
 
     await waitFor(() => expect(screen.getByText('Select source type', { selector: 'button' })).toBeInTheDocument());
 
-    await userEvent.click(screen.getByText('OpenShift Container Platform'));
+    await userEvent.click(screen.getByText('Google Cloud'));
     container.getElementsByTagName('form')[0].submit();
 
     await waitFor(() => expect(() => screen.getByText('Validating credentials')).toThrow());
     expect(submitCallback).toHaveBeenCalledWith({
-      values: { source_type: OPENSHIFT_NAME },
+      values: { source_type: GOOGLE_NAME },
       isErrored: true,
       sourceTypes,
       error: 'Error - wrong name',
@@ -131,12 +132,12 @@ describe('AddSourceWizard', () => {
 
     await waitFor(() => expect(screen.getByText('Select source type', { selector: 'button' })).toBeInTheDocument());
 
-    await userEvent.click(screen.getByText('OpenShift Container Platform'));
+    await userEvent.click(screen.getByText('Google Cloud'));
     await userEvent.click(screen.getByLabelText('Close wizard'));
 
     expect(screen.getByText('Exit source creation?')).toBeInTheDocument();
     await userEvent.click(screen.getByText('Exit'));
-    expect(onClose).toHaveBeenCalledWith({ source_type: OPENSHIFT_NAME });
+    expect(onClose).toHaveBeenCalledWith({ source_type: GOOGLE_NAME });
   });
 
   it('stay on the wizard', async () => {
@@ -146,12 +147,12 @@ describe('AddSourceWizard', () => {
 
     await waitFor(() => expect(screen.getByText('Select source type', { selector: 'button' })).toBeInTheDocument());
 
-    await userEvent.click(screen.getByText('OpenShift Container Platform'));
+    await userEvent.click(screen.getByText('Google Cloud'));
     await userEvent.click(screen.getByLabelText('Close wizard'));
     await userEvent.click(screen.getByText('Stay'));
 
     expect(onClose).not.toHaveBeenCalled();
-    expect(screen.getByText('OpenShift Container Platform').closest('.pf-m-selected')).toBeInTheDocument();
+    expect(screen.getByText('Google Cloud').closest('.pf-m-selected')).toBeInTheDocument();
   });
 
   it('show error step after failing the form', async () => {
@@ -162,7 +163,7 @@ describe('AddSourceWizard', () => {
 
     await waitFor(() => expect(screen.getByText('Select source type', { selector: 'button' })).toBeInTheDocument());
 
-    await userEvent.click(screen.getByText('OpenShift Container Platform'));
+    await userEvent.click(screen.getByText('Google Cloud'));
     container.getElementsByTagName('form')[0].submit();
 
     await waitFor(() => expect(() => screen.getByText('Validating credentials')).toThrow());
@@ -184,7 +185,7 @@ describe('AddSourceWizard', () => {
 
     await waitFor(() => expect(screen.getByText('Select source type', { selector: 'button' })).toBeInTheDocument());
 
-    await userEvent.click(screen.getByText('OpenShift Container Platform'));
+    await userEvent.click(screen.getByText('Google Cloud'));
     container.getElementsByTagName('form')[0].submit();
 
     await waitFor(() => expect(() => screen.getByText('Validating credentials')).toThrow());
@@ -205,7 +206,7 @@ describe('AddSourceWizard', () => {
 
     await waitFor(() => expect(screen.getByText('Select source type', { selector: 'button' })).toBeInTheDocument());
 
-    await userEvent.click(screen.getByText('OpenShift Container Platform'));
+    await userEvent.click(screen.getByText('Google Cloud'));
     container.getElementsByTagName('form')[0].submit();
 
     await waitFor(() => expect(() => screen.getByText('Validating credentials')).toThrow());
@@ -224,14 +225,14 @@ describe('AddSourceWizard', () => {
 
     await waitFor(() => expect(screen.getByText('Select source type', { selector: 'button' })).toBeInTheDocument());
 
-    await userEvent.click(screen.getByText('OpenShift Container Platform'));
+    await userEvent.click(screen.getByText('Google Cloud'));
     container.getElementsByTagName('form')[0].submit();
 
     await waitFor(() => expect(() => screen.getByText('Validating credentials')).toThrow());
 
     await userEvent.click(screen.getByText('Add another source'));
 
-    expect(screen.getByText('OpenShift Container Platform').closest('.pf-m-selected')).toBeNull();
+    expect(screen.getByText('Google Cloud').closest('.pf-m-selected')).toBeNull();
   });
 
   it('tryAgain retries the request', async () => {
@@ -241,7 +242,7 @@ describe('AddSourceWizard', () => {
 
     await waitFor(() => expect(screen.getByText('Select source type', { selector: 'button' })).toBeInTheDocument());
 
-    await userEvent.click(screen.getByText('OpenShift Container Platform'));
+    await userEvent.click(screen.getByText('Google Cloud'));
     container.getElementsByTagName('form')[0].submit();
 
     await waitFor(() => expect(() => screen.getByText('Validating credentials')).toThrow());
@@ -251,11 +252,7 @@ describe('AddSourceWizard', () => {
     await userEvent.click(screen.getByText('Retry'));
 
     await waitFor(() =>
-      expect(createSource.doCreateSource).toHaveBeenCalledWith(
-        { source_type: OPENSHIFT_NAME },
-        expect.any(Array),
-        applicationTypes
-      )
+      expect(createSource.doCreateSource).toHaveBeenCalledWith({ source_type: GOOGLE_NAME }, expect.any(Array), applicationTypes)
     );
   });
 
@@ -264,7 +261,7 @@ describe('AddSourceWizard', () => {
       [...container.parentElement.getElementsByClassName('pf-c-wizard__nav-item')].map((item) => item.textContent);
 
     it('show configuration step when selectedType is set - CLOUD', async () => {
-      const { container } = render(<AddSourceWizard {...initialProps} selectedType="amazon" activeVendor={CLOUD_VENDOR} />);
+      const { container } = render(<AddSourceWizard {...initialProps} selectedType="amazon" activeCategory={CLOUD_VENDOR} />);
 
       await waitFor(() => expect(screen.getByText('Name source', { selector: 'button' })).toBeInTheDocument());
 
@@ -273,7 +270,7 @@ describe('AddSourceWizard', () => {
 
     it('show source type selection when CLOUD', async () => {
       const { container } = render(
-        <AddSourceWizard {...initialProps} initialValues={{ source_type: 'amazon' }} activeVendor={CLOUD_VENDOR} />
+        <AddSourceWizard {...initialProps} initialValues={{ source_type: 'amazon' }} activeCategory={CLOUD_VENDOR} />
       );
 
       await waitFor(() => expect(screen.getByText('Name source', { selector: 'button' })).toBeInTheDocument());
@@ -287,7 +284,7 @@ describe('AddSourceWizard', () => {
           {...initialProps}
           selectedType="amazon"
           initialValues={{ source: { app_creation_workflow: 'account_authorization' } }}
-          activeVendor={CLOUD_VENDOR}
+          activeCategory={CLOUD_VENDOR}
         />
       );
 
@@ -302,7 +299,7 @@ describe('AddSourceWizard', () => {
           {...initialProps}
           selectedType="amazon"
           initialValues={{ source: { app_creation_workflow: 'manual_configuration' } }}
-          activeVendor={CLOUD_VENDOR}
+          activeCategory={CLOUD_VENDOR}
         />
       );
 
@@ -312,7 +309,7 @@ describe('AddSourceWizard', () => {
     });
 
     it('show application step when selectedType is set - RED HAT', async () => {
-      const { container } = render(<AddSourceWizard {...initialProps} selectedType="openshift" activeVendor={REDHAT_VENDOR} />);
+      const { container } = render(<AddSourceWizard {...initialProps} selectedType="openshift" activeCategory={REDHAT_VENDOR} />);
 
       await waitFor(() => expect(screen.getByText('Name source', { selector: 'button' })).toBeInTheDocument());
 
@@ -326,7 +323,7 @@ describe('AddSourceWizard', () => {
     });
 
     it('show source type selection when REDHAT', async () => {
-      const { container } = render(<AddSourceWizard {...initialProps} activeVendor={REDHAT_VENDOR} />);
+      const { container } = render(<AddSourceWizard {...initialProps} activeCategory={REDHAT_VENDOR} />);
 
       await waitFor(() => expect(screen.getByText('Name source', { selector: 'button' })).toBeInTheDocument());
 

--- a/src/test/addSourceWizard/helpers/sourceTypes.js
+++ b/src/test/addSourceWizard/helpers/sourceTypes.js
@@ -77,6 +77,7 @@ const sourceTypes = [
     },
     updated_at: '2019-09-16T14:03:35Z',
     vendor: 'Red Hat',
+    category: 'Red Hat',
   },
   {
     created_at: '2019-03-26T14:05:45Z',
@@ -181,6 +182,7 @@ const sourceTypes = [
     },
     updated_at: '2019-09-11T14:03:04Z',
     vendor: 'Amazon',
+    category: 'Cloud',
   },
   {
     created_at: '2019-04-05T17:54:38Z',
@@ -294,6 +296,7 @@ const sourceTypes = [
     },
     updated_at: '2019-09-16T14:03:35Z',
     vendor: 'Red Hat',
+    category: 'Red Hat',
   },
   {
     created_at: '2019-07-16T13:52:12Z',
@@ -303,6 +306,7 @@ const sourceTypes = [
     product_name: 'VMware vSphere',
     updated_at: '2019-08-30T13:52:33Z',
     vendor: 'VMware',
+    category: 'Cloud',
   },
   {
     created_at: '2019-07-16T13:52:12Z',
@@ -311,6 +315,7 @@ const sourceTypes = [
     product_name: 'Red Hat Virtualization',
     updated_at: '2019-07-16T13:52:12Z',
     vendor: 'Red Hat',
+    category: 'Red Hat',
   },
   {
     created_at: '2019-07-16T13:52:12Z',
@@ -319,6 +324,7 @@ const sourceTypes = [
     product_name: 'Red Hat OpenStack',
     updated_at: '2019-07-16T13:52:12Z',
     vendor: 'Red Hat',
+    category: 'Red Hat',
   },
   {
     created_at: '2019-07-16T13:52:12Z',
@@ -327,6 +333,7 @@ const sourceTypes = [
     product_name: 'Red Hat CloudForms',
     updated_at: '2019-07-16T13:52:12Z',
     vendor: 'Red Hat',
+    category: 'Red Hat',
   },
   {
     created_at: '2019-08-19T14:53:02Z',
@@ -379,6 +386,7 @@ const sourceTypes = [
     },
     updated_at: '2019-09-11T14:03:04Z',
     vendor: 'Azure',
+    category: 'Cloud',
   },
   {
     created_at: '2019-08-19T14:53:02Z',
@@ -438,6 +446,7 @@ const sourceTypes = [
     },
     updated_at: '2019-09-11T14:03:04Z',
     vendor: 'Google',
+    category: 'Cloud',
     icon_url: '/apps/frontend-assets/partners-icons/google-cloud.svg',
   },
 ];

--- a/src/test/api/helpers.test.js
+++ b/src/test/api/helpers.test.js
@@ -70,19 +70,19 @@ describe('api helpers', () => {
 
     it('creates cloud vendor [GRAPHQL]', () => {
       const filterValue = {};
-      const activeVendor = CLOUD_VENDOR;
+      const activeCategory = CLOUD_VENDOR;
 
-      expect(filtering(filterValue, activeVendor)).toEqual(
-        'filter: [ { name: "source_type.vendor", operation: "not_eq", value: "Red Hat" } ]'
+      expect(filtering(filterValue, activeCategory)).toEqual(
+        'filter: [ { name: "source_type.category", operation: "eq", value: "Cloud" } ]'
       );
     });
 
     it('creates red hat vendor [GRAPHQL]', () => {
       const filterValue = {};
-      const activeVendor = REDHAT_VENDOR;
+      const activeCategory = REDHAT_VENDOR;
 
-      expect(filtering(filterValue, activeVendor)).toEqual(
-        'filter: [ { name: "source_type.vendor", operation: "eq", value: "Red Hat" } ]'
+      expect(filtering(filterValue, activeCategory)).toEqual(
+        'filter: [ { name: "source_type.category", operation: "eq", value: "Red Hat" } ]'
       );
     });
 
@@ -140,16 +140,16 @@ describe('api helpers', () => {
 
     it('creates cloud vendor [REST]', () => {
       const filterValue = {};
-      const activeVendor = CLOUD_VENDOR;
+      const activeCategory = CLOUD_VENDOR;
 
-      expect(restFilterGenerator(filterValue, activeVendor)).toEqual('filter[source_type][vendor][not_eq]=Red Hat');
+      expect(restFilterGenerator(filterValue, activeCategory)).toEqual('filter[source_type][category]=Cloud');
     });
 
     it('creates red hat vendor [REST]', () => {
       const filterValue = {};
-      const activeVendor = REDHAT_VENDOR;
+      const activeCategory = REDHAT_VENDOR;
 
-      expect(restFilterGenerator(filterValue, activeVendor)).toEqual('filter[source_type][vendor]=Red Hat');
+      expect(restFilterGenerator(filterValue, activeCategory)).toEqual('filter[source_type][category]=Red Hat');
     });
 
     it('creates available filter [REST]', () => {

--- a/src/test/components/TabNavigation.test.js
+++ b/src/test/components/TabNavigation.test.js
@@ -12,10 +12,10 @@ import mockStore from '../__mocks__/mockStore';
 describe('TabNavigation', () => {
   let store;
 
-  it('renders correctly on Cloud vendor', () => {
+  it('renders correctly on Cloud Category', () => {
     store = mockStore({
       sources: {
-        activeVendor: CLOUD_VENDOR,
+        activeCategory: CLOUD_VENDOR,
       },
     });
 
@@ -28,10 +28,10 @@ describe('TabNavigation', () => {
     expect(screen.getByText('Red Hat sources')).toBeInTheDocument();
   });
 
-  it('renders correctly on Red Hat vendor', () => {
+  it('renders correctly on Red Hat Category', () => {
     store = mockStore({
       sources: {
-        activeVendor: REDHAT_VENDOR,
+        activeCategory: REDHAT_VENDOR,
       },
     });
 
@@ -45,20 +45,20 @@ describe('TabNavigation', () => {
   });
 
   it('triggers redux changed', async () => {
-    actions.setActiveVendor = jest.fn().mockImplementation(() => ({ type: 'something' }));
+    actions.setActiveCategory = jest.fn().mockImplementation(() => ({ type: 'something' }));
 
     render(componentWrapperIntl(<TabNavigation />, store));
 
-    expect(actions.setActiveVendor).not.toHaveBeenCalled();
+    expect(actions.setActiveCategory).not.toHaveBeenCalled();
 
     await userEvent.click(screen.getByText('Cloud sources'));
 
-    expect(actions.setActiveVendor).toHaveBeenCalledWith(CLOUD_VENDOR);
+    expect(actions.setActiveCategory).toHaveBeenCalledWith(CLOUD_VENDOR);
 
-    actions.setActiveVendor.mockClear();
+    actions.setActiveCategory.mockClear();
 
     await userEvent.click(screen.getByText('Red Hat sources'));
 
-    expect(actions.setActiveVendor).toHaveBeenCalledWith(REDHAT_VENDOR);
+    expect(actions.setActiveCategory).toHaveBeenCalledWith(REDHAT_VENDOR);
   });
 });

--- a/src/test/components/cloudTiles/CloudEmptyState.test.js
+++ b/src/test/components/cloudTiles/CloudEmptyState.test.js
@@ -21,7 +21,7 @@ describe('CloudEmptyState', () => {
 
     store = mockStore({
       user: { writePermissions: true },
-      sources: { sourceTypes: [...sourceTypes.data, googleType, ibmType], activeVendor: CLOUD_VENDOR },
+      sources: { sourceTypes: [...sourceTypes.data, googleType, ibmType], activeCategory: CLOUD_VENDOR },
     });
   });
 

--- a/src/test/components/cloudTiles/CloudTiles.test.js
+++ b/src/test/components/cloudTiles/CloudTiles.test.js
@@ -24,7 +24,7 @@ describe('CloudTiles', () => {
 
     store = mockStore({
       user: { writePermissions: true },
-      sources: { sourceTypes: [...sourceTypes.data, googleType, ibmType], activeVendor: CLOUD_VENDOR },
+      sources: { sourceTypes: [...sourceTypes.data, googleType, ibmType], activeCategory: CLOUD_VENDOR },
     });
   });
 
@@ -43,7 +43,7 @@ describe('CloudTiles', () => {
   it('renders correctly when no permissions', async () => {
     store = mockStore({
       user: { writePermissions: false },
-      sources: { sourceTypes: [...sourceTypes.data, googleType, ibmType], activeVendor: CLOUD_VENDOR },
+      sources: { sourceTypes: [...sourceTypes.data, googleType, ibmType], activeCategory: CLOUD_VENDOR },
     });
 
     const { container } = render(componentWrapperIntl(<CloudTiles {...initialProps} />, store));

--- a/src/test/components/redhatTiles/RedHatEmptyState.test.js
+++ b/src/test/components/redhatTiles/RedHatEmptyState.test.js
@@ -21,8 +21,7 @@ describe('RedhatEmptyState', () => {
 
     store = mockStore({
       user: { writePermissions: true },
-      sources: { sourceTypes: sourceTypes.data },
-      activeVendor: REDHAT_VENDOR,
+      sources: { sourceTypes: sourceTypes.data, activeCategory: REDHAT_VENDOR },
     });
   });
 

--- a/src/test/components/redhatTiles/RedHatTiles.test.js
+++ b/src/test/components/redhatTiles/RedHatTiles.test.js
@@ -23,7 +23,7 @@ describe('RedhatTiles', () => {
 
     store = mockStore({
       user: { writePermissions: true },
-      sources: { sourceTypes: sourceTypes.data, activeVendor: REDHAT_VENDOR },
+      sources: { sourceTypes: sourceTypes.data, activeCategory: REDHAT_VENDOR },
     });
   });
 
@@ -35,7 +35,10 @@ describe('RedhatTiles', () => {
   });
 
   it('renders correctly when no permissions', async () => {
-    store = mockStore({ user: { writePermissions: false }, sources: { sourceTypes: sourceTypes.data } });
+    store = mockStore({
+      user: { writePermissions: false },
+      sources: { sourceTypes: sourceTypes.data, activeCategory: REDHAT_VENDOR },
+    });
 
     render(componentWrapperIntl(<RedHatTiles {...initialProps} />, store));
 

--- a/src/test/pages/Sources.test.js
+++ b/src/test/pages/Sources.test.js
@@ -138,7 +138,7 @@ describe('SourcesPage', () => {
 
   it('do not show CloudCards on Red Hat page', async () => {
     store = getStore([], {
-      sources: { activeVendor: REDHAT_VENDOR },
+      sources: { activeCategory: REDHAT_VENDOR },
       user: { writePermissions: true },
     });
 
@@ -150,7 +150,7 @@ describe('SourcesPage', () => {
 
   it('renders empty state when there are no Sources - CLOUD', async () => {
     store = getStore([], {
-      sources: { activeVendor: CLOUD_VENDOR },
+      sources: { activeCategory: CLOUD_VENDOR },
       user: { writePermissions: true },
     });
 
@@ -174,10 +174,10 @@ describe('SourcesPage', () => {
     delete window.location;
     window.location = {};
     window.location.pathname = routes.sources.path;
-    window.location.search = `?activeVendor=${CLOUD_VENDOR}`;
+    window.location.search = `?category=${CLOUD_VENDOR}`;
 
     store = getStore([], {
-      sources: { activeVendor: CLOUD_VENDOR },
+      sources: { activeCategory: CLOUD_VENDOR },
       user: { writePermissions: true },
     });
 
@@ -197,7 +197,7 @@ describe('SourcesPage', () => {
 
   it('renders empty state when there are no Sources - RED HAT', async () => {
     store = getStore([], {
-      sources: { activeVendor: REDHAT_VENDOR },
+      sources: { activeCategory: REDHAT_VENDOR },
       user: { writePermissions: true },
     });
 
@@ -216,7 +216,7 @@ describe('SourcesPage', () => {
 
   it('renders empty state when there are no Sources and open openshift selection', async () => {
     store = getStore([], {
-      sources: { activeVendor: REDHAT_VENDOR },
+      sources: { activeCategory: REDHAT_VENDOR },
       user: { writePermissions: true },
     });
 
@@ -306,14 +306,14 @@ describe('SourcesPage', () => {
     });
 
     it('shows only Red Hat sources in the selection (do not filter hidden types)', async () => {
-      window.location.search = `?activeVendor=${REDHAT_VENDOR}`;
+      window.location.search = `?category=${REDHAT_VENDOR}`;
 
       store = getStore([], {
         sources: {
           loaded: 1,
           numberOfEntities: 5,
           sourceTypes: sourceTypesData.data,
-          activeVendor: REDHAT_VENDOR,
+          activeCategory: REDHAT_VENDOR,
         },
         user: { writePermissions: true },
       });
@@ -336,14 +336,14 @@ describe('SourcesPage', () => {
     });
 
     it('shows only Cloud sources in the selection', async () => {
-      window.location.search = `?activeVendor=${CLOUD_VENDOR}`;
+      window.location.search = `?category=${CLOUD_VENDOR}`;
 
       store = getStore([], {
         sources: {
           loaded: 1,
           numberOfEntities: 5,
           sourceTypes: sourceTypesData.data,
-          activeVendor: CLOUD_VENDOR,
+          activeCategory: CLOUD_VENDOR,
         },
         user: { writePermissions: true },
       });
@@ -370,7 +370,7 @@ describe('SourcesPage', () => {
           loaded: 1,
           numberOfEntities: 5,
           sourceTypes: sourceTypesData.data,
-          activeVendor: CLOUD_VENDOR,
+          activeCategory: CLOUD_VENDOR,
         },
         user: { writePermissions: true },
       });
@@ -815,7 +815,7 @@ describe('SourcesPage', () => {
 
     it('show empty state table after clicking on clears all filter in empty table state - RED HAT', async () => {
       store = getStore([], {
-        sources: { activeVendor: REDHAT_VENDOR },
+        sources: { activeCategory: REDHAT_VENDOR },
         user: { writePermissions: true },
       });
 

--- a/src/test/redux/sources/actions.test.js
+++ b/src/test/redux/sources/actions.test.js
@@ -15,7 +15,7 @@ import {
   removeApplication,
   loadSourceTypes,
   renameSource,
-  setActiveVendor,
+  setActiveCategory,
   pauseSource,
   resumeSource,
 } from '../../../redux/sources/actions';
@@ -26,7 +26,7 @@ import {
   SORT_ENTITIES,
   FILTER_SOURCES,
   CLEAR_FILTERS,
-  SET_VENDOR,
+  SET_CATEGORY,
 } from '../../../redux/sources/actionTypes';
 import { ADD_NOTIFICATION, REMOVE_NOTIFICATION } from '@redhat-cloud-services/frontend-components-notifications';
 import * as api from '../../../api/entities';
@@ -377,11 +377,11 @@ describe('redux actions', () => {
     });
   });
 
-  it('setActiveVendor creates an object', async () => {
-    await setActiveVendor(CLOUD_VENDOR)(dispatch);
+  it('setActiveCategory creates an object', async () => {
+    await setActiveCategory(CLOUD_VENDOR)(dispatch);
 
     expect(dispatch.mock.calls).toHaveLength(2);
-    expect(dispatch.mock.calls[0][0]).toEqual({ type: SET_VENDOR, payload: { vendor: CLOUD_VENDOR } });
+    expect(dispatch.mock.calls[0][0]).toEqual({ type: SET_CATEGORY, payload: { category: CLOUD_VENDOR } });
     expect(dispatch.mock.calls[1][0]).toEqual(expect.any(Function));
   });
 

--- a/src/test/utilities/filterApps.spec.js
+++ b/src/test/utilities/filterApps.spec.js
@@ -13,10 +13,10 @@ describe('filterApps', () => {
 
   describe('vendor filter', () => {
     const sourceTypesVendors = [
-      { id: '1', name: 'azure', vendor: 'Microsoft' },
-      { id: '2', name: 'aws', vendor: 'amazon' },
-      { id: '3', name: 'openshift', vendor: 'Red Hat' },
-      { id: '4', name: 'vmware', vendor: 'vmware' },
+      { id: '1', name: 'azure', vendor: 'Microsoft', category: 'Cloud' },
+      { id: '2', name: 'aws', vendor: 'amazon', category: 'Cloud' },
+      { id: '3', name: 'openshift', vendor: 'Red Hat', category: 'Red Hat' },
+      { id: '4', name: 'vmware', vendor: 'vmware', category: 'Cloud' },
     ];
 
     const appTypes = [
@@ -36,9 +36,9 @@ describe('filterApps', () => {
 
     it('filters CLOUD source types when only cloud source types - when type is not, filter the app', () => {
       const onlyCloudTypes = [
-        { id: '1', name: 'azure', vendor: 'Microsoft' },
-        { id: '2', name: 'aws', vendor: 'amazon' },
-        { id: '4', name: 'vmware', vendor: 'vmware' },
+        { id: '1', name: 'azure', vendor: 'Microsoft', category: 'Cloud' },
+        { id: '2', name: 'aws', vendor: 'amazon', category: 'Cloud' },
+        { id: '4', name: 'vmware', vendor: 'vmware', category: 'Cloud' },
       ];
 
       expect(appTypes.filter(filterVendorAppTypes(onlyCloudTypes, CLOUD_VENDOR))).toEqual([

--- a/src/test/utilities/filterTypes.spec.js
+++ b/src/test/utilities/filterTypes.spec.js
@@ -17,33 +17,33 @@ describe('filterTypes', () => {
 
   describe('vendor filter', () => {
     const sourceTypesVendors = [
-      { id: '1', name: 'azure', vendor: 'Microsoft' },
-      { id: '2', name: 'aws', vendor: 'amazon' },
-      { id: '3', name: 'openshift', vendor: 'Red Hat' },
-      { id: '4', name: 'vmware', vendor: 'vmware' },
-      { id: '5', name: 'ansible-tower', vendor: 'Red Hat' },
-      { id: '6', name: 'satellite', vendor: 'Red Hat' },
+      { id: '1', name: 'azure', vendor: 'Microsoft', category: 'Cloud' },
+      { id: '2', name: 'aws', vendor: 'amazon', category: 'Cloud' },
+      { id: '3', name: 'openshift', vendor: 'Red Hat', category: 'Red Hat' },
+      { id: '4', name: 'vmware', vendor: 'vmware', category: 'Cloud' },
+      { id: '5', name: 'ansible-tower', vendor: 'Red Hat', category: 'Red Hat' },
+      { id: '6', name: 'satellite', vendor: 'Red Hat', category: 'Red Hat' },
     ];
 
     it('filters CLOUD source types', () => {
       expect(sourceTypesVendors.filter(filterVendorTypes(CLOUD_VENDOR))).toEqual([
-        { id: '1', name: 'azure', vendor: 'Microsoft' },
-        { id: '2', name: 'aws', vendor: 'amazon' },
-        { id: '4', name: 'vmware', vendor: 'vmware' },
+        { id: '1', name: 'azure', vendor: 'Microsoft', category: 'Cloud' },
+        { id: '2', name: 'aws', vendor: 'amazon', category: 'Cloud' },
+        { id: '4', name: 'vmware', vendor: 'vmware', category: 'Cloud' },
       ]);
     });
 
     it('filters RED HAT source types', () => {
       expect(sourceTypesVendors.filter(filterVendorTypes(REDHAT_VENDOR))).toEqual([
-        { id: '3', name: 'openshift', vendor: 'Red Hat' },
+        { id: '3', name: 'openshift', vendor: 'Red Hat', category: 'Red Hat' },
       ]);
     });
 
     it('filters RED HAT source types and show hidden', () => {
       expect(sourceTypesVendors.filter(filterVendorTypes(REDHAT_VENDOR, true))).toEqual([
-        { id: '3', name: 'openshift', vendor: 'Red Hat' },
-        { id: '5', name: 'ansible-tower', vendor: 'Red Hat' },
-        { id: '6', name: 'satellite', vendor: 'Red Hat' },
+        { id: '3', name: 'openshift', vendor: 'Red Hat', category: 'Red Hat' },
+        { id: '5', name: 'ansible-tower', vendor: 'Red Hat', category: 'Red Hat' },
+        { id: '6', name: 'satellite', vendor: 'Red Hat', category: 'Red Hat' },
       ]);
     });
   });

--- a/src/test/utilities/urlQuery.test.js
+++ b/src/test/utilities/urlQuery.test.js
@@ -51,7 +51,7 @@ describe('urlQuery helpers', () => {
       };
 
       expectedQuery =
-        'sources?sort_by[]=name:asc&limit=50&offset=550&activeVendor=Cloud&filter[name][contains_i]=pepa&filter[source_type_id][]=125&filter[source_type_id][]=542&filter[source_type_id][]=1';
+        'sources?sort_by[]=name:asc&limit=50&offset=550&category=Cloud&filter[name][contains_i]=pepa&filter[source_type_id][]=125&filter[source_type_id][]=542&filter[source_type_id][]=1';
     });
 
     afterEach(() => {
@@ -78,7 +78,7 @@ describe('urlQuery helpers', () => {
         filterValue: {},
       };
 
-      expectedQuery = 'sources?sort_by[]=name:asc&limit=50&offset=550&activeVendor=Cloud';
+      expectedQuery = 'sources?sort_by[]=name:asc&limit=50&offset=550&category=Cloud';
 
       updateQuery(params);
 
@@ -335,22 +335,22 @@ describe('urlQuery helpers', () => {
 
     describe('active vendor', () => {
       it('red hat vendor', () => {
-        window.location.search = `?activeVendor=${REDHAT_VENDOR}`;
+        window.location.search = `?category=${REDHAT_VENDOR}`;
 
         const result = parseQuery();
 
         expect(result).toEqual({
-          activeVendor: REDHAT_VENDOR,
+          activeCategory: REDHAT_VENDOR,
         });
       });
 
       it('cloud vendors', () => {
-        window.location.search = `?activeVendor=${CLOUD_VENDOR}`;
+        window.location.search = `?category=${CLOUD_VENDOR}`;
 
         const result = parseQuery();
 
         expect(result).toEqual({
-          activeVendor: CLOUD_VENDOR,
+          activeCategory: CLOUD_VENDOR,
         });
       });
     });

--- a/src/test/utilities/urlQuery.test.js
+++ b/src/test/utilities/urlQuery.test.js
@@ -333,8 +333,8 @@ describe('urlQuery helpers', () => {
       });
     });
 
-    describe('active vendor', () => {
-      it('red hat vendor', () => {
+    describe('active category', () => {
+      it('red hat category', () => {
         window.location.search = `?category=${REDHAT_VENDOR}`;
 
         const result = parseQuery();
@@ -344,13 +344,35 @@ describe('urlQuery helpers', () => {
         });
       });
 
-      it('cloud vendors', () => {
+      it('cloud category', () => {
         window.location.search = `?category=${CLOUD_VENDOR}`;
 
         const result = parseQuery();
 
         expect(result).toEqual({
           activeCategory: CLOUD_VENDOR,
+        });
+      });
+
+      describe('activeVendor [DEPRECATED]', () => {
+        it('red hat category', () => {
+          window.location.search = `?activeVendor=${REDHAT_VENDOR}`;
+
+          const result = parseQuery();
+
+          expect(result).toEqual({
+            activeCategory: REDHAT_VENDOR,
+          });
+        });
+
+        it('cloud category', () => {
+          window.location.search = `?activeVendor=${CLOUD_VENDOR}`;
+
+          const result = parseQuery();
+
+          expect(result).toEqual({
+            activeCategory: CLOUD_VENDOR,
+          });
         });
       });
     });

--- a/src/utilities/constants.js
+++ b/src/utilities/constants.js
@@ -10,7 +10,7 @@ export const CLOUD_METER_APP_NAME = '/insights/platform/cloud-meter';
 export const CATALOG_APP = '/insights/platform/catalog';
 export const OPENSHIFT_NAME = 'openshift';
 
-export const getActiveVendor = () => new URLSearchParams(window.location.search).get('activeVendor');
+export const getActiveCategory = () => new URLSearchParams(window.location.search).get('activeCategory');
 
 export const timeoutedApps = (appTypes) => [
   appTypes.find(({ name }) => name === CLOUD_METER_APP_NAME)?.id,

--- a/src/utilities/filterApps.js
+++ b/src/utilities/filterApps.js
@@ -1,14 +1,10 @@
-import { CLOUD_VENDOR, REDHAT_VENDOR, TOPOLOGY_INV_NAME } from './constants';
+import { TOPOLOGY_INV_NAME } from './constants';
 
 const filterApps = (type) => type.name !== TOPOLOGY_INV_NAME;
 
 export const filterVendorAppTypes =
-  (sourceTypes, activeVendor) =>
+  (sourceTypes, category) =>
   ({ supported_source_types }) =>
-    supported_source_types.find((type) =>
-      activeVendor === CLOUD_VENDOR
-        ? (sourceTypes.find(({ name }) => type === name)?.vendor || REDHAT_VENDOR) !== REDHAT_VENDOR
-        : sourceTypes.find(({ name }) => type === name)?.vendor === REDHAT_VENDOR
-    );
+    supported_source_types.find((type) => sourceTypes.find(({ name }) => type === name)?.category === category);
 
 export default filterApps;

--- a/src/utilities/filterTypes.js
+++ b/src/utilities/filterTypes.js
@@ -1,20 +1,16 @@
-import { ANSIBLE_TOWER_NAME, CLOUD_VENDOR, REDHAT_VENDOR, SATELLITE_NAME } from './constants';
+import { ANSIBLE_TOWER_NAME, SATELLITE_NAME } from './constants';
 
 const filterTypes = (type) => type.schema;
 
 const hiddenTypes = [SATELLITE_NAME, ANSIBLE_TOWER_NAME];
 
 export const filterVendorTypes =
-  (activeVendor, showHidden) =>
-  ({ vendor, name }) => {
-    if (activeVendor === CLOUD_VENDOR) {
-      return vendor !== REDHAT_VENDOR;
+  (activeCategory, showHidden) =>
+  ({ category, name }) => {
+    if (showHidden) {
+      return category === activeCategory;
     } else {
-      if (showHidden) {
-        return vendor === REDHAT_VENDOR;
-      } else {
-        return vendor === REDHAT_VENDOR && !hiddenTypes.includes(name);
-      }
+      return category === activeCategory && !hiddenTypes.includes(name);
     }
   };
 

--- a/src/utilities/urlQuery.js
+++ b/src/utilities/urlQuery.js
@@ -148,7 +148,7 @@ export const parseQuery = (getState) => {
     };
   }
 
-  const activeCategory = urlParams.get('category');
+  const activeCategory = urlParams.get('category') || urlParams.get('activeVendor');
 
   if (activeCategory === CLOUD_VENDOR || activeCategory === REDHAT_VENDOR) {
     fetchOptions = {

--- a/src/utilities/urlQuery.js
+++ b/src/utilities/urlQuery.js
@@ -3,10 +3,10 @@ import { AVAILABLE, UNAVAILABLE } from '../views/formatters';
 import { sourcesColumns } from '../views/sourcesViewDefinition';
 import { CLOUD_VENDOR, REDHAT_VENDOR } from './constants';
 
-export const updateQuery = ({ sortBy, sortDirection, pageNumber, pageSize, filterValue, activeVendor }) => {
+export const updateQuery = ({ sortBy, sortDirection, pageNumber, pageSize, filterValue, activeCategory }) => {
   const sortQuery = `sort_by[]=${sortBy}:${sortDirection}`;
 
-  const paginationQuery = `limit=${pageSize}&offset=${(pageNumber - 1) * pageSize}&activeVendor=${activeVendor || CLOUD_VENDOR}`;
+  const paginationQuery = `limit=${pageSize}&offset=${(pageNumber - 1) * pageSize}&category=${activeCategory || CLOUD_VENDOR}`;
 
   const filterQuery = restFilterGenerator(filterValue);
 
@@ -148,12 +148,12 @@ export const parseQuery = (getState) => {
     };
   }
 
-  const activeVendor = urlParams.get('activeVendor');
+  const activeCategory = urlParams.get('category');
 
-  if (activeVendor === CLOUD_VENDOR || activeVendor === REDHAT_VENDOR) {
+  if (activeCategory === CLOUD_VENDOR || activeCategory === REDHAT_VENDOR) {
     fetchOptions = {
       ...fetchOptions,
-      activeVendor,
+      activeCategory,
     };
   }
 


### PR DESCRIPTION
### category

Two options: `Cloud` | `Red Hat`

`Cloud` shows table for cloud providers (Amazon, Google, Azure, ...).

`Red Hat` shows all Red Hat types (Openshift, Satellite, ...).

```
category=Red%20Hat
```

### activeVendor [DEPRECATED]

See [Category](#activevendor-deprecated) above. This option is **deprecated** and it stays to keep backwards compatibility.

```
activeVendor=Red%20Hat
```