### PR TITLE
Allow users with read permissions to view Integrations tabs

### DIFF
--- a/src/components/PermissionsChecker.js
+++ b/src/components/PermissionsChecker.js
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
-import { loadOrgAdmin, loadWritePermissions } from '../redux/user/actions';
+import { loadOrgAdmin, loadReadIntegrationsEndpointsPermissions, loadWritePermissions } from '../redux/user/actions';
 
 const PermissionsChecker = ({ children }) => {
   const dispatch = useDispatch();
@@ -12,7 +12,11 @@ const PermissionsChecker = ({ children }) => {
   } = useChrome();
 
   useEffect(() => {
-    Promise.all([dispatch(loadWritePermissions(getUserPermissions)), dispatch(loadOrgAdmin(getUser))]);
+    Promise.all([
+      dispatch(loadWritePermissions(getUserPermissions)),
+      dispatch(loadOrgAdmin(getUser)),
+      dispatch(loadReadIntegrationsEndpointsPermissions(getUserPermissions)),
+    ]);
   }, []);
 
   return children;

--- a/src/components/TabNavigation.js
+++ b/src/components/TabNavigation.js
@@ -17,6 +17,7 @@ const TabNavigation = () => {
   const enableIntegrations = useFlag('platform.sources.integrations');
   const enableBreakdown = useFlag('platform.sources.integrations.breakdown');
   const isOrgAdmin = useSelector(({ user }) => user.isOrgAdmin);
+  const hasReadPermissions = useSelector(({ user }) => user?.readIntegrationsEndpointsPermissions);
 
   return (
     <Tabs activeKey={activeCategory} onSelect={(_e, key) => dispatch(setActiveCategory(key))} className="pf-v5-u-mt-md">
@@ -52,7 +53,7 @@ const TabNavigation = () => {
           </React.Fragment>
         }
       />
-      {isOrgAdmin &&
+      {(isOrgAdmin || hasReadPermissions) &&
         (enableIntegrations || enableBreakdown) &&
         (enableBreakdown ? (
           <>

--- a/src/redux/user/actionTypes.js
+++ b/src/redux/user/actionTypes.js
@@ -1,4 +1,4 @@
-export const ACTION_TYPES = ['SET_WRITE_PERMISSIONS', 'SET_ORG_ADMIN'].reduce(
+export const ACTION_TYPES = ['SET_WRITE_PERMISSIONS', 'SET_ORG_ADMIN', 'SET_READ_INTEGRATIONS_ENDPOINTS_PERMISSIONS'].reduce(
   (acc, curr) => ({
     ...acc,
     [curr]: curr,

--- a/src/redux/user/actions.js
+++ b/src/redux/user/actions.js
@@ -26,6 +26,33 @@ export const loadWritePermissions = (getUserPermissions) => (dispatch) => {
     );
 };
 
+export const loadReadIntegrationsEndpointsPermissions = (getUserPermissions) => (dispatch) => {
+  dispatch({ type: ACTION_TYPES.SET_READ_INTEGRATIONS_ENDPOINTS_PERMISSIONS_PENDING });
+
+  return getUserPermissions('integrations', true) // bypassCache = true
+    .then((permissions) => {
+      const allPermission = permissions.reduce((acc, curr) => [...acc, curr?.permission], []);
+      const readIntegrationsEndpointsPermissions =
+        allPermission.includes('integrations:*:*') || allPermission.includes('integrations:endpoints:read');
+
+      dispatch({
+        type: ACTION_TYPES.SET_READ_INTEGRATIONS_ENDPOINTS_PERMISSIONS_FULFILLED,
+        payload: readIntegrationsEndpointsPermissions,
+      });
+    })
+    .catch((error) =>
+      dispatch({
+        type: ACTION_TYPES.SET_READ_INTEGRATIONS_ENDPOINTS_PERMISSIONS_REJECTED,
+        payload: {
+          error: {
+            detail: error.detail || error.data,
+            title: "Cannot get user's credentials",
+          },
+        },
+      }),
+    );
+};
+
 export const loadOrgAdmin = (getUser) => (dispatch) => {
   dispatch({ type: ACTION_TYPES.SET_ORG_ADMIN_PENDING });
 

--- a/src/redux/user/actions.js
+++ b/src/redux/user/actions.js
@@ -31,7 +31,7 @@ export const loadReadIntegrationsEndpointsPermissions = (getUserPermissions) => 
 
   return getUserPermissions('integrations', true) // bypassCache = true
     .then((permissions) => {
-      const allPermission = permissions.reduce((acc, curr) => [...acc, curr?.permission], []);
+      const allPermission = permissions.map((curr) => curr?.permission);
       const readIntegrationsEndpointsPermissions =
         allPermission.includes('integrations:*:*') || allPermission.includes('integrations:endpoints:read');
 

--- a/src/redux/user/reducer.js
+++ b/src/redux/user/reducer.js
@@ -2,6 +2,7 @@ import { ACTION_TYPES } from './actionTypes';
 
 export const defaultUserState = {
   writePermissions: undefined,
+  readIntegrationsEndpointsPermissions: undefined,
   isOrgAdmin: undefined,
 };
 
@@ -25,6 +26,16 @@ export const isOrgAdminLoaded = (state, { payload: isOrgAdmin }) => ({
   isOrgAdmin,
 });
 
+export const readIntegrationsEndpointsPermissionsPending = (state) => ({
+  ...state,
+  readIntegrationsEndpointsPermissions: undefined,
+});
+
+export const readIntegrationsEndpointsPermissionsLoaded = (state, { payload: readIntegrationsEndpointsPermissions }) => ({
+  ...state,
+  readIntegrationsEndpointsPermissions,
+});
+
 export default {
   [ACTION_TYPES.SET_WRITE_PERMISSIONS_PENDING]: writePermissionsPending,
   [ACTION_TYPES.SET_WRITE_PERMISSIONS_FULFILLED]: writePermissionsLoaded,
@@ -32,4 +43,7 @@ export default {
   [ACTION_TYPES.SET_ORG_ADMIN_PENDING]: isOrgAdminPending,
   [ACTION_TYPES.SET_ORG_ADMIN_FULFILLED]: isOrgAdminLoaded,
   [ACTION_TYPES.SET_ORG_ADMIN_REJECTED]: isOrgAdminPending,
+  [ACTION_TYPES.SET_READ_INTEGRATIONS_ENDPOINTS_PERMISSIONS_PENDING]: readIntegrationsEndpointsPermissionsPending,
+  [ACTION_TYPES.SET_READ_INTEGRATIONS_ENDPOINTS_PERMISSIONS_FULFILLED]: readIntegrationsEndpointsPermissionsLoaded,
+  [ACTION_TYPES.SET_READ_INTEGRATIONS_ENDPOINTS_PERMISSIONS_REJECTED]: readIntegrationsEndpointsPermissionsPending,
 };

--- a/src/test/components/PermissionsChecker.test.js
+++ b/src/test/components/PermissionsChecker.test.js
@@ -9,6 +9,7 @@ describe('PermissionChecker', () => {
     const Children = () => <h1>App</h1>;
     actions.loadWritePermissions = jest.fn().mockImplementation(() => ({ type: 'type' }));
     actions.loadOrgAdmin = jest.fn().mockImplementation(() => ({ type: 'type' }));
+    actions.loadReadIntegrationsEndpointsPermissions = jest.fn().mockImplementation(() => ({ type: 'type' }));
 
     render(
       componentWrapperIntl(

--- a/src/test/redux/user/actions.test.js
+++ b/src/test/redux/user/actions.test.js
@@ -1,4 +1,4 @@
-import { loadOrgAdmin, loadWritePermissions } from '../../../redux/user/actions';
+import { loadOrgAdmin, loadReadIntegrationsEndpointsPermissions, loadWritePermissions } from '../../../redux/user/actions';
 import { ACTION_TYPES } from '../../../redux/user/actionTypes';
 
 describe('user reducer actions', () => {
@@ -191,6 +191,82 @@ describe('user reducer actions', () => {
       });
       expect(dispatch.mock.calls[1][0]).toEqual({
         type: ACTION_TYPES.SET_ORG_ADMIN_REJECTED,
+        payload: { error: { detail: ERROR.data, title: expect.any(String) } },
+      });
+    });
+  });
+
+  describe('loadReadIntegrationsEndpointsPermissions', () => {
+    let getUserPermissions;
+
+    it('has read integrations endpoints permissions', async () => {
+      getUserPermissions = jest.fn().mockImplementation(() => Promise.resolve([{ permission: 'integrations:endpoints:read' }]));
+
+      await loadReadIntegrationsEndpointsPermissions(getUserPermissions)(dispatch);
+
+      expect(dispatch.mock.calls.length).toEqual(2);
+
+      expect(dispatch.mock.calls[0][0]).toEqual({
+        type: ACTION_TYPES.SET_READ_INTEGRATIONS_ENDPOINTS_PERMISSIONS_PENDING,
+      });
+      expect(dispatch.mock.calls[1][0]).toEqual({
+        type: ACTION_TYPES.SET_READ_INTEGRATIONS_ENDPOINTS_PERMISSIONS_FULFILLED,
+        payload: true,
+      });
+    });
+
+    it('does not have read integrations endpoints permissions', async () => {
+      getUserPermissions = jest.fn().mockImplementation(() => Promise.resolve([]));
+
+      await loadReadIntegrationsEndpointsPermissions(getUserPermissions)(dispatch);
+
+      expect(dispatch.mock.calls.length).toEqual(2);
+
+      expect(dispatch.mock.calls[0][0]).toEqual({
+        type: ACTION_TYPES.SET_READ_INTEGRATIONS_ENDPOINTS_PERMISSIONS_PENDING,
+      });
+      expect(dispatch.mock.calls[1][0]).toEqual({
+        type: ACTION_TYPES.SET_READ_INTEGRATIONS_ENDPOINTS_PERMISSIONS_FULFILLED,
+        payload: false,
+      });
+    });
+
+    it('rejected', async () => {
+      const ERROR = {
+        detail: 'detail',
+      };
+
+      getUserPermissions = jest.fn().mockImplementation(() => Promise.reject(ERROR));
+
+      await loadReadIntegrationsEndpointsPermissions(getUserPermissions)(dispatch);
+
+      expect(dispatch.mock.calls.length).toEqual(2);
+
+      expect(dispatch.mock.calls[0][0]).toEqual({
+        type: ACTION_TYPES.SET_READ_INTEGRATIONS_ENDPOINTS_PERMISSIONS_PENDING,
+      });
+      expect(dispatch.mock.calls[1][0]).toEqual({
+        type: ACTION_TYPES.SET_READ_INTEGRATIONS_ENDPOINTS_PERMISSIONS_REJECTED,
+        payload: { error: { detail: ERROR.detail, title: expect.any(String) } },
+      });
+    });
+
+    it('rejected with data', async () => {
+      const ERROR = {
+        data: 'detail',
+      };
+
+      getUserPermissions = jest.fn().mockImplementation(() => Promise.reject(ERROR));
+
+      await loadReadIntegrationsEndpointsPermissions(getUserPermissions)(dispatch);
+
+      expect(dispatch.mock.calls.length).toEqual(2);
+
+      expect(dispatch.mock.calls[0][0]).toEqual({
+        type: ACTION_TYPES.SET_READ_INTEGRATIONS_ENDPOINTS_PERMISSIONS_PENDING,
+      });
+      expect(dispatch.mock.calls[1][0]).toEqual({
+        type: ACTION_TYPES.SET_READ_INTEGRATIONS_ENDPOINTS_PERMISSIONS_REJECTED,
         payload: { error: { detail: ERROR.data, title: expect.any(String) } },
       });
     });


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUD-XXXXXX link (if proposed change involves tracked issue or story) -->
Update the `/settings/integrations` page so that the Communications, Reporting and Automation, and Webhooks tabs are visible for users with `integrations:endpoints:read` or `integrations:*:*` permissions instead of only Org Admins.

[RHCLOUD-30431](https://issues.redhat.com/browse/RHCLOUD-30431)

(Merge only after https://github.com/RedHatInsights/notifications-frontend/pull/543 is merged)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
![image](https://github.com/RedHatInsights/sources-ui/assets/39098327/684fc702-9ef7-4c03-a194-e88c26fdb3b3)

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##