### PR TITLE
Using the console's billing proxy instead of directly

### DIFF
--- a/src/api/checkAccountHCS.js
+++ b/src/api/checkAccountHCS.js
@@ -1,5 +1,5 @@
 export const checkAccountHCS = async (jwtToken, isProd) => {
-  return fetch(`https://billing.${isProd ? '' : 'stage.'}api.redhat.com/v1/authorization/hcsEnrollment`, {
+  return fetch(`https://console.${isProd ? '' : 'stage.'}redhat.com/api/billing/v1/authorization/hcsEnrollment`, {
     headers: { Authorization: `Bearer ${jwtToken}` },
   })
     .then((response) => {


### PR DESCRIPTION
### Description
How's it going? A while ago, customers reported popups opening in ui, they were from making requests to the billing API directly. I added a proxy through console to fix it.

Just changing the URL here to avoid the popup. Can't reproduce this myself though.

Old ticket: https://issues.redhat.com/browse/RHCLOUD-27373

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
![Image from iOS (1)](https://github.com/user-attachments/assets/d11c8a14-6312-4c82-ad3e-2cf1b0743a10)

---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
