### PR TITLE
Remove 'no application' option from Add Source Wizard

### DIFF
--- a/src/components/addSourceWizard/SourceAddSchema.js
+++ b/src/components/addSourceWizard/SourceAddSchema.js
@@ -186,9 +186,15 @@ export const applicationStep = (applicationTypes, intl, activeCategory, hcsEnrol
     {
       component: 'enhanced-radio',
       name: 'application.application_type_id',
+      label: intl.formatMessage({
+        id: 'wizard.selectApplicationType',
+        defaultMessage: 'Select an application',
+      }),
       options: compileAllApplicationComboOptions(applicationTypes, intl, activeCategory, hcsEnrolled),
       mutator: appMutatorRedHat(applicationTypes),
       menuIsPortal: true,
+      isRequired: true,
+      validate: [{ type: validatorTypes.REQUIRED }],
     },
     {
       component: componentTypes.TEXT_FIELD,

--- a/src/components/addSourceWizard/SourceAddSchema.js
+++ b/src/components/addSourceWizard/SourceAddSchema.js
@@ -190,7 +190,7 @@ export const applicationStep = (applicationTypes, intl, activeCategory, hcsEnrol
         id: 'wizard.selectApplicationType',
         defaultMessage: 'Select an application',
       }),
-      options: compileAllApplicationComboOptions(applicationTypes, intl, activeCategory, hcsEnrolled),
+      options: compileAllApplicationComboOptions(applicationTypes, intl, hcsEnrolled),
       mutator: appMutatorRedHat(applicationTypes),
       menuIsPortal: true,
       isRequired: true,

--- a/src/components/addSourceWizard/compileAllApplicationComboOptions.js
+++ b/src/components/addSourceWizard/compileAllApplicationComboOptions.js
@@ -2,14 +2,7 @@ import React from 'react';
 import { Label } from '@patternfly/react-core';
 import SubWatchDescription from './descriptions/SubWatchDescription';
 import HybridCommittedSpendDescription from './descriptions/HybridCommittedSpendDescription';
-import { NO_APPLICATION_VALUE } from './stringConstants';
-import {
-  CLOUD_METER_APP_NAME,
-  COST_MANAGEMENT_APP_NAME,
-  HCS_APP_NAME,
-  PROVISIONING_APP_NAME,
-  REDHAT_VENDOR,
-} from '../../utilities/constants';
+import { CLOUD_METER_APP_NAME, COST_MANAGEMENT_APP_NAME, HCS_APP_NAME, PROVISIONING_APP_NAME } from '../../utilities/constants';
 
 export const descriptionMapper = (type, intl, hcsEnrolled) =>
   ({
@@ -54,7 +47,7 @@ export const labelMapper = (type, intl, hcsEnrolled) =>
     ),
   })[type.name];
 
-export const compileAllApplicationComboOptions = (applicationTypes, intl, activeCategory, hcsEnrolled) => [
+export const compileAllApplicationComboOptions = (applicationTypes, intl, hcsEnrolled) => [
   ...applicationTypes
     .sort((a, b) => a.display_name.localeCompare(b.display_name))
     .map((t) => ({
@@ -62,15 +55,4 @@ export const compileAllApplicationComboOptions = (applicationTypes, intl, active
       label: labelMapper(t, intl, hcsEnrolled) || t.display_name,
       description: descriptionMapper(t, intl, hcsEnrolled),
     })),
-  ...(activeCategory !== REDHAT_VENDOR
-    ? [
-        {
-          label: intl.formatMessage({
-            id: 'wizard.noApplication',
-            defaultMessage: 'No application',
-          }),
-          value: NO_APPLICATION_VALUE,
-        },
-      ]
-    : []),
 ];

--- a/src/components/addSourceWizard/stringConstants.js
+++ b/src/components/addSourceWizard/stringConstants.js
@@ -22,5 +22,3 @@ export const wizardTitle = (activeCategory) =>
   );
 export const HCCM_DOCS_PREFIX = 'https://access.redhat.com/documentation/en-us/cost_management_service/2023';
 export const HCCM_LATEST_DOCS_PREFIX = 'https://access.redhat.com/documentation/en-us/cost_management_service/1-latest';
-
-export const NO_APPLICATION_VALUE = 'no-application';

--- a/src/test/addSourceWizard/addSourceWizard/addSourceSchema.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/addSourceSchema.test.js
@@ -206,7 +206,6 @@ describe('Add source schema', () => {
         },
         { label: expect.any(Object), value: '5', description: <SubWatchDescription id="5" /> },
         { label: 'Topological Inventory', value: '3', description: undefined },
-        { value: NO_APPLICATION_VALUE, label: 'No application' },
       ]);
     });
   });
@@ -237,7 +236,6 @@ describe('Add source schema', () => {
         },
         { label: expect.any(Object), value: '5', description: <SubWatchDescription id="5" /> },
         { label: 'Topological Inventory', value: '3', description: undefined },
-        { value: NO_APPLICATION_VALUE, label: 'No application' },
       ]);
     });
   });

--- a/src/test/addSourceWizard/addSourceWizard/addSourceSchema.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/addSourceSchema.test.js
@@ -17,7 +17,6 @@ import sourceTypes, { OPENSHIFT_TYPE } from '../../__mocks__/sourceTypes';
 import applicationTypes from '../../__mocks__/applicationTypes';
 
 import render from '../__mocks__/render';
-import { NO_APPLICATION_VALUE } from '../../../components/addSourceWizard/stringConstants';
 import SubWatchDescription from '../../../components/addSourceWizard/descriptions/SubWatchDescription';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
 import SourcesFormRenderer from '../../../utilities/SourcesFormRenderer';

--- a/src/test/addSourceWizard/addSourceWizard/compileAllApplicationComboOptions.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/compileAllApplicationComboOptions.test.js
@@ -6,7 +6,6 @@ import {
   REDHAT_VENDOR,
 } from '../../../utilities/constants';
 import { compileAllApplicationComboOptions } from '../../../components/addSourceWizard/compileAllApplicationComboOptions';
-import { NO_APPLICATION_VALUE } from '../../../components/addSourceWizard/stringConstants';
 import HybridCommittedSpendDescription from '../../../components/addSourceWizard/descriptions/HybridCommittedSpendDescription';
 import { Label } from '@patternfly/react-core';
 
@@ -14,13 +13,6 @@ describe('compileAllApplicationComboOptions', () => {
   const mockAppTypes = [{ name: 'app', display_name: 'Application', id: '1' }];
 
   const INTl = { formatMessage: ({ defaultMessage }) => defaultMessage };
-
-  it('cloud type selection - has none application', () => {
-    expect(compileAllApplicationComboOptions(mockAppTypes, INTl, CLOUD_VENDOR)).toEqual([
-      { label: 'Application', value: '1', description: undefined },
-      { label: 'No application', value: NO_APPLICATION_VALUE },
-    ]);
-  });
 
   it('red hat type selection - is none', () => {
     expect(compileAllApplicationComboOptions(mockAppTypes, INTl, REDHAT_VENDOR)).toEqual([
@@ -42,10 +34,6 @@ describe('compileAllApplicationComboOptions', () => {
           </span>
         ),
         value: '2',
-      },
-      {
-        label: 'No application',
-        value: 'no-application',
       },
     ]);
   });

--- a/src/test/addSourceWizard/addSourceWizard/compileAllApplicationComboOptions.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/compileAllApplicationComboOptions.test.js
@@ -1,10 +1,4 @@
-import {
-  CLOUD_VENDOR,
-  COST_MANAGEMENT_APP_ID,
-  COST_MANAGEMENT_APP_NAME,
-  HCS_APP_NAME,
-  REDHAT_VENDOR,
-} from '../../../utilities/constants';
+import { COST_MANAGEMENT_APP_ID, COST_MANAGEMENT_APP_NAME, HCS_APP_NAME, REDHAT_VENDOR } from '../../../utilities/constants';
 import { compileAllApplicationComboOptions } from '../../../components/addSourceWizard/compileAllApplicationComboOptions';
 import HybridCommittedSpendDescription from '../../../components/addSourceWizard/descriptions/HybridCommittedSpendDescription';
 import { Label } from '@patternfly/react-core';
@@ -22,7 +16,7 @@ describe('compileAllApplicationComboOptions', () => {
 
   it('cost type selection - HCS', () => {
     const appTypes = [{ name: COST_MANAGEMENT_APP_NAME, display_name: 'Cost Management', id: COST_MANAGEMENT_APP_ID }];
-    expect(compileAllApplicationComboOptions(appTypes, INTl, CLOUD_VENDOR, true)).toEqual([
+    expect(compileAllApplicationComboOptions(appTypes, INTl, true)).toEqual([
       {
         description: <HybridCommittedSpendDescription id="2" />,
         label: (

--- a/src/test/addSourceWizard/addSourceWizard/superKey/applicationsStep.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/superKey/applicationsStep.test.js
@@ -47,7 +47,6 @@ describe('applicationsStep', () => {
         value: '5',
       },
       { description: undefined, label: 'Topological Inventory', value: '3' },
-      { label: 'No application', value: NO_APPLICATION_VALUE },
     ]);
   });
 });

--- a/src/test/addSourceWizard/addSourceWizard/superKey/applicationsStep.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/superKey/applicationsStep.test.js
@@ -6,7 +6,6 @@ import componentTypes from '@data-driven-forms/react-form-renderer/component-typ
 import applicationsStep from '../../../../components/addSourceWizard/superKey/applicationsStep';
 import applicationTypes from '../../../__mocks__/applicationTypes';
 import SubWatchDescription from '../../../../components/addSourceWizard/descriptions/SubWatchDescription';
-import { NO_APPLICATION_VALUE } from '../../../../components/addSourceWizard/stringConstants';
 
 describe('applicationsStep', () => {
   it('generates applications step', () => {


### PR DESCRIPTION
# [RHCLOUD-24803](https://issues.redhat.com/browse/RHCLOUD-24803)

- Remove the option to choose 'No Application' in the 'Add a cloud source' wizard.
- Make selection of an application required.

**Before:**
![image](https://github.com/RedHatInsights/sources-ui/assets/39098327/8448c688-0493-48b3-be9f-4d1b7bfad1c2)

**After:**
![image](https://github.com/RedHatInsights/sources-ui/assets/39098327/eb4b3b60-154d-46dd-a7ab-32b677e30d68)
