### PR TITLE
fix(widgets): fix openshift icon and default expand

### DIFF
--- a/src/components/Widget/consts/widgetData.tsx
+++ b/src/components/Widget/consts/widgetData.tsx
@@ -155,7 +155,7 @@ export const integrationsData = [
           icon: (
             <ImageWithPlaceholder
               className="redhat-icon"
-              src="/apps/frontend-assets/red-hat-logos/stacked.svg"
+              src="/apps/frontend-assets/service-dropdown-icons/openshift.svg"
               alt="red hat logo"
             />
           ),


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
UX suggestions after seeing integrations widget -- 

1. The icon for OCP should just be the OpenShfit icon not the whole Red Hat logo (with logotype)
2. Can we have the default expandable behavior be: show expanded state for any integration types that have at least one integration? For example: if you have a google chat integration, the communication expansion should default to being open
3. Right now, when one expansion open it causes the previously opened one to close. Can we change this so that you can open as many or as few as you want?

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
on initial load the first category expanded 
![Screenshot 2024-11-06 at 1 21 06 PM](https://github.com/user-attachments/assets/8ea163cc-e17b-4773-a188-1592be13eaa5)

#### After:
now all categories with integrations open on load
![Screenshot 2024-11-06 at 1 21 46 PM](https://github.com/user-attachments/assets/f952ef0b-2b7f-4a78-9983-a481529a581d)

add other openshift icon
![Screenshot 2024-11-06 at 1 22 23 PM](https://github.com/user-attachments/assets/eba4e8ed-b313-42b6-b724-b028f30280d4)



### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
