### PR TITLE
Get Azure Lighthouse template from S3

### DIFF
--- a/src/components/addSourceWizard/hardcodedComponents/azure/provisioning.js
+++ b/src/components/addSourceWizard/hardcodedComponents/azure/provisioning.js
@@ -2,19 +2,12 @@ import React from 'react';
 import { useIntl } from 'react-intl';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
 import { Button, Text, TextContent } from '@patternfly/react-core';
-import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
-
-const PROVISIONING_API_BASE_V1 = `${process.env.BASE_PATH || '/api'}/provisioning/v1`;
 
 export const LighthouseDescription = () => {
   const intl = useIntl();
   const formOptions = useFormApi();
-  const { isProd } = useChrome();
-  const templatePath = `${PROVISIONING_API_BASE_V1}/azure_offering_template`;
-  const portalLink = isProd()
-    ? `https://console.redhat.com${templatePath}`
-    : 'https://gist.githubusercontent.com/ezr-ondrej/eda9ef57c42083cdaaf43e58ae225ed0/raw/e31412c8d31339c14e34e0e73c87f8999336d015/stageTemplate';
-  const link = `https://portal.azure.com/#create/Microsoft.Template/uri/${encodeURIComponent(portalLink)}`;
+  const templateLink = 'https://provisioning-public-assets.s3.amazonaws.com/AzureLighthouse/offering_template.json';
+  const link = `https://portal.azure.com/#create/Microsoft.Template/uri/${encodeURIComponent(templateLink)}`;
 
   return (
     <TextContent>

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/azure_provisioning.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/azure_provisioning.test.js
@@ -31,7 +31,9 @@ describe('Azure-Provisioning hardcoded schemas', () => {
       expect(screen.getByText('Take me to Lighthouse')).not.toHaveAttribute('aria-disabled', 'true');
       expect(screen.getByText('Take me to Lighthouse')).toHaveAttribute(
         'href',
-        expect.stringMatching(/console.redhat.com%2Fapi%2Fprovisioning%2Fv1%2Fazure_offering_template/)
+        expect.stringMatching(
+          /https%3A%2F%2Fprovisioning-public-assets.s3.amazonaws.com%2FAzureLighthouse%2Foffering_template.json$/
+        )
       );
     });
 
@@ -49,7 +51,9 @@ describe('Azure-Provisioning hardcoded schemas', () => {
       expect(screen.getByText('Take me to Lighthouse')).not.toHaveAttribute('aria-disabled', 'true');
       expect(screen.getByText('Take me to Lighthouse')).toHaveAttribute(
         'href',
-        expect.stringMatching(/gist.githubusercontent.com%2Fezr-ondrej%2Feda9ef57c42083cdaaf43e58ae225ed0%2Fraw/)
+        expect.stringMatching(
+          /https%3A%2F%2Fprovisioning-public-assets.s3.amazonaws.com%2FAzureLighthouse%2Foffering_template.json$/
+        )
       );
     });
 


### PR DESCRIPTION
Azure Lighthouse needs to download the template from publicly available place. Our portal's Akamai gateway unfortunatelly disables access by CORS, which Azure respects.

We were not able to find an easy solution for CORS settings, so we have put the teamplate to S3 temporarily until we figure out a way around this.