### PR TITLE
Anchor Wizard to correct element

### DIFF
--- a/src/components/addSourceWizard/FinalWizard.js
+++ b/src/components/addSourceWizard/FinalWizard.js
@@ -195,7 +195,7 @@ const FinalWizard = ({
     );
   }
 
-  const appendTo = React.useMemo(() => document.querySelector('.pf-c-page.chr-c-page'));
+  const appendTo = React.useMemo(() => document.querySelector('.pf-c-page.chr-c-page'), []);
 
   return (
     <Modal isOpen modalVariant={ModalVariant.large} hasNoBodyWrapper appendTo={appendTo} showClose={false}>

--- a/src/components/addSourceWizard/FinalWizard.js
+++ b/src/components/addSourceWizard/FinalWizard.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, useIntl } from 'react-intl';
 
-import { Button, Text, TextContent, Wizard } from '@patternfly/react-core';
+import { Button, Modal, ModalVariant, Text, TextContent, Wizard } from '@patternfly/react-core';
 
 import { wizardDescription, wizardTitle } from './stringConstants';
 import { getSourcesApi } from '../../api/entities';
@@ -195,21 +195,24 @@ const FinalWizard = ({
     );
   }
 
+  const appendTo = React.useMemo(() => document.querySelector('.pf-c-page.chr-c-page'));
+
   return (
-    <Wizard
-      className="sources"
-      isOpen={true}
-      onClose={isFinished ? afterSubmit : afterError}
-      title={wizardTitle(activeCategory)}
-      description={wizardDescription(activeCategory)}
-      steps={[
-        {
-          name: 'Finish',
-          component: step,
-          isFinishedStep: true,
-        },
-      ]}
-    />
+    <Modal isOpen modalVariant={ModalVariant.large} hasNoBodyWrapper appendTo={appendTo} showClose={false}>
+      <Wizard
+        className="sources"
+        onClose={isFinished ? afterSubmit : afterError}
+        title={wizardTitle(activeCategory)}
+        description={wizardDescription(activeCategory)}
+        steps={[
+          {
+            name: 'Finish',
+            component: step,
+            isFinishedStep: true,
+          },
+        ]}
+      />
+    </Modal>
   );
 };
 


### PR DESCRIPTION
By default all modal wizards are anchored to document.body which interferes with Quickstarts by overlaying them. This patch anchors the modal to the main element outside of the Quickstart so that both can be visible at the same time.