### PR TITLE
Update OCI integrations wizard to use new RH managed OCI tenant

### DIFF
--- a/src/components/addSourceWizard/hardcodedComponents/oci/costManagement.js
+++ b/src/components/addSourceWizard/hardcodedComponents/oci/costManagement.js
@@ -94,7 +94,7 @@ export const PolicyCompartment = ({ fields }) => {
             defaultMessage: 'Create cost and usage reports policy using the following command',
           })}
           <ClipboardCopy className="pf-v5-u-mt-sm" variant={ClipboardCopyVariant.expansion}>
-            {`oci iam policy create --compartment-id ${values?.application?.extra?.compartment_id} --description "test" --name "test" --statements '["define tenancy usage-report as ocid1.tenancy.oc1..aaaaaaaaned4fkpkisbwjlr56u7cj63lf3wffbilvqknstgtvzub7vhqkggq","endorse group Administrators to read objects in tenancy usage-report"]'`}
+            {`oci iam policy create --compartment-id ${values?.application?.extra?.compartment_id} --description "test" --name "test" --statements '["define tenancy usage-report as ocid1.tenancy.oc1..aaaaaaaayikwwnfeirfik6fwqdt5rfjfajmwjuj5u34vkbpao5u6hohucnsa","endorse group Administrators to read objects in tenancy usage-report"]'`}
           </ClipboardCopy>
         </TextListItem>
         <TextListItem className="pf-v5-u-mb-lg">

--- a/src/components/addSourceWizard/hardcodedComponents/oci/costManagement.js
+++ b/src/components/addSourceWizard/hardcodedComponents/oci/costManagement.js
@@ -94,7 +94,7 @@ export const PolicyCompartment = ({ fields }) => {
             defaultMessage: 'Create cost and usage reports policy using the following command',
           })}
           <ClipboardCopy className="pf-v5-u-mt-sm" variant={ClipboardCopyVariant.expansion}>
-            {`oci iam policy create --compartment-id ${values?.application?.extra?.compartment_id} --description "test" --name "test" --statements '["define tenancy usage-report as ocid1.tenancy.oc1..aaaaaaaayikwwnfeirfik6fwqdt5rfjfajmwjuj5u34vkbpao5u6hohucnsa","endorse group Administrators to read objects in tenancy usage-report"]'`}
+            {`oci iam policy create --compartment-id ${values?.application?.extra?.compartment_id} --description "test" --name "test" --statements '["define tenancy usage-report as ocid1.tenancy.oc1..aaaaaaaaned4fkpkisbwjlr56u7cj63lf3wffbilvqknstgtvzub7vhqkggq","endorse group Administrators to read objects in tenancy usage-report"]'`}
           </ClipboardCopy>
         </TextListItem>
         <TextListItem className="pf-v5-u-mb-lg">
@@ -216,7 +216,7 @@ export const PopulateBucket = () => {
             defaultMessage: 'In your Oracle Cloud shell, create this read policy for the new bucket',
           })}
           <ClipboardCopy className="pf-v5-u-mt-sm" variant={ClipboardCopyVariant.expansion}>
-            {`oci iam policy create --compartment-id ${values?.application?.extra?.compartment_id} --description 'Grant cost management bucket read access' --name Cost-managment-bucket-read --statements '["Define tenancy SourceTenancy as ocid1.tenancy.oc1..aaaaaaaa7bmeqn34urxue57x75fg4nlzh4w6ttjxckhaue2itbefeen2gdma","Define group StorageAdmins as ocid1.group.oc1..aaaaaaaamwx3swyherxtnvtq3vjmcflmteojw6lxf5i6bgwjygq642a2ejpa","Admit group StorageAdmins of tenancy SourceTenancy to read objects in tenancy"]'`}
+            {`oci iam policy create --compartment-id ${values?.application?.extra?.compartment_id} --description 'Grant cost management bucket read access' --name Cost-managment-bucket-read --statements '["Define tenancy SourceTenancy as ocid1.tenancy.oc1..aaaaaaaayikwwnfeirfik6fwqdt5rfjfajmwjuj5u34vkbpao5u6hohucnsa","Define group StorageAdmins as ocid1.group.oc1..aaaaaaaaodcwqk362uyloxbzocfhufwihjxybten5h6xbqk3vlzgcnbmelpq","Admit group StorageAdmins of tenancy SourceTenancy to read objects in tenancy"]'`}
           </ClipboardCopy>
         </TextListItem>
       </TextList>

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/cost_management_oracle.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/cost_management_oracle.test.js
@@ -134,7 +134,7 @@ describe('Cost Management Oracle steps components', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('In your Oracle Cloud shell, create this read policy for the new bucket')).toBeInTheDocument();
     expect(screen.getByLabelText('Copyable input')).toHaveValue(
-      `oci iam policy create --compartment-id compartment-id --description 'Grant cost management bucket read access' --name Cost-managment-bucket-read --statements '["Define tenancy SourceTenancy as ocid1.tenancy.oc1..aaaaaaaa7bmeqn34urxue57x75fg4nlzh4w6ttjxckhaue2itbefeen2gdma","Define group StorageAdmins as ocid1.group.oc1..aaaaaaaamwx3swyherxtnvtq3vjmcflmteojw6lxf5i6bgwjygq642a2ejpa","Admit group StorageAdmins of tenancy SourceTenancy to read objects in tenancy"]'`,
+      `oci iam policy create --compartment-id compartment-id --description 'Grant cost management bucket read access' --name Cost-managment-bucket-read --statements '["Define tenancy SourceTenancy as ocid1.tenancy.oc1..aaaaaaaayikwwnfeirfik6fwqdt5rfjfajmwjuj5u34vkbpao5u6hohucnsa","Define group StorageAdmins as ocid1.group.oc1..aaaaaaaaodcwqk362uyloxbzocfhufwihjxybten5h6xbqk3vlzgcnbmelpq","Admit group StorageAdmins of tenancy SourceTenancy to read objects in tenancy"]'`,
     );
   });
 });


### PR DESCRIPTION
### Description
This Change updates the integrations wizard for Cost Management with regards to which tenant to use for endorsing policies. Recently we switched our Payer account to the new RH managed account.

[COST-4880)](https://issues.redhat.com/browse/COST-4880)

---

### Screenshots
#### Before:
![image](https://github.com/RedHatInsights/sources-ui/assets/18352403/479e8300-5eab-4d87-9edf-c9ff1d569041)


#### After:
The same as above but with the new tenant ID and Storage account ID
---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
