### PR TITLE
Do not append source_id to created authentication

### DIFF
--- a/src/api/doAttachApp.js
+++ b/src/api/doAttachApp.js
@@ -114,6 +114,8 @@ export const doAttachApp = async (values, formApi, authenticationInitialValues, 
     // eslint-disable-next-line no-unused-vars
     const [_sourceDataOut, endpointDataOut, applicationDataOut] = await Promise.all(promises);
 
+    appId = applicationDataOut?.id;
+
     let authenticationDataOut;
 
     if (
@@ -128,14 +130,11 @@ export const doAttachApp = async (values, formApi, authenticationInitialValues, 
           ...filteredValues.authentication,
           resource_id: endpointDataOut?.id || applicationDataOut?.id,
           resource_type: endpointDataOut?.id ? 'Endpoint' : 'Application',
-          source_id: sourceId,
         };
 
         authenticationDataOut = await getSourcesApi().createAuthentication(authenticationData);
       }
     }
-
-    appId = applicationDataOut?.id;
 
     const authenticationId = selectedAuthId || authenticationDataOut?.id;
 

--- a/src/test/api/doAttachApp.test.js
+++ b/src/test/api/doAttachApp.test.js
@@ -561,7 +561,6 @@ describe('doAttachApp', () => {
       ...VALUES.authentication,
       resource_id: undefined, // no endpoint values
       resource_type: 'Application',
-      source_id: SOURCE_ID,
     });
     expect(endpointCreate).not.toHaveBeenCalled();
     expect(appCreate).not.toHaveBeenCalled();
@@ -644,7 +643,6 @@ describe('doAttachApp', () => {
       ...VALUES.authentication,
       resource_id: RETURNED_ENDPOINT.id,
       resource_type: 'Endpoint',
-      source_id: SOURCE_ID,
     });
     expect(endpointCreate).toHaveBeenCalledWith({
       port: 8989,
@@ -676,7 +674,6 @@ describe('doAttachApp', () => {
       ...VALUES.authentication,
       resource_id: undefined, // empty endpoint values
       resource_type: 'Application',
-      source_id: SOURCE_ID,
     });
     expect(endpointCreate).not.toHaveBeenCalled();
     expect(appCreate).not.toHaveBeenCalled();
@@ -704,7 +701,6 @@ describe('doAttachApp', () => {
       ...VALUES.authentication,
       resource_id: RETURNED_APP.id,
       resource_type: 'Application',
-      source_id: SOURCE_ID,
     });
     expect(endpointCreate).not.toHaveBeenCalled();
     expect(appCreate).toHaveBeenCalledWith({ source_id: SOURCE_ID, application_type_id: APP_ID });


### PR DESCRIPTION
Due to changed API endpoint, we have to remove `source_id` from the newly created authentication object.

+ appId moved right after application creation, so it can be removed later if the authentication request fails

