### PR TITLE
Update S3 Bucket validator according to AWS documentation

### DIFF
--- a/src/components/addSourceWizard/hardcodedSchemas.js
+++ b/src/components/addSourceWizard/hardcodedSchemas.js
@@ -625,11 +625,12 @@ const hardcodedSchemas = {
               },
               {
                 type: validatorTypes.PATTERN,
-                pattern: /^[A-Za-z0-9]+[A-Za-z0-9_-]*$/,
+                pattern:
+                  /(?!(^((2(5[0-5]|[0-4][0-9])|[01]?[0-9]{1,2})\.){3}(2(5[0-5]|[0-4][0-9])|[01]?[0-9]{1,2})$|^xn--|-s3alias$))^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$/,
                 message: (
                   <FormattedMessage
                     id="cost.arn.s3BucketPattern"
-                    defaultMessage="S3 bucket name must start with alphanumeric character and can contain underscore and hyphen"
+                    defaultMessage="S3 bucket name must start with alphanumeric character and can contain lowercase letters, numbers, dots, and hyphens"
                   />
                 ),
               },


### PR DESCRIPTION
According to https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html

**After**
<img width="852" alt="Screenshot 2022-05-18 at 18 26 34" src="https://user-images.githubusercontent.com/32869456/169094176-d60b38c0-1e80-4a00-a533-fe14be7c8cd4.png">
<img width="867" alt="Screenshot 2022-05-18 at 18 26 20" src="https://user-images.githubusercontent.com/32869456/169094182-e8653ca3-e362-428c-85d2-1b9c87b58978.png">

