### PR TITLE
RHCLOUD-22885: Cost export scopes can contain colon characters

### DIFF
--- a/src/components/addSourceWizard/hardcodedSchemas.js
+++ b/src/components/addSourceWizard/hardcodedSchemas.js
@@ -641,7 +641,7 @@ const hardcodedSchemas = {
             validate: [
               {
                 type: validatorTypes.PATTERN,
-                pattern: /^[\/A-Za-z0-9]+[\.\/A-Za-z0-9_-]*$/, // eslint-disable-line no-useless-escape
+                pattern: /^[\/A-Za-z0-9]+[\.\/\:A-Za-z0-9_-]*$/, // eslint-disable-line no-useless-escape
                 message: (
                   <FormattedMessage
                     id="cost.scopePattern"


### PR DESCRIPTION
* Update validation pattern to allow for colon characters

This was found while testing in stage with an Azure billing profile obtained from an internal billing account.

Related to: https://issues.redhat.com/browse/RHCLOUD-22885