### PR TITLE
[COST-4978] - Tweak AWS wizard to match new AWS changes

### DIFF
--- a/src/components/addSourceWizard/hardcodedComponents/aws/arn.js
+++ b/src/components/addSourceWizard/hardcodedComponents/aws/arn.js
@@ -52,7 +52,7 @@ export const StorageDescription = ({ showHCS }) => {
           {
             id: 'cost.storageDescription.storageDescription',
             defaultMessage:
-              'To store the cost and usage reports needed for cost management, you need to create an Amazon S3 bucket. {link}',
+              'To store the data export (formerly cost and usage report) needed for cost management, you need to create an Amazon S3 bucket. {link}',
           },
           {
             link: showHCS ? null : ( // remove when HCS docs links are available
@@ -102,7 +102,7 @@ export const UsageDescription = ({ showHCS }) => {
           {
             id: 'cost.usageDescription.usageDescription',
             defaultMessage:
-              "The information {application} would need is your AWS account's cost and usage report (CUR). If there is a need to further customize the CUR you want to send to {application}, select the manually customize option and follow the special instructions on how to.",
+              "The information {application} would need is your AWS account's data export (formerly cost and usage report). If there is a need to further customize the data you want to send to {application}, select the manually customize option and follow the special instructions on how to.",
           },
           {
             application,
@@ -136,7 +136,7 @@ export const UsageSteps = () => {
         {intl.formatMessage({
           id: 'cost.usageDescription.manualDescriptionCUR',
           defaultMessage:
-            'Since you have chosen to manually customize the data set you want to send to Cost Management, you do not need to create a cost and usage report at this point.',
+            'Since you have chosen to manually customize the data set you want to send to Cost Management, you do not need to create a data export (formerly cost and usage report) at this point.',
         })}
       </EmptyStateBody>
       <EmptyStateActions>
@@ -154,19 +154,19 @@ export const UsageSteps = () => {
         <TextListItem>
           {intl.formatMessage({
             id: 'cost.usageDescription.addFollowingValues',
-            defaultMessage: 'Create a cost and usage report using the following values:',
+            defaultMessage: 'Create a data export (formerly cost and usage report) using the following values:',
           })}
           <TextList>
             <TextListItem>
               {intl.formatMessage({
-                id: 'cost.usageDescription.repornName',
-                defaultMessage: 'Report name: koku',
+                id: 'cost.usageDescription.exportType',
+                defaultMessage: 'Export type: Legacy CUR export',
               })}
             </TextListItem>
             <TextListItem>
               {intl.formatMessage({
-                id: 'cost.usageDescription.timeUnitHoulry',
-                defaultMessage: 'Time unit: hourly',
+                id: 'cost.usageDescription.exportName',
+                defaultMessage: 'Export name: koku',
               })}
             </TextListItem>
             <TextListItem>
@@ -177,20 +177,32 @@ export const UsageSteps = () => {
             </TextListItem>
             <TextListItem>
               {intl.formatMessage({
+                id: 'cost.usageDescription.dataRefreshSettings',
+                defaultMessage: 'Enable: Refresh automatically',
+              })}
+            </TextListItem>
+            <TextListItem>
+              {intl.formatMessage({
+                id: 'cost.usageDescription.timeUnitHourly',
+                defaultMessage: 'Time unit: hourly',
+              })}
+            </TextListItem>
+            <TextListItem>
+              {intl.formatMessage({
                 id: 'cost.usageDescription.enableSupport',
                 defaultMessage: 'Enable support for: RedShift, QuickSight and disable support for Athena',
               })}
             </TextListItem>
             <TextListItem>
               {intl.formatMessage({
-                id: 'cost.usageDescription.reportPathPrefix',
-                defaultMessage: 'Report path prefix: cost',
+                id: 'cost.usageDescription.compression',
+                defaultMessage: 'Compression type: GZIP',
               })}
             </TextListItem>
             <TextListItem>
               {intl.formatMessage({
-                id: 'cost.usageDescription.compression',
-                defaultMessage: 'Compression type: GZIP',
+                id: 'cost.usageDescription.reportBucket',
+                defaultMessage: 'Report path prefix: cost',
               })}
             </TextListItem>
           </TextList>

--- a/src/components/addSourceWizard/hardcodedComponents/aws/arn.js
+++ b/src/components/addSourceWizard/hardcodedComponents/aws/arn.js
@@ -136,7 +136,7 @@ export const UsageSteps = () => {
         {intl.formatMessage({
           id: 'cost.usageDescription.manualDescriptionCUR',
           defaultMessage:
-            'Because you have chosen to manually customize the data set you want to send to cost management, you do not need to create a data export (previously called a  cost and usage report).',
+            'Because you have chosen to manually customize the data set you want to send to cost management, you do not need to create a data export (previously called a cost and usage report).',
         })}
       </EmptyStateBody>
       <EmptyStateActions>

--- a/src/components/addSourceWizard/hardcodedComponents/aws/arn.js
+++ b/src/components/addSourceWizard/hardcodedComponents/aws/arn.js
@@ -154,7 +154,7 @@ export const UsageSteps = () => {
         <TextListItem>
           {intl.formatMessage({
             id: 'cost.usageDescription.addFollowingValues',
-            defaultMessage: 'Create a data export (formerly cost and usage report) using the following values:',
+            defaultMessage: 'Create a data export using the following values:',
           })}
           <TextList>
             <TextListItem>

--- a/src/components/addSourceWizard/hardcodedComponents/aws/arn.js
+++ b/src/components/addSourceWizard/hardcodedComponents/aws/arn.js
@@ -52,7 +52,7 @@ export const StorageDescription = ({ showHCS }) => {
           {
             id: 'cost.storageDescription.storageDescription',
             defaultMessage:
-              'To store the data export (formerly cost and usage report) needed for cost management, you need to create an Amazon S3 bucket. {link}',
+              'To store the data export (previously called a cost and usage report) for cost management, create an Amazon S3 bucket. {link}',
           },
           {
             link: showHCS ? null : ( // remove when HCS docs links are available
@@ -136,7 +136,7 @@ export const UsageSteps = () => {
         {intl.formatMessage({
           id: 'cost.usageDescription.manualDescriptionCUR',
           defaultMessage:
-            'Since you have chosen to manually customize the data set you want to send to Cost Management, you do not need to create a data export (formerly cost and usage report) at this point.',
+            'Because you have chosen to manually customize the data set you want to send to cost management, you do not need to create a data export (previously called a  cost and usage report).',
         })}
       </EmptyStateBody>
       <EmptyStateActions>

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/arn.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/arn.test.js
@@ -311,7 +311,7 @@ describe('AWS-ARN hardcoded schemas', () => {
     expect(screen.getByText('Skip this step and proceed to next step')).toBeInTheDocument();
     expect(
       screen.getByText(
-        'Since you have chosen to manually customize the data set you want to send to Cost Management, you do not need to create a data export (formerly cost and usage report) at this point.',
+        'Because you have chosen to manually customize the data set you want to send to cost management, you do not need to create a data export (previously called a  cost and usage report).',
       ),
     ).toBeInTheDocument();
     expect(screen.queryByText('Additional configuration steps')).toBeInTheDocument();
@@ -322,7 +322,7 @@ describe('AWS-ARN hardcoded schemas', () => {
 
     expect(
       screen.getByText(
-        'To store the data export (formerly cost and usage report) needed for cost management, you need to create an Amazon S3 bucket.'
+        'To store the data export (previously called a cost and usage report) for cost management, create an Amazon S3 bucket.'
       ),
     ).toBeInTheDocument();
     expect(
@@ -336,7 +336,7 @@ describe('AWS-ARN hardcoded schemas', () => {
 
     expect(
       screen.getByText(
-        'To store the data export (formerly cost and usage report) needed for cost management, you need to create an Amazon S3 bucket.'
+        'To store the data export (previously called a cost and usage report) for cost management, create an Amazon S3 bucket.'
       ),
     ).toBeInTheDocument();
     expect(

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/arn.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/arn.test.js
@@ -277,7 +277,7 @@ describe('AWS-ARN hardcoded schemas', () => {
       </RendererContext.Provider>,
     );
 
-    expect(screen.getByText('Create a data export (formerly cost and usage report) using the following values:')).toBeInTheDocument();
+    expect(screen.getByText('Create a data export using the following values:')).toBeInTheDocument();
     expect(screen.getByText('Export type: Legacy CUR export')).toBeInTheDocument();
     expect(screen.getByText('Export name: koku')).toBeInTheDocument();
     expect(screen.getByText('Include: Resource IDs')).toBeInTheDocument();

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/arn.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/arn.test.js
@@ -242,7 +242,7 @@ describe('AWS-ARN hardcoded schemas', () => {
 
     expect(
       screen.getByText(
-        "The information Cost Management would need is your AWS account's cost and usage report (CUR). If there is a need to further customize the CUR you want to send to Cost Management, select the manually customize option and follow the special instructions on how to.",
+        "The information Cost Management would need is your AWS account's data export (formerly cost and usage report). If there is a need to further customize the data you want to send to Cost Management, select the manually customize option and follow the special instructions on how to.",
       ),
     ).toBeInTheDocument();
   });
@@ -252,7 +252,7 @@ describe('AWS-ARN hardcoded schemas', () => {
 
     expect(
       screen.getByText(
-        `The information ${HCS_APP_NAME} would need is your AWS account's cost and usage report (CUR). If there is a need to further customize the CUR you want to send to ${HCS_APP_NAME}, select the manually customize option and follow the special instructions on how to.`,
+        `The information ${HCS_APP_NAME} would need is your AWS account's data export (formerly cost and usage report). If there is a need to further customize the data you want to send to ${HCS_APP_NAME}, select the manually customize option and follow the special instructions on how to.`,
       ),
     ).toBeInTheDocument();
   });
@@ -277,10 +277,12 @@ describe('AWS-ARN hardcoded schemas', () => {
       </RendererContext.Provider>,
     );
 
-    expect(screen.getByText('Create a cost and usage report using the following values:')).toBeInTheDocument();
-    expect(screen.getByText('Report name: koku')).toBeInTheDocument();
-    expect(screen.getByText('Time unit: hourly')).toBeInTheDocument();
+    expect(screen.getByText('Create a data export (formerly cost and usage report) using the following values:')).toBeInTheDocument();
+    expect(screen.getByText('Export type: Legacy CUR export')).toBeInTheDocument();
+    expect(screen.getByText('Export name: koku')).toBeInTheDocument();
     expect(screen.getByText('Include: Resource IDs')).toBeInTheDocument();
+    expect(screen.getByText('Enable: Refresh automatically')).toBeInTheDocument();
+    expect(screen.getByText('Time unit: hourly')).toBeInTheDocument();
     expect(screen.getByText('Enable support for: RedShift, QuickSight and disable support for Athena')).toBeInTheDocument();
     expect(screen.getByText('Report path prefix: cost')).toBeInTheDocument();
     expect(screen.getByText('Compression type: GZIP')).toBeInTheDocument();
@@ -309,7 +311,7 @@ describe('AWS-ARN hardcoded schemas', () => {
     expect(screen.getByText('Skip this step and proceed to next step')).toBeInTheDocument();
     expect(
       screen.getByText(
-        'Since you have chosen to manually customize the data set you want to send to Cost Management, you do not need to create a cost and usage report at this point.',
+        'Since you have chosen to manually customize the data set you want to send to Cost Management, you do not need to create a data export (formerly cost and usage report) at this point.',
       ),
     ).toBeInTheDocument();
     expect(screen.queryByText('Additional configuration steps')).toBeInTheDocument();
@@ -319,7 +321,7 @@ describe('AWS-ARN hardcoded schemas', () => {
     render(<AwsArn.StorageDescription />);
 
     expect(
-      screen.getByText('To store the cost and usage reports needed for cost management, you need to create an Amazon S3 bucket.'),
+      screen.getByText('To store the data export (formerly cost and usage report) needed for cost management, you need to create an Amazon S3 bucket.'),
     ).toBeInTheDocument();
     expect(
       screen.getByText("On AWS, specify or create an Amazon S3 bucket for your account and enter it's name below."),
@@ -331,7 +333,7 @@ describe('AWS-ARN hardcoded schemas', () => {
     render(<AwsArn.StorageDescription showHCS />);
 
     expect(
-      screen.getByText('To store the cost and usage reports needed for cost management, you need to create an Amazon S3 bucket.'),
+      screen.getByText('To store the data export (formerly cost and usage report) needed for cost management, you need to create an Amazon S3 bucket.'),
     ).toBeInTheDocument();
     expect(
       screen.getByText("On AWS, specify or create an Amazon S3 bucket for your account and enter it's name below."),

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/arn.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/arn.test.js
@@ -322,7 +322,7 @@ describe('AWS-ARN hardcoded schemas', () => {
 
     expect(
       screen.getByText(
-        'To store the data export (previously called a cost and usage report) for cost management, create an Amazon S3 bucket.'
+        'To store the data export (previously called a cost and usage report) for cost management, create an Amazon S3 bucket.',
       ),
     ).toBeInTheDocument();
     expect(
@@ -336,7 +336,7 @@ describe('AWS-ARN hardcoded schemas', () => {
 
     expect(
       screen.getByText(
-        'To store the data export (previously called a cost and usage report) for cost management, create an Amazon S3 bucket.'
+        'To store the data export (previously called a cost and usage report) for cost management, create an Amazon S3 bucket.',
       ),
     ).toBeInTheDocument();
     expect(

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/arn.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/arn.test.js
@@ -321,7 +321,9 @@ describe('AWS-ARN hardcoded schemas', () => {
     render(<AwsArn.StorageDescription />);
 
     expect(
-      screen.getByText('To store the data export (formerly cost and usage report) needed for cost management, you need to create an Amazon S3 bucket.'),
+      screen.getByText(
+        'To store the data export (formerly cost and usage report) needed for cost management, you need to create an Amazon S3 bucket.'
+      ),
     ).toBeInTheDocument();
     expect(
       screen.getByText("On AWS, specify or create an Amazon S3 bucket for your account and enter it's name below."),
@@ -333,7 +335,9 @@ describe('AWS-ARN hardcoded schemas', () => {
     render(<AwsArn.StorageDescription showHCS />);
 
     expect(
-      screen.getByText('To store the data export (formerly cost and usage report) needed for cost management, you need to create an Amazon S3 bucket.'),
+      screen.getByText(
+        'To store the data export (formerly cost and usage report) needed for cost management, you need to create an Amazon S3 bucket.'
+      ),
     ).toBeInTheDocument();
     expect(
       screen.getByText("On AWS, specify or create an Amazon S3 bucket for your account and enter it's name below."),

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/arn.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/arn.test.js
@@ -311,7 +311,7 @@ describe('AWS-ARN hardcoded schemas', () => {
     expect(screen.getByText('Skip this step and proceed to next step')).toBeInTheDocument();
     expect(
       screen.getByText(
-        'Because you have chosen to manually customize the data set you want to send to cost management, you do not need to create a data export (previously called a  cost and usage report).',
+        'Because you have chosen to manually customize the data set you want to send to cost management, you do not need to create a data export (previously called a cost and usage report).',
       ),
     ).toBeInTheDocument();
     expect(screen.queryByText('Additional configuration steps')).toBeInTheDocument();


### PR DESCRIPTION
### Description

This changes the Cost Management Integrations flow wizard specifically for AWS to update the CUR (cost and usage report) naming to data export matching AWS updates. The old naming and creation of CUR's will be deprecated on June 1st.

[COST-4978](https://issues.redhat.com/browse/COST-4978)

---

### Screenshots
![image](https://github.com/RedHatInsights/sources-ui/assets/18352403/3543a04b-d5b6-4877-8332-5500df12603b)

This screen and a few other spots just updating some wording.

