### PR TITLE
Refactor launch app AWS integration

### DIFF
--- a/src/components/addSourceWizard/hardcodedSchemas.js
+++ b/src/components/addSourceWizard/hardcodedSchemas.js
@@ -1169,7 +1169,7 @@ const hardcodedSchemas = {
           'authentication.username': provArnField,
           additionalSteps: [
             {
-              title: <FormattedMessage id="provisioning.createIamPolicy" defaultMessage="Create IAM policy" />,
+              title: <FormattedMessage id="provisioning.createIamPolicy" defaultMessage="AWS Account Number" />,
               nextStep: 'prov-iam-role',
               substepOf: {
                 name: 'eaa',
@@ -1179,7 +1179,15 @@ const hardcodedSchemas = {
                 {
                   name: 'iam-policy-description',
                   component: 'description',
-                  Content: ProvAwsArn.IAMPolicyDescription,
+                  Content: ProvAwsArn.AccountNumber,
+                },
+                {
+                  component: componentTypes.TEXT_FIELD,
+                  name: 'meta.account',
+                  isRequired: true,
+                  label: 'Account number',
+                  placeholder: '123456789',
+                  validate: [{ type: 'required' }],
                 },
                 {
                   component: componentTypes.TEXT_FIELD,

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/provisioningArn.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/provisioningArn.test.js
@@ -7,22 +7,9 @@ import * as ProvAwsArn from '../../../../components/addSourceWizard/hardcodedCom
 import * as api from '../../../../api/entities';
 
 describe('Provisioning AWS ARN hardcoded schemas', () => {
-  it('IAM POLICY is rendered correctly', async () => {
-    render(<ProvAwsArn.IAMPolicyDescription />);
-
-    expect(
-      screen.getByText(
-        'Create the following AWS Identity and Access Management (IAM) policy to grant Red Hat permissions to run instances on your Amazon Web Services (AWS) Elastic Cloud (EC2).',
-        { exact: false },
-      ),
-    ).toBeInTheDocument();
-    expect(screen.getByText('Log in to AWS CLI by running:', { exact: false })).toBeInTheDocument();
-    expect(
-      screen.getByText('Create a new policy and store its ARN by running following command in your terminal.', { exact: false }),
-    ).toBeInTheDocument();
-    expect(screen.getByLabelText('Copyable input')).toHaveDisplayValue(
-      /^\s*POLICY_ARN=\$\(aws iam create-policy --policy-name RH-HCC-provisioning-policy --policy-document/,
-    );
+  it('AccountNumber is rendered correctly', async () => {
+    render(<ProvAwsArn.AccountNumber />);
+    expect(screen.getByText('Login to your AWS account and copy your account number')).toBeInTheDocument();
   });
 
   it('IAM ROLE is rendered correctly', async () => {
@@ -39,23 +26,11 @@ describe('Provisioning AWS ARN hardcoded schemas', () => {
 
     render(<ProvAwsArn.IAMRoleDescription />);
 
-    expect(
-      screen.getByText('To delegate account access, create an IAM role and associate it with your IAM policy.', { exact: false }),
-    ).toBeInTheDocument();
-
     expect(screen.getByText('Loading configuration...')).toBeInTheDocument();
-
-    const copyInputs = await screen.findAllByLabelText('Copyable input');
-
-    expect(
-      screen.getByText('Create a new role and add the Red Hat account as a trusted entity and fetch the role ARN:', {
-        exact: false,
-      }),
-    ).toBeInTheDocument();
-    expect(copyInputs[0]).toHaveDisplayValue(/372779871274/);
-
-    expect(screen.getByText('Attach the permissions policy that you just created.', { exact: false })).toBeInTheDocument();
-    expect(copyInputs[1]).toHaveValue('aws iam attach-role-policy --role-name RH-HCC-provisioning-role --policy-arn $POLICY_ARN');
+    const button = await screen.findByText('Connect AWS');
+    expect(button).toBeInTheDocument();
+    const StackCreationURL = `https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=https://provisioning-public-assets.s3.amazonaws.com/AWSStack/provisioning.yml&stackName=RH-HCC-provisioning-stack&param_RoleName=RH-HCC-provisioning-role&param_ProvisioningAwsAccount=${awsAccId}&param_PolicyName=RH-HCC-provisioning-policy`;
+    expect(button).toHaveAttribute('href', StackCreationURL);
   });
 
   it('IAM ROLE is rendered correctly with error', async () => {
@@ -73,19 +48,5 @@ describe('Provisioning AWS ARN hardcoded schemas', () => {
         'There was an error while loading the commands. Please go back and return to this step to try again.',
       ),
     ).toBeInTheDocument();
-  });
-
-  it('IAM ARN is rendered correctly', async () => {
-    render(<ProvAwsArn.ArnDescription />);
-
-    expect(
-      screen.getByText('To enable account access, capture the ARN associated with the role you just created.', { exact: false }),
-    ).toBeInTheDocument();
-
-    expect(screen.getByText('Run', { exact: false })).toBeInTheDocument();
-    expect(screen.getByText('echo $ROLE_ARN', { exact: false })).toBeInTheDocument();
-    expect(screen.getByText('in your terminal to print the role ARN', { exact: false })).toBeInTheDocument();
-
-    expect(screen.getByText('Copy it to the ARN field below.', { exact: false })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

Currently, our AWS integration wizard guides users through creating a policy and role resources, attaching them manually via the AWS CLI, and entering the ARN.

By leveraging an AWS CloudFormation stack template, we can streamline this process. Users will be able to achieve this with a simple redirection to AWS console with a dedicated template, eliminating the need for CLI commands or copy any JSON file. The ARN will be retrieved automatically, simplifying the integration with our service.


[HMS-4041](https://issues.redhat.com/browse/HMS-4041)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:

https://github.com/RedHatInsights/sources-ui/assets/11807069/c8589562-2dd4-4b12-a2be-8198f97bee66



#### After:

https://github.com/RedHatInsights/sources-ui/assets/11807069/7b0b2ce4-6c55-486c-b9d8-efd15ca1d069



---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [x] _(Optional) UX: Has been mentioned_
##
