### PR TITLE
Only expose api version 3.1 in deploy template

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -13,9 +13,6 @@ objects:
       deploymentRepo: https://github.com/RedHatInsights/sources-ui
       API:
         versions:
-          - v1.0
-          - v2.0
-          - v3.0
           - v3.1
       frontend:
         paths:


### PR DESCRIPTION
Since the operator takes the first version listed, we can move 3.1 to the top and remove the others.