### PR TITLE
Add exception for sources created by operator

### DIFF
--- a/src/components/SourceEditForm/parser/application.js
+++ b/src/components/SourceEditForm/parser/application.js
@@ -13,7 +13,7 @@ export const APP_NAMES = {
   CLOUD_METER: '/insights/platform/cloud-meter',
 };
 
-const createOneAppFields = (appType, sourceType, app) => [
+const createOneAppFields = (appType, sourceType, app, clusterId) => [
   {
     name: `messages.${app.id}`,
     component: 'description',
@@ -28,10 +28,11 @@ const createOneAppFields = (appType, sourceType, app) => [
     sourceType,
     appType?.name,
     app.id,
+    clusterId,
   ),
 ];
 
-export const applicationsFields = (applications, sourceType, appTypes, hcsEnrolled) => [
+export const applicationsFields = (applications, sourceType, appTypes, hcsEnrolled, clusterId) => [
   {
     component: componentTypes.TABS,
     name: 'app-tabs',
@@ -40,7 +41,7 @@ export const applicationsFields = (applications, sourceType, appTypes, hcsEnroll
       ...applications.map((app) => {
         const appType = appTypes.find(({ id }) => id === app.application_type_id);
 
-        let fields = createOneAppFields(appType, sourceType, app);
+        let fields = createOneAppFields(appType, sourceType, app, clusterId);
 
         const hasEndpoint = app.authentications.find(({ resource_type }) => resource_type === 'Endpoint');
 

--- a/src/components/SourceEditForm/parser/authentication.js
+++ b/src/components/SourceEditForm/parser/authentication.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import get from 'lodash/get';
 import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
+import { COST_MANAGEMENT_APP_NAME } from '../../../utilities/constants';
 import { FormattedMessage } from 'react-intl';
 import { doLoadRegions } from '../../../api/doLoadRegions';
 import hardcodedSchemas from '../../../components/addSourceWizard/hardcodedSchemas';
+import { MANUAL_CONFIGURATION } from '../../constants';
 
 export const createAuthFieldName = (fieldName, id) => `authentications.a${id}.${fieldName.replace('authentication.', '')}`;
 
@@ -25,7 +27,7 @@ export const getAdditionalAuthStepsKeys = (sourceType, authtype, appName = 'gene
 
 export const getAdditionalFields = (auth, stepKey) => auth?.fields?.filter((field) => stepKey && field.stepKey === stepKey) || [];
 
-export const modifyAuthSchemas = (fields, id, appId) =>
+export const modifyAuthSchemas = (fields, id, appId, useOpenShiftOperatorException) =>
   fields.map((field) => {
     let editedName = field.name.startsWith('authentication')
       ? createAuthFieldName(field.name, id)
@@ -41,6 +43,7 @@ export const modifyAuthSchemas = (fields, id, appId) =>
     const isPassword = getLastPartOfName(finalField.name) === 'password';
     const isAwsRegion = getLastPartOfName(finalField.name) === 'bucket_region' && finalField.label.includes('AWS');
     const isExternalId = getLastPartOfName(finalField.name) === 'external_id';
+    const isClusterId = getLastPartOfName(finalField.name) === 'source_ref';
 
     if (isPassword) {
       finalField.component = 'authentication';
@@ -57,15 +60,29 @@ export const modifyAuthSchemas = (fields, id, appId) =>
       finalField.isReadOnly = true;
     }
 
+    if (isClusterId && useOpenShiftOperatorException) {
+      finalField.isDisabled = true;
+      finalField.helperText = 'Value cannot be modified since it has been set using the API';
+    }
+
     return finalField;
   });
 
-export const authenticationFields = (authentications, sourceType, appName, appId) => {
-  if (!authentications || authentications.length === 0 || !sourceType.schema || !sourceType.schema.authentication) {
+export const authenticationFields = (authentications, sourceType, appName, appId, clusterId) => {
+  let auths = authentications;
+
+  // programically adding authentication as an exception for sources defined using the CostManagementMetricsOperator - see RHCLOUD-27445
+  let useOpenShiftOperatorException =
+    (auths || auths.length === 0) && appName === COST_MANAGEMENT_APP_NAME && clusterId?.length > 0;
+  if (useOpenShiftOperatorException) {
+    auths = [{ authtype: 'token' }];
+  }
+
+  if (!auths || auths.length === 0 || !sourceType.schema || !sourceType.schema.authentication) {
     return [];
   }
 
-  return authentications.map((auth) => {
+  return auths.map((auth) => {
     const schemaAuth = sourceType?.schema?.authentication?.find(({ type }) => type === auth.authtype);
 
     if (!schemaAuth) {
@@ -93,6 +110,6 @@ export const authenticationFields = (authentications, sourceType, appName, appId
         ...getEnhancedAuthField(sourceType.name, auth.authtype, field.name, appName),
       }));
 
-    return modifyAuthSchemas(enhancedFields, auth.id, appId);
+    return modifyAuthSchemas(enhancedFields, auth.id, appId, useOpenShiftOperatorException);
   });
 };

--- a/src/components/SourceEditForm/parser/authentication.js
+++ b/src/components/SourceEditForm/parser/authentication.js
@@ -5,7 +5,6 @@ import { COST_MANAGEMENT_APP_NAME } from '../../../utilities/constants';
 import { FormattedMessage } from 'react-intl';
 import { doLoadRegions } from '../../../api/doLoadRegions';
 import hardcodedSchemas from '../../../components/addSourceWizard/hardcodedSchemas';
-import { MANUAL_CONFIGURATION } from '../../constants';
 
 export const createAuthFieldName = (fieldName, id) => `authentications.a${id}.${fieldName.replace('authentication.', '')}`;
 

--- a/src/components/SourceEditForm/parser/parseSourceToSchema.js
+++ b/src/components/SourceEditForm/parser/parseSourceToSchema.js
@@ -5,5 +5,5 @@ export const parseSourceToSchema = (source, sourceType, appTypes, intl, hcsEnrol
     id: 'sources.editFormDescripiton',
     defaultMessage: 'Use the form fields to edit application credentials.',
   }),
-  fields: applicationsFields(source.applications, sourceType, appTypes, hcsEnrolled),
+  fields: applicationsFields(source.applications, sourceType, appTypes, hcsEnrolled, source?.source?.source_ref),
 });

--- a/src/test/components/sourceEditForm/parser/parseSourceToSchema.test.js
+++ b/src/test/components/sourceEditForm/parser/parseSourceToSchema.test.js
@@ -40,6 +40,6 @@ describe('parseSourceToSchema', () => {
   it('calls all subsections', () => {
     parseSourceToSchema(SOURCE, SOURCE_TYPE, APP_TYPES, INTL, false);
 
-    expect(app.applicationsFields).toHaveBeenCalledWith(SOURCE.applications, SOURCE_TYPE, APP_TYPES, false);
+    expect(app.applicationsFields).toHaveBeenCalledWith(SOURCE.applications, SOURCE_TYPE, APP_TYPES, false, undefined);
   });
 });


### PR DESCRIPTION
Fixes [RHCLOUD-27445](https://issues.redhat.com/browse/RHCLOUD-27445)

![image](https://github.com/RedHatInsights/sources-ui/assets/50696716/693f72a7-f2f9-425c-94ea-600201acd8f2)


Problem:
"The CostManagementMetricsOperator can create OCP sources via the API. The operator uses a relatively old API flow, but the source creation and integration with cost-management works just fine. However, the cluster-id for those sources is missing in the Sources UI."

Solution:
Added an exception to the process of generating an edit form which shows the the previously not visible field in a disabled state together with a helper text.