### PR TITLE
Update HCCM docs prefix with "/2023"

### DIFF
--- a/src/components/addSourceWizard/stringConstants.js
+++ b/src/components/addSourceWizard/stringConstants.js
@@ -20,6 +20,6 @@ export const wizardTitle = (activeCategory) =>
   ) : (
     <FormattedMessage id="wizard.wizardTitleRedhat" defaultMessage="Add Red Hat source" />
   );
-export const HCCM_DOCS_PREFIX = 'https://access.redhat.com/documentation/en-us/cost_management_service/';
+export const HCCM_DOCS_PREFIX = 'https://access.redhat.com/documentation/en-us/cost_management_service/2023';
 
 export const NO_APPLICATION_VALUE = 'no-application';


### PR DESCRIPTION
Update HCCM docs prefix with "/2023" to reflect URL changes on the docs side.