### PR TITLE
Add temporary docs links to additional CUR steps

### DIFF
--- a/src/components/FormComponents/SourceWizardSummary.js
+++ b/src/components/FormComponents/SourceWizardSummary.js
@@ -1,16 +1,18 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
+import { shallowEqual, useSelector } from 'react-redux';
 import get from 'lodash/get';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
 import { FormattedMessage, useIntl } from 'react-intl';
 import {
   Alert,
-  AlertActionLink,
   DescriptionList,
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
   Label,
+  Text,
+  TextVariants,
 } from '@patternfly/react-core';
 import { useFlag } from '@unleash/proxy-client-react';
 
@@ -25,15 +27,12 @@ import {
   injectEndpointFieldsInfo,
   shouldSkipEndpoint,
 } from '../../components/addSourceWizard/schemaBuilder';
-import { shallowEqual } from 'react-intl/src/utils';
-import { useSelector } from 'react-redux';
-
-const CUSTOMIZING_CUR_LINK = undefined; // specify when docs link is available
+import { MANUAL_CUR_ADDITIONAL_STEPS } from '../addSourceWizard/hardcodedComponents/aws/arn';
 
 const SummaryAlert = ({ appName, sourceType, hcsEnrolled }) => {
   const intl = useIntl();
 
-  if (appName === COST_MANAGEMENT_APP_NAME && !hcsEnrolled) {
+  if (appName === COST_MANAGEMENT_APP_NAME) {
     return (
       <Fragment>
         <Alert
@@ -44,27 +43,30 @@ const SummaryAlert = ({ appName, sourceType, hcsEnrolled }) => {
             defaultMessage: "Don't forget additional configuration steps!",
           })}
           actionLinks={
-            CUSTOMIZING_CUR_LINK ? <AlertActionLink>Customizing your AWS cost and usage report</AlertActionLink> : null
+            <Text component={TextVariants.a} href={MANUAL_CUR_ADDITIONAL_STEPS}>
+              Customizing your AWS cost and usage report
+            </Text>
           }
         >
           {intl.formatMessage({
             id: 'cost.warningDescriptionCUR',
-            defaultMessage: `You will need to perform more configuration steps after creating the source.${
-              CUSTOMIZING_CUR_LINK ? ' To find more information, click on the link below' : ''
-            }`,
-          })}
-        </Alert>
-        <Alert
-          variant="default"
-          isInline
-          title={intl.formatMessage({ id: 'cost.rbacWarningTitle', defaultMessage: 'Manage permissions in User Access' })}
-        >
-          {intl.formatMessage({
-            id: 'cost.rbacWarningDescription',
             defaultMessage:
-              'Make sure to manage permissions for this source in custom roles that contain permissions for Cost Management.',
+              'You will need to perform more configuration steps after creating the source. To find more information, click on the link below.',
           })}
         </Alert>
+        {hcsEnrolled ? null : (
+          <Alert
+            variant="default"
+            isInline
+            title={intl.formatMessage({ id: 'cost.rbacWarningTitle', defaultMessage: 'Manage permissions in User Access' })}
+          >
+            {intl.formatMessage({
+              id: 'cost.rbacWarningDescription',
+              defaultMessage:
+                'Make sure to manage permissions for this source in custom roles that contain permissions for Cost Management.',
+            })}
+          </Alert>
+        )}
       </Fragment>
     );
   }

--- a/src/components/addSourceWizard/hardcodedComponents/aws/arn.js
+++ b/src/components/addSourceWizard/hardcodedComponents/aws/arn.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 
@@ -37,18 +37,39 @@ const ENABLE_AWS_ACCOUNT = `${HCCM_DOCS_PREFIX}/html/adding_an_amazon_web_servic
 const ENABLE_HCS_AWS_ACCOUNT = ''; // specify when HCS docs links are available
 const CONFIG_AWS_TAGS = `${HCCM_DOCS_PREFIX}/html/adding_an_amazon_web_services_aws_source_to_cost_management/assembly-cost-management-next-steps-aws#configure-cost-models-next-step_next-steps-aws`;
 const CONFIG_HCS_AWS_TAGS = ''; // specify when HCS docs links are available
-const MANUAL_CUR_ADDITIONAL_STEPS = ''; // specify when docs links are available
+export const MANUAL_CUR_ADDITIONAL_STEPS = 'https://github.com/project-koku/koku-data-selector/blob/main/docs/aws/aws.rst'; // replace with public link when available
 
-export const StorageDescription = () => {
+export const StorageDescription = ({ showHCS }) => {
   const intl = useIntl();
   return (
     <TextContent>
       <Text>
-        {intl.formatMessage({
-          id: 'cost.storageDescription.storageDescription',
-          defaultMessage:
-            'To store the cost and usage reports needed for cost management, you need to create an Amazon S3 bucket',
-        })}
+        {intl.formatMessage(
+          {
+            id: 'cost.storageDescription.storageDescription',
+            defaultMessage:
+              'To store the cost and usage reports needed for cost management, you need to create an Amazon S3 bucket. {link}',
+          },
+          {
+            link: showHCS ? null : ( // remove when HCS docs links are available
+              <Fragment>
+                <br />
+                <Text
+                  key="link"
+                  component={TextVariants.a}
+                  href={showHCS ? CREATE_HCS_S3_BUCKET : CREATE_S3_BUCKET}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  {intl.formatMessage({
+                    id: 'cost.learnMore',
+                    defaultMessage: 'Learn more',
+                  })}
+                </Text>
+              </Fragment>
+            ),
+          }
+        )}
       </Text>
       <TextList className="pf-u-ml-0" component={TextListVariants.ol}>
         <TextListItem>
@@ -62,6 +83,10 @@ export const StorageDescription = () => {
   );
 };
 
+StorageDescription.propTypes = {
+  showHCS: PropTypes.bool,
+};
+
 export const UsageDescription = ({ showHCS }) => {
   const intl = useIntl();
   const application = showHCS ? HCS_APP_NAME : 'Cost Management';
@@ -73,23 +98,9 @@ export const UsageDescription = ({ showHCS }) => {
           {
             id: 'cost.usageDescription.usageDescription',
             defaultMessage:
-              "The information {application} would need is your AWS account's cost and usage report (CUR). If there is a need to further customize the CUR you want to send to {application}, select the manually customize option and follow the special instructions on how to. {link}",
+              "The information {application} would need is your AWS account's cost and usage report (CUR). If there is a need to further customize the CUR you want to send to {application}, select the manually customize option and follow the special instructions on how to.",
           },
           {
-            link: showHCS ? null : ( // remove when HCS docs links are available
-              <Text
-                key="link"
-                component={TextVariants.a}
-                href={showHCS ? CREATE_HCS_S3_BUCKET : CREATE_S3_BUCKET}
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                {intl.formatMessage({
-                  id: 'cost.learnMore',
-                  defaultMessage: 'Learn more',
-                })}
-              </Text>
-            ),
             application,
           }
         )}
@@ -124,16 +135,14 @@ export const UsageSteps = () => {
             'Since you have chosen to manually customize the CUR you want to send to Cost Management, you do not need to create at this point and time.',
         })}
       </EmptyStateBody>
-      {MANUAL_CUR_ADDITIONAL_STEPS.length > 0 ? (
-        <EmptyStatePrimary>
-          <Button variant="link">
-            {intl.formatMessage({
-              id: 'cost.usageDescription.additionalStepsCUR',
-              defaultMessage: 'Additional configuration steps',
-            })}
-          </Button>
-        </EmptyStatePrimary>
-      ) : null}
+      <EmptyStatePrimary>
+        <Text variant="link" component={TextVariants.a} href={MANUAL_CUR_ADDITIONAL_STEPS}>
+          {intl.formatMessage({
+            id: 'cost.usageDescription.additionalStepsCUR',
+            defaultMessage: 'Additional configuration steps',
+          })}
+        </Text>
+      </EmptyStatePrimary>
     </EmptyState>
   ) : (
     <TextContent>

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/arn.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/arn.test.js
@@ -173,7 +173,6 @@ describe('AWS-ARN hardcoded schemas', () => {
         "The information Cost Management would need is your AWS account's cost and usage report (CUR). If there is a need to further customize the CUR you want to send to Cost Management, select the manually customize option and follow the special instructions on how to."
       )
     ).toBeInTheDocument();
-    expect(screen.getByText('Learn more')).toBeInTheDocument();
   });
 
   it('USAGE description is rendered correctly for HCS', () => {
@@ -241,18 +240,31 @@ describe('AWS-ARN hardcoded schemas', () => {
         'Since you have chosen to manually customize the CUR you want to send to Cost Management, you do not need to create at this point and time.'
       )
     ).toBeInTheDocument();
-    expect(screen.queryByText('Additional configuration steps')).toBeNull();
+    expect(screen.queryByText('Additional configuration steps')).toBeInTheDocument();
   });
 
-  it('IncludeAliasesLabel description is rendered correctly', () => {
+  it('StorageDescription is rendered correctly', () => {
     render(<AwsArn.StorageDescription />);
 
     expect(
-      screen.getByText('To store the cost and usage reports needed for cost management, you need to create an Amazon S3 bucket')
+      screen.getByText('To store the cost and usage reports needed for cost management, you need to create an Amazon S3 bucket.')
     ).toBeInTheDocument();
     expect(
       screen.getByText("On AWS, specify or create an Amazon S3 bucket for your account and enter it's name below.")
     ).toBeInTheDocument();
+    expect(screen.getByText('Learn more')).toBeInTheDocument();
+  });
+
+  it('StorageDescription is rendered correctly - HCS', () => {
+    render(<AwsArn.StorageDescription showHCS />);
+
+    expect(
+      screen.getByText('To store the cost and usage reports needed for cost management, you need to create an Amazon S3 bucket.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("On AWS, specify or create an Amazon S3 bucket for your account and enter it's name below.")
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Learn more')).toBeNull();
   });
 
   it('IncludeAliasesLabel description is rendered correctly', () => {

--- a/src/test/components/formComponents/sourceWizardSummary.test.js
+++ b/src/test/components/formComponents/sourceWizardSummary.test.js
@@ -263,6 +263,11 @@ describe('SourceWizardSummary component', () => {
       ]);
 
       expect(screen.queryByText('Manage permissions in User Access')).not.toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'You will need to perform more configuration steps after creating the source. To find more information, click on the link below.'
+        )
+      ).toBeInTheDocument();
     });
 
     it('google - cost management - include google - cost alert', () => {
@@ -318,6 +323,11 @@ describe('SourceWizardSummary component', () => {
         ['', '-'],
         ['Cloud storage bucket name', '-'],
       ]);
+      expect(
+        screen.getByText(
+          'You will need to perform more configuration steps after creating the source. To find more information, click on the link below.'
+        )
+      ).toBeInTheDocument();
     });
 
     it('openshift cost management - include appended field from DB and rbac alert message', () => {
@@ -419,6 +429,11 @@ describe('SourceWizardSummary component', () => {
       ]);
 
       expect(screen.queryByText('Manage permissions in User Access')).not.toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'You will need to perform more configuration steps after creating the source. To find more information, click on the link below.'
+        )
+      ).toBeInTheDocument();
     });
 
     it('azure rhel management - lighthouse', () => {


### PR DESCRIPTION
1. Moved link "Learn more" from "Create cost and usage report" step to the "Create storage step"
2. Added temp links for CUR additional steps docs

![image](https://user-images.githubusercontent.com/50696716/230225927-d8ca456e-d5e6-4ed3-9164-19c66f6beffc.png)

![image](https://user-images.githubusercontent.com/50696716/230225989-6db871c6-0e74-4eab-a1dd-7272ae56b91a.png)

![image](https://user-images.githubusercontent.com/50696716/230226056-7e8339a6-4eee-4c4e-8cd4-b3f7045e696f.png)
