### PR TITLE
Remove usage of preview flag of sources + integrations

### DIFF
--- a/src/components/SourcesHeader.js
+++ b/src/components/SourcesHeader.js
@@ -4,11 +4,11 @@ import { useIntl } from 'react-intl';
 import { PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components/PageHeader';
 
 import TabNavigation from './TabNavigation';
-import { usePreviewFlag } from '../utilities/usePreviewFlag';
+import { useFlag } from '@unleash/proxy-client-react';
 
 const SourcesHeader = () => {
   const intl = useIntl();
-  const enableIntegrations = usePreviewFlag('platform.sources.integrations');
+  const enableIntegrations = useFlag('platform.sources.integrations');
 
   return (
     <PageHeader className="pf-u-pb-0">

--- a/src/components/TabNavigation.js
+++ b/src/components/TabNavigation.js
@@ -8,13 +8,13 @@ import CloudIcon from '@patternfly/react-icons/dist/esm/icons/cloud-icon';
 
 import { setActiveCategory } from '../redux/sources/actions';
 import { CLOUD_VENDOR, INTEGRATIONS, REDHAT_VENDOR } from '../utilities/constants';
-import { usePreviewFlag } from '../utilities/usePreviewFlag';
+import { useFlag } from '@unleash/proxy-client-react';
 
 const TabNavigation = () => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const activeCategory = useSelector(({ sources }) => sources.activeCategory);
-  const enableIntegrations = usePreviewFlag('platform.sources.integrations');
+  const enableIntegrations = useFlag('platform.sources.integrations');
 
   return (
     <Tabs activeKey={activeCategory} onSelect={(_e, key) => dispatch(setActiveCategory(key))} className="pf-u-mt-md">

--- a/src/pages/Sources.js
+++ b/src/pages/Sources.js
@@ -41,7 +41,7 @@ import SourcesHeader from '../components/SourcesHeader';
 import generateCSV from '../utilities/generateCSV';
 import generateJSON from '../utilities/generateJSON';
 import { Outlet } from 'react-router-dom';
-import { usePreviewFlag } from '../utilities/usePreviewFlag';
+import { useFlag } from '@unleash/proxy-client-react';
 
 const initialState = {
   filter: undefined,
@@ -69,7 +69,7 @@ const SourcesPage = () => {
   const entitiesLoaded = useIsLoaded();
   const hasWritePermissions = useHasWritePermissions();
   const isOrgAdmin = useSelector(({ user }) => user.isOrgAdmin);
-  const enableIntegrations = usePreviewFlag('platform.sources.integrations');
+  const enableIntegrations = useFlag('platform.sources.integrations');
 
   const appNavigate = useAppNavigate();
   const intl = useIntl();


### PR DESCRIPTION
### Description

Since we want to release sources + integrations to production we should replace usage of preview flag with actual flag. That way we can enable it in production.