### PR TITLE
Make app_creation_workflow optional

### DIFF
--- a/src/components/addSourceWizard/descriptions/HybridCommittedSpendDescription.js
+++ b/src/components/addSourceWizard/descriptions/HybridCommittedSpendDescription.js
@@ -17,8 +17,8 @@ const HybridCommittedSpendDescription = ({ id }) => {
 
   const isEnabled = useMemo(
     () =>
-      (values.source.app_creation_workflow === ACCOUNT_AUTHORIZATION && values.applications?.includes(id)) ||
-      (values.source.app_creation_workflow !== ACCOUNT_AUTHORIZATION && values.application?.application_type_id === id),
+      (values.source?.app_creation_workflow === ACCOUNT_AUTHORIZATION && values.applications?.includes(id)) ||
+      (values.source?.app_creation_workflow !== ACCOUNT_AUTHORIZATION && values.application?.application_type_id === id),
     [values.application?.application_type_id],
   );
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-30239

Made app_creation_workflow optional since it may not be defined for some flows and it caused the wizard to fail unnecessarily