### PR TITLE
removing reader role from Azure wizard cost mgmt

### DIFF
--- a/src/components/addSourceWizard/hardcodedComponents/azure/costManagement.js
+++ b/src/components/addSourceWizard/hardcodedComponents/azure/costManagement.js
@@ -188,32 +188,17 @@ const InternalReaderRoleDescription = () => {
   }
 
   return application.extra.storage_only ? null : (
-    <Fragment>
-      <TextContent>
-        <Text component={TextVariants.p}>
-          {intl.formatMessage({
-            id: 'cost.azure.createCostReaderRole',
-            defaultMessage: 'Run the following command in Cloud Shell to create a Cost Management Reader role:',
-          })}
-        </Text>
-        <ClipboardCopy>
-          {`az role assignment create --assignee "${authentication?.username}" --role "Cost Management Reader" --scope "${scope}"`}
-        </ClipboardCopy>
-      </TextContent>
-      {application?.extra?.metered && (
-        <TextContent>
-          <Text component={TextVariants.p}>
-            {intl.formatMessage({
-              id: 'cost.azure.createReaderRole',
-              defaultMessage: 'Run the following command in Cloud Shell to create a Reader role:',
-            })}
-          </Text>
-          <ClipboardCopy>
-            {`az role assignment create --assignee "${authentication?.username}" --role "Reader" --scope "${scope}"`}
-          </ClipboardCopy>
-        </TextContent>
-      )}
-    </Fragment>
+    <TextContent>
+      <Text component={TextVariants.p}>
+        {intl.formatMessage({
+          id: 'cost.azure.createCostReaderRole',
+          defaultMessage: 'Run the following command in Cloud Shell to create a Cost Management Reader role:',
+        })}
+      </Text>
+      <ClipboardCopy>
+        {`az role assignment create --assignee "${authentication?.username}" --role "Cost Management Reader" --scope "${scope}"`}
+      </ClipboardCopy>
+    </TextContent>
   );
 };
 

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/cost_management_azure.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/cost_management_azure.test.js
@@ -190,33 +190,6 @@ describe('Cost Management Azure steps components', () => {
     );
   });
 
-  it('Read Role description', () => {
-    mockedRender(
-      <Form onSubmit={jest.fn()}>
-        {() => (
-          <RenderContext.Provider
-            value={{
-              formOptions: {
-                getState: () => ({
-                  values: {
-                    authentication: { username: 'some-user-name' },
-                    application: {
-                      extra: { subscription_id: 'my-sub-id-1', resource_group: 'my-resource-group-1', metered: 'rhel' },
-                    },
-                  },
-                }),
-              },
-            }}
-          >
-            <Cm.ReaderRoleDescription />
-          </RenderContext.Provider>
-        )}
-      </Form>,
-    );
-
-    expect(screen.getByText('Run the following command in Cloud Shell to create a Reader role:')).toBeInTheDocument();
-  });
-
   it('Read Role description - storage only', () => {
     mockedRender(
       <Form onSubmit={jest.fn()}>


### PR DESCRIPTION
### Description
This change removes the additional Azure Reader role from the integration wizard during the cost management steps. This reader role is no longer required.

[RHCLOUD-34800](https://issues.redhat.com/browse/RHCLOUD-34800)

---

### Screenshots
#### Before:
![Screenshot from 2024-08-28 13-34-09](https://github.com/user-attachments/assets/14a319af-bde6-4689-a5b9-e59b46b03d60)


#### After:
![Screenshot from 2024-08-28 13-34-20](https://github.com/user-attachments/assets/2012010c-897a-4616-870c-657decde3d6a)


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
