### PR TITLE
Add external ID support to AWS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,8 @@
         "react-router-dom": "^6.8.0",
         "redux": "^4.2.0",
         "redux-promise-middleware": "^6.1.2",
-        "redux-thunk": "^2.4.1"
+        "redux-thunk": "^2.4.1",
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.18.9",
@@ -1941,6 +1942,15 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/@cypress/request/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@cypress/xvfb": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@cypress/xvfb/-/xvfb-1.2.4.tgz",
@@ -3076,6 +3086,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@openshift/dynamic-plugin-sdk/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@patternfly/react-core": {
@@ -15637,6 +15655,15 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -16663,6 +16690,15 @@
         "uuid": "^8.3.2"
       }
     },
+    "node_modules/unleash-proxy-client/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -16782,9 +16818,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -19069,6 +19105,12 @@
             "psl": "^1.1.28",
             "punycode": "^2.1.1"
           }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "peer": true
         }
       }
     },
@@ -19944,6 +19986,11 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         }
       }
     },
@@ -29434,6 +29481,14 @@
         "faye-websocket": "^0.11.3",
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
       }
     },
     "source-map": {
@@ -30201,6 +30256,14 @@
       "requires": {
         "tiny-emitter": "^2.1.0",
         "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "peer": true
+        }
       }
     },
     "unpipe": {
@@ -30297,9 +30360,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "react-router-dom": "^6.8.0",
     "redux": "^4.2.0",
     "redux-promise-middleware": "^6.1.2",
-    "redux-thunk": "^2.4.1"
+    "redux-thunk": "^2.4.1",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.18.9",

--- a/src/api/checkAccountHCS.js
+++ b/src/api/checkAccountHCS.js
@@ -1,11 +1,19 @@
 export const checkAccountHCS = async (jwtToken, isProd) => {
   return fetch(`https://billing.${isProd ? '' : 'stage.'}api.redhat.com/v1/authorization/hcsEnrollment`, {
     headers: { Authorization: `Bearer ${jwtToken}` },
-  }).then((response) => {
-    if (response.status !== 200) {
-      return { hcsDeal: false };
-    }
+  })
+    .then((response) => {
+      if (response.status !== 200) {
+        return { hcsDeal: false };
+      }
 
-    return response.json();
-  });
+      return response.json();
+    })
+    .catch((e) => {
+      // eslint-disable-next-line no-console
+      console.error(e);
+      // eslint-disable-next-line no-console
+      console.log('Failed to check HCS enrollment');
+      return { hcsDeal: false };
+    });
 };

--- a/src/components/FormComponents/ClipboardCopy.js
+++ b/src/components/FormComponents/ClipboardCopy.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { ClipboardCopy as ClipboardCopyPF, FormGroup } from '@patternfly/react-core';
+import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
+
+const ClipboardCopy = (props) => {
+  const { label, input } = useFieldApi(props);
+
+  return (
+    <FormGroup label={label}>
+      <ClipboardCopyPF label={label} isReadOnly>
+        {input.value}
+      </ClipboardCopyPF>
+    </FormGroup>
+  );
+};
+
+ClipboardCopyPF.propTypes = {
+  label: PropTypes.string,
+};
+
+export default ClipboardCopy;

--- a/src/components/SourceEditForm/SourceEditModal.js
+++ b/src/components/SourceEditForm/SourceEditModal.js
@@ -11,10 +11,11 @@ import { onSubmit } from './onSubmit';
 
 import { useSource } from '../../hooks/useSource';
 import { useIsLoaded } from '../../hooks/useIsLoaded';
+import { prepareMessages } from './helpers';
 import reducer, { initialState } from './reducer';
 import SubmittingModal from './SubmittingModal';
 import ErroredModal from './ErroredModal';
-import { prepareMessages } from './helpers';
+import ClipboardCopy from '../FormComponents/ClipboardCopy';
 
 const SourceEditModal = () => {
   const [state, setState] = useReducer(reducer, initialState);
@@ -95,6 +96,7 @@ const SourceEditModal = () => {
         ...(!sourceRedux.paused_at && { message }),
         ...(!sourceRedux.paused_at && { messages }),
       }}
+      componentMapper={{ 'clipboard-copy': ClipboardCopy }}
     />
   );
 };

--- a/src/components/SourceEditForm/parser/authentication.js
+++ b/src/components/SourceEditForm/parser/authentication.js
@@ -1,7 +1,9 @@
+import React from 'react';
 import get from 'lodash/get';
 import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
-import hardcodedSchemas from '../../../components/addSourceWizard/hardcodedSchemas';
+import { FormattedMessage } from 'react-intl';
 import { doLoadRegions } from '../../../api/doLoadRegions';
+import hardcodedSchemas from '../../../components/addSourceWizard/hardcodedSchemas';
 
 export const createAuthFieldName = (fieldName, id) => `authentications.a${id}.${fieldName.replace('authentication.', '')}`;
 
@@ -38,6 +40,7 @@ export const modifyAuthSchemas = (fields, id, appId) =>
 
     const isPassword = getLastPartOfName(finalField.name) === 'password';
     const isAwsRegion = getLastPartOfName(finalField.name) === 'bucket_region' && finalField.label.includes('AWS');
+    const isExternalId = getLastPartOfName(finalField.name) === 'external_id';
 
     if (isPassword) {
       finalField.component = 'authentication';
@@ -45,6 +48,13 @@ export const modifyAuthSchemas = (fields, id, appId) =>
 
     if (isAwsRegion) {
       finalField.loadOptions = () => doLoadRegions().then((data) => data.map((item) => ({ value: item, label: item })));
+    }
+
+    if (isExternalId) {
+      finalField.hideField = false;
+      finalField.label = <FormattedMessage id="cost.arn.externalId" defaultMessage="External ID" />;
+      finalField.component = 'clipboard-copy';
+      finalField.isReadOnly = true;
     }
 
     return finalField;

--- a/src/components/addSourceWizard/hardcodedComponents/aws/arn.js
+++ b/src/components/addSourceWizard/hardcodedComponents/aws/arn.js
@@ -1,6 +1,7 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
+import { v4 as uuidv4 } from 'uuid';
 
 import {
   Button,
@@ -198,6 +199,16 @@ export const UsageSteps = () => {
 
 export const IAMRoleDescription = () => {
   const intl = useIntl();
+  const externalId = useMemo(() => uuidv4(), []);
+  const formOptions = useFormApi();
+  const { authentication = {} } = formOptions.getState().values;
+
+  useEffect(() => {
+    formOptions.change('authentication', {
+      ...authentication,
+      extra: { ...(authentication?.extra || {}), external_id: externalId },
+    });
+  }, [externalId]);
 
   return (
     <TextContent>
@@ -223,6 +234,15 @@ export const IAMRoleDescription = () => {
         </TextListItem>
         <ClipboardCopy className="pf-u-m-sm-on-sm" isReadOnly>
           589173575009
+        </ClipboardCopy>
+        <TextListItem>
+          {intl.formatMessage({
+            id: 'cost.iamrole.enterExternalId',
+            defaultMessage: 'Paste the following value in the External ID field:',
+          })}
+        </TextListItem>
+        <ClipboardCopy className="pf-u-m-sm-on-sm" isReadOnly>
+          {externalId}
         </ClipboardCopy>
         <TextListItem>
           {intl.formatMessage({

--- a/src/components/addSourceWizard/hardcodedSchemas.js
+++ b/src/components/addSourceWizard/hardcodedSchemas.js
@@ -258,6 +258,12 @@ const getArn = (authUsername, showHCS) => ({
       substepOf: 'eaa',
       fields: [
         {
+          name: 'authentication.extra.external_id',
+          component: componentTypes.TEXT_FIELD,
+          hideField: true,
+          initializeOnMount: true,
+        },
+        {
           name: 'iam-role-description',
           component: 'description',
           Content: AwsArn.IAMRoleDescription,

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/arn.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/arn.test.js
@@ -88,7 +88,22 @@ describe('AWS-ARN hardcoded schemas', () => {
   });
 
   it('IAM ROLE is rendered correctly', () => {
-    render(<AwsArn.IAMRoleDescription />);
+    const changeSpy = jest.fn();
+    const FORM_OPTIONS = {
+      getState: () => ({
+        values: {
+          application: {
+            extra: {},
+          },
+        },
+      }),
+      change: changeSpy,
+    };
+    render(
+      <RendererContext.Provider value={{ formOptions: FORM_OPTIONS }}>
+        <AwsArn.IAMRoleDescription />
+      </RendererContext.Provider>
+    );
 
     expect(
       screen.getByText('To delegate account access, create an IAM role to associate with your IAM policy.')
@@ -101,11 +116,30 @@ describe('AWS-ARN hardcoded schemas', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('Attach the permissions policy that you just created.')).toBeInTheDocument();
     expect(screen.getByText('Complete the process to create your new role.')).toBeInTheDocument();
-    expect(screen.getByRole('textbox', { name: 'Copyable input' })).toHaveValue('589173575009');
+    expect(screen.getAllByRole('textbox', { name: 'Copyable input' })[0]).toHaveValue('589173575009');
+    expect(changeSpy).toHaveBeenCalledWith('authentication', {
+      extra: expect.objectContaining({ external_id: expect.any(String) }),
+    });
   });
 
   it('IAM ROLE is rendered correctly for HCS', () => {
-    render(<AwsArn.IAMRoleDescription showHCS />);
+    const changeSpy = jest.fn();
+    const FORM_OPTIONS = {
+      getState: () => ({
+        values: {
+          application: {
+            extra: {},
+          },
+        },
+      }),
+      change: changeSpy,
+    };
+
+    render(
+      <RendererContext.Provider value={{ formOptions: FORM_OPTIONS }}>
+        <AwsArn.IAMRoleDescription showHCS />
+      </RendererContext.Provider>
+    );
 
     expect(
       screen.getByText('To delegate account access, create an IAM role to associate with your IAM policy.')
@@ -118,7 +152,10 @@ describe('AWS-ARN hardcoded schemas', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('Attach the permissions policy that you just created.')).toBeInTheDocument();
     expect(screen.getByText('Complete the process to create your new role.')).toBeInTheDocument();
-    expect(screen.getByRole('textbox', { name: 'Copyable input' })).toHaveValue('589173575009');
+    expect(screen.getAllByRole('textbox', { name: 'Copyable input' })[0]).toHaveValue('589173575009');
+    expect(changeSpy).toHaveBeenCalledWith('authentication', {
+      extra: expect.objectContaining({ external_id: expect.any(String) }),
+    });
   });
 
   it('TAGS DESCRIPTION is rendered correctly for Cost Management', () => {


### PR DESCRIPTION
[RHCLOUD-25937](https://issues.redhat.com/browse/RHCLOUD-25937)

- added external ID support to AWS in the add source wizard & detail
- fixed current tests, full test coverage will follow 

New field in the wizard:
![ext1](https://github.com/RedHatInsights/sources-ui/assets/50696716/c0b971a7-c7ac-41fa-b425-623e897e95b3)

Detail:
![ext2](https://github.com/RedHatInsights/sources-ui/assets/50696716/4c37a0e0-aa02-4620-8413-441c1f5afd46)

