### PR TITLE
Use preview flag for RHEL AWS

### DIFF
--- a/src/components/FormComponents/PFDivider.js
+++ b/src/components/FormComponents/PFDivider.js
@@ -1,10 +1,10 @@
 import React from 'react';
 
 import { Divider } from '@patternfly/react-core';
-import { useFlag } from '@unleash/proxy-client-react';
+import { usePreviewFlag } from '../../utilities/usePreviewFlag';
 
 const PFDivider = () => {
-  const rhelAws = useFlag('platform.sources.metered-rhel');
+  const rhelAws = usePreviewFlag('platform.sources.metered-rhel');
 
   if (!rhelAws) {
     return null;

--- a/src/components/FormComponents/RhelAwsCheckbox.js
+++ b/src/components/FormComponents/RhelAwsCheckbox.js
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
 
 import { Checkbox } from '@patternfly/react-core';
-import { useFlag } from '@unleash/proxy-client-react';
+import { usePreviewFlag } from '../../utilities/usePreviewFlag';
 
 const RhelAwsCheckbox = ({ ...props }) => {
   const { label, input } = useFieldApi(props);
-  const rhelAws = useFlag('platform.sources.metered-rhel');
+  const rhelAws = usePreviewFlag('platform.sources.metered-rhel');
 
   if (!rhelAws) {
     return null;

--- a/src/components/addSourceWizard/hardcodedComponents/aws/arn.js
+++ b/src/components/addSourceWizard/hardcodedComponents/aws/arn.js
@@ -32,7 +32,7 @@ import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
 
 import { HCCM_DOCS_PREFIX } from '../../stringConstants';
 import { HCS_APP_NAME } from '../../../../utilities/constants';
-import { useFlag } from '@unleash/proxy-client-react';
+import { usePreviewFlag } from '../../../../utilities/usePreviewFlag';
 
 const CREATE_HCS_S3_BUCKET = ''; // specify when HCS docs links are available
 const CREATE_S3_BUCKET = `${HCCM_DOCS_PREFIX}/html/adding_an_amazon_web_services_aws_source_to_cost_management/assembly-adding-aws-sources#creating-an-aws-s3-bucket_adding-aws-sources`;
@@ -387,7 +387,7 @@ IAMPolicyDescription.propTypes = {
 export const TagsDescription = ({ showHCS }) => {
   const intl = useIntl();
   const application = showHCS ? HCS_APP_NAME : 'Cost Management';
-  const rhelAws = useFlag('platform.sources.metered-rhel');
+  const rhelAws = usePreviewFlag('platform.sources.metered-rhel');
 
   return (
     <Fragment>

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/arn.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/arn.test.js
@@ -13,6 +13,10 @@ jest.mock('uuid', () => ({
   v4: () => 'test-uuid',
 }));
 
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => {
+  return () => ({ getEnvironment: () => 'bar', isBeta: () => false });
+});
+
 describe('AWS-ARN hardcoded schemas', () => {
   it('ARN DESCRIPTION is rendered correctly', () => {
     render(<AwsArn.ArnDescription />);


### PR DESCRIPTION
### Description

We want to surface the RHEL AWS on prod preview for certain account, let's add the preview flag to hide it only on prod9stable env.

### JIRA

https://issues.redhat.com/browse/RHCLOUD-29129