### PR TITLE
hccdoc-2342 Neutral filenames, CUR>data export, and OCI link fix

### DIFF
--- a/src/components/addSourceWizard/hardcodedComponents/aws/arn.js
+++ b/src/components/addSourceWizard/hardcodedComponents/aws/arn.js
@@ -102,7 +102,7 @@ export const UsageDescription = ({ showHCS }) => {
           {
             id: 'cost.usageDescription.usageDescription',
             defaultMessage:
-              "The information {application} would need is your AWS account's cost and usage report (CUR). If there is a need to further customize the CUR you want to send to {application}, select the manually customize option and follow the special instructions on how to.",
+              "The information {application} would need is your AWS account's data export. If there is a need to further customize the data export you want to send to {application}, select the manually customize option and follow the special instructions on how to.",
           },
           {
             application,

--- a/src/components/addSourceWizard/hardcodedComponents/azure/costManagement.js
+++ b/src/components/addSourceWizard/hardcodedComponents/azure/costManagement.js
@@ -29,12 +29,12 @@ import { HCS_APP_NAME } from '../../../../utilities/constants';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 
 const CREATE_AZURE_STORAGE = `${HCCM_LATEST_DOCS_PREFIX}/html-single/integrating_microsoft_azure_data_into_cost_management/index#creating-an-azure-storage-account_adding-an-azure-int`;
-const CREATE_HCS_AZURE_STORAGE = `${HCS_LATEST_DOCS_PREFIX}/html/integrating_microsoft_azure_data_into_hybrid_committed_spend/assembly-adding-azure-int-hcs#creating-an-azure-storage-account-hcs_adding-an-azure-int-hcs`;
+const CREATE_HCS_AZURE_STORAGE = `${HCS_LATEST_DOCS_PREFIX}/html/integrating_microsoft_azure_data_into_hybrid_committed_spend/assembly-adding-azure-int-hcs#creating-an-azure-storage-account-filtered_adding-an-azure-int-hcs`;
 const AZURE_CREDS_URL = `${HCCM_LATEST_DOCS_PREFIX}/html-single/integrating_microsoft_azure_data_into_cost_management/index#configuring-azure-roles_adding-an-azure-int`;
 const AZURE_HCS_CREDS_URL = `${HCS_LATEST_DOCS_PREFIX}/html/integrating_microsoft_azure_data_into_hybrid_committed_spend/assembly-adding-azure-int-hcs#configuring-azure-roles-hcs_adding-an-azure-int-hcs`;
 const AZURE_ROLES_URL = `${HCCM_LATEST_DOCS_PREFIX}/html-single/integrating_microsoft_azure_data_into_cost_management/index#configuring-azure-roles_adding-an-azure-int`;
-const RECURRING_TASK_URL = `${HCCM_LATEST_DOCS_PREFIX}/html-single/integrating_microsoft_azure_data_into_cost_management/index#creating-daily-export-azure-hcs_adding-filtered-azure-int`;
-const RECURRING_HCS_TASK_URL = `${HCS_LATEST_DOCS_PREFIX}/html/integrating_microsoft_azure_data_into_hybrid_committed_spend/assembly-adding-filtered-azure-int-hcs#creating-function-filter-azure-hcs_adding-filtered-azure-int-hcs`;
+const RECURRING_TASK_URL = `${HCCM_LATEST_DOCS_PREFIX}/html-single/integrating_microsoft_azure_data_into_cost_management/index#creating-daily-export-azure_adding-filtered-azure-int`;
+const RECURRING_HCS_TASK_URL = `${HCS_LATEST_DOCS_PREFIX}/html/integrating_microsoft_azure_data_into_hybrid_committed_spend/assembly-adding-filtered-azure-int-hcs#creating-function-filter-azure_adding-filtered-azure-int-hcs`;
 export const MANUAL_CUR_STEPS = `${HCCM_LATEST_DOCS_PREFIX}/html-single/integrating_microsoft_azure_data_into_cost_management/index#choosing-azure-cost-export-scope_adding-an-azure-int`;
 
 export const ConfigureResourceGroupAndStorageAccount = () => {

--- a/src/components/addSourceWizard/hardcodedComponents/oci/costManagement.js
+++ b/src/components/addSourceWizard/hardcodedComponents/oci/costManagement.js
@@ -202,11 +202,10 @@ export const PopulateBucket = () => {
         <TextListItem className="pf-v5-u-mb-lg">
           {intl.formatMessage({
             id: 'cost.oci.populateBucket.subtitle1',
-            defaultMessage:
-              'In your Oracle Cloud account, create a VM and run a script similar to the one from this github repository:',
+            defaultMessage: 'In your Oracle Cloud account, create a VM and run a script provided in the documentation:',
           })}
           <a className="pf-v5-u-mt-md pf-v5-u-display-block" href={CREATE_OCI_SCRIPT} target="_blank" rel="noreferrer">
-            {CREATE_OCI_SCRIPT}
+            Replicating reports to a bucket
             <i className="pf-v5-u-ml-xs fas fa-external-link-alt pf-v5-u-font-size-xs"></i>
           </a>
         </TextListItem>

--- a/src/components/addSourceWizard/hardcodedSchemas.js
+++ b/src/components/addSourceWizard/hardcodedSchemas.js
@@ -160,7 +160,7 @@ const getArn = (authUsername, showHCS) => ({
               label: (
                 <FormattedMessage
                   id="cost.arn.sendDefaultCUR"
-                  defaultMessage="I am OK with sending the default CUR to Cost Management"
+                  defaultMessage="I am OK with sending the default data export to Cost Management"
                 />
               ),
               value: false,
@@ -170,7 +170,7 @@ const getArn = (authUsername, showHCS) => ({
                 <span>
                   <FormattedMessage
                     id="cost.arn.customizeCUR"
-                    defaultMessage="I wish to manually customize the CUR sent to Cost Management"
+                    defaultMessage="I wish to manually customize the data export sent to Cost Management"
                   />{' '}
                   <Popover
                     aria-label="Help text"

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/arn.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/arn.test.js
@@ -242,7 +242,7 @@ describe('AWS-ARN hardcoded schemas', () => {
 
     expect(
       screen.getByText(
-        "The information Cost Management would need is your AWS account's cost and usage report (CUR). If there is a need to further customize the CUR you want to send to Cost Management, select the manually customize option and follow the special instructions on how to.",
+        "The information Cost Management would need is your AWS account's data export. If there is a need to further customize the data export you want to send to Cost Management, select the manually customize option and follow the special instructions on how to.",
       ),
     ).toBeInTheDocument();
   });
@@ -252,7 +252,7 @@ describe('AWS-ARN hardcoded schemas', () => {
 
     expect(
       screen.getByText(
-        `The information ${HCS_APP_NAME} would need is your AWS account's cost and usage report (CUR). If there is a need to further customize the CUR you want to send to ${HCS_APP_NAME}, select the manually customize option and follow the special instructions on how to.`,
+        `The information ${HCS_APP_NAME} would need is your AWS account's data export. If there is a need to further customize the data export you want to send to ${HCS_APP_NAME}, select the manually customize option and follow the special instructions on how to.`,
       ),
     ).toBeInTheDocument();
   });

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/cost_management_oracle.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/cost_management_oracle.test.js
@@ -123,15 +123,9 @@ describe('Cost Management Oracle steps components', () => {
       ),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(
-        'In your Oracle Cloud account, create a VM and run a script similar to the one from this github repository:',
-      ),
+      screen.getByText('In your Oracle Cloud account, create a VM and run a script provided in the documentation:'),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        'https://access.redhat.com/documentation/en-us/cost_management_service/1-latest/html/integrating_oracle_cloud_data_into_cost_management/assembly-adding-oci-int#create-oci-script_adding-oci-int',
-      ),
-    ).toBeInTheDocument();
+    expect(screen.getByText('Replicating reports to a bucket')).toBeInTheDocument();
     expect(screen.getByText('In your Oracle Cloud shell, create this read policy for the new bucket')).toBeInTheDocument();
     expect(screen.getByLabelText('Copyable input')).toHaveValue(
       `oci iam policy create --compartment-id compartment-id --description 'Grant cost management bucket read access' --name Cost-managment-bucket-read --statements '["Define tenancy SourceTenancy as ocid1.tenancy.oc1..aaaaaaaayikwwnfeirfik6fwqdt5rfjfajmwjuj5u34vkbpao5u6hohucnsa","Define group StorageAdmins as ocid1.group.oc1..aaaaaaaaodcwqk362uyloxbzocfhufwihjxybten5h6xbqk3vlzgcnbmelpq","Admit group StorageAdmins of tenancy SourceTenancy to read objects in tenancy"]'`,


### PR DESCRIPTION
### Description
This fixes links and link text issues the integration wizard in three parts. First, in conjunction with [hccdoc-2342](https://gitlab.cee.redhat.com/red-hat-cloud-services-software-documentation/red-hat-cost-documentation/-/merge_requests/190#706e26636df0b8edb6411804553366a8366ba4c3), this changes the filenames in some cost management docs so that they don't have HCS in the URL and makes the links from the sources UI point to the correct locations.

For [HCCDOC-2389](https://issues.redhat.com/browse/HCCDOC-2389), it changes CUR to data export to track with a change made in HCS.

And as part of [HCSDOC-2363](https://issues.redhat.com/browse/HCCDOC-2363), it fixes a naked URL link to the docs and covers it with appropriate link text.

---

### Screenshots
![Oracle cloud](https://github.com/RedHatInsights/sources-ui/assets/12660270/15d281e1-c0b5-46c8-9cfd-893a1218670f)


#### After:

It should say after `In your Oracle Cloud account, create a VM and run a script the documentation: Replicating reports to a bucket`

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
