### PR TITLE
Accept category query param

### DIFF
--- a/src/components/addSourceWizard/stringConstants.js
+++ b/src/components/addSourceWizard/stringConstants.js
@@ -22,3 +22,4 @@ export const wizardTitle = (activeCategory) =>
   );
 export const HCCM_DOCS_PREFIX = 'https://access.redhat.com/documentation/en-us/cost_management_service/2023';
 export const HCCM_LATEST_DOCS_PREFIX = 'https://access.redhat.com/documentation/en-us/cost_management_service/1-latest';
+export const NO_APPLICATION_VALUE = 'no-application';

--- a/src/utilities/store.js
+++ b/src/utilities/store.js
@@ -35,14 +35,13 @@ export const getStore = (addMiddlewares = [], initialState = {}) => {
   const params = parseQuery();
 
   const registry = new ReducerRegistry({}, middlewares);
-
   registry.register({
     sources: applyReducerHash(SourcesReducer, {
       ...defaultSourcesState,
       ...initialState.sources,
       activeCategory: [CLOUD_VENDOR, REDHAT_VENDOR, COMMUNICATIONS, REPORTING, WEBHOOKS].includes(params?.activeCategory)
         ? params.activeCategory
-        : CLOUD_VENDOR,
+        : initialState.sources?.activeCategory || defaultSourcesState?.activeCategory || CLOUD_VENDOR,
     }),
   });
   registry.register({ user: applyReducerHash(UserReducer, { ...defaultUserState, ...initialState.user }) });

--- a/src/utilities/store.js
+++ b/src/utilities/store.js
@@ -40,7 +40,7 @@ export const getStore = (addMiddlewares = [], initialState = {}) => {
     sources: applyReducerHash(SourcesReducer, {
       ...defaultSourcesState,
       ...initialState.sources,
-      activeCategory: [CLOUD_VENDOR, REDHAT_VENDOR, COMMUNICATIONS, REPORTING, WEBHOOKS].includes(params.activeCategory)
+      activeCategory: [CLOUD_VENDOR, REDHAT_VENDOR, COMMUNICATIONS, REPORTING, WEBHOOKS].includes(params?.activeCategory)
         ? params.activeCategory
         : CLOUD_VENDOR,
     }),

--- a/src/utilities/store.js
+++ b/src/utilities/store.js
@@ -6,9 +6,9 @@ import promise from 'redux-promise-middleware';
 
 import SourcesReducer, { defaultSourcesState } from '../redux/sources/reducer';
 import UserReducer, { defaultUserState } from '../redux/user/reducer';
-import { updateQuery } from './urlQuery';
+import { parseQuery, updateQuery } from './urlQuery';
 import { ACTION_TYPES, SET_CATEGORY } from '../redux/sources/actionTypes';
-import { INTEGRATIONS } from './constants';
+import { CLOUD_VENDOR, COMMUNICATIONS, INTEGRATIONS, REDHAT_VENDOR, REPORTING, WEBHOOKS } from './constants';
 
 export const urlQueryMiddleware = (store) => (next) => (action) => {
   if (action.type === ACTION_TYPES.LOAD_ENTITIES_PENDING) {
@@ -32,11 +32,18 @@ export const getStore = (addMiddlewares = [], initialState = {}) => {
     urlQueryMiddleware,
     ...addMiddlewares,
   ];
+  const params = parseQuery();
 
   const registry = new ReducerRegistry({}, middlewares);
 
   registry.register({
-    sources: applyReducerHash(SourcesReducer, { ...defaultSourcesState, ...initialState.sources }),
+    sources: applyReducerHash(SourcesReducer, {
+      ...defaultSourcesState,
+      ...initialState.sources,
+      activeCategory: [CLOUD_VENDOR, REDHAT_VENDOR, COMMUNICATIONS, REPORTING, WEBHOOKS].includes(params.activeCategory)
+        ? params.activeCategory
+        : CLOUD_VENDOR,
+    }),
   });
   registry.register({ user: applyReducerHash(UserReducer, { ...defaultUserState, ...initialState.user }) });
   registry.register({ notifications: notificationsReducer });

--- a/src/utilities/urlQuery.js
+++ b/src/utilities/urlQuery.js
@@ -1,7 +1,7 @@
 import { restFilterGenerator } from '../api/entities';
 import { AVAILABLE, UNAVAILABLE } from '../views/formatters';
 import { sourcesColumns } from '../views/sourcesViewDefinition';
-import { CLOUD_VENDOR, INTEGRATIONS, REDHAT_VENDOR } from './constants';
+import { CLOUD_VENDOR, COMMUNICATIONS, REDHAT_VENDOR, REPORTING, WEBHOOKS } from './constants';
 
 export const updateQuery = ({ sortBy, sortDirection, pageNumber, pageSize, filterValue, activeCategory, removeQuery }) => {
   const sortQuery = `sort_by[]=${sortBy}:${sortDirection}`;
@@ -26,10 +26,12 @@ export const loadEnhancedAttributes = (params) => {
 
   const applications = urlParams.getAll('application');
   const types = urlParams.getAll('type');
+  const category = urlParams.getAll('category');
 
   return {
     applications: applications.length && applications,
     types: types.length && types,
+    category,
   };
 };
 
@@ -150,7 +152,7 @@ export const parseQuery = (getState) => {
 
   const activeCategory = urlParams.get('category') || urlParams.get('activeVendor');
 
-  if (activeCategory === CLOUD_VENDOR || activeCategory === REDHAT_VENDOR || activeCategory === INTEGRATIONS) {
+  if ([CLOUD_VENDOR, REDHAT_VENDOR, COMMUNICATIONS, REPORTING, WEBHOOKS].includes(activeCategory)) {
     fetchOptions = {
       ...fetchOptions,
       activeCategory,


### PR DESCRIPTION
Fixes [RHCLOUD-30764](https://issues.redhat.com/browse/RHCLOUD-30764)

![chrome-capture-2024-2-2](https://github.com/RedHatInsights/sources-ui/assets/50696716/8f08797d-c4c1-4ed6-aae3-d674ab64a339)

- made integrations tabs accept the category
- merge of [RHCLOUD-30785](https://issues.redhat.com/browse/RHCLOUD-30785) is needed to display the empty states properly\
- added missing NO_APPLICATION_VALUE per warning in the console