### PR TITLE
fix: fix wording "source" vs "integration"

### DIFF
--- a/src/components/AddApplication/AddApplication.js
+++ b/src/components/AddApplication/AddApplication.js
@@ -158,7 +158,7 @@ const AddApplication = () => {
   const description = intl.formatMessage(
     {
       id: 'sources.addApplicationNameDescription',
-      defaultMessage: 'Configure {appName} for this source.',
+      defaultMessage: 'Configure {appName} for this integration.',
     },
     {
       appName: applicationType?.display_name || 'application',

--- a/src/components/AddApplication/RemoveAppModal.js
+++ b/src/components/AddApplication/RemoveAppModal.js
@@ -89,7 +89,7 @@ const RemoveAppModal = () => {
           {intl.formatMessage(
             {
               id: 'sources.deleteAppWarning',
-              defaultMessage: '{ appName } will be disconnected from this source.',
+              defaultMessage: '{ appName } will be disconnected from this integration.',
             },
             { appName: <b key="b">{app.display_name}</b> },
           )}

--- a/src/components/AddApplication/removeAppSubmit.js
+++ b/src/components/AddApplication/removeAppSubmit.js
@@ -4,7 +4,7 @@ const removeAppSubmit = (app, intl, onCancel, dispatch, source) => {
   const titleSuccess = intl.formatMessage(
     {
       id: 'sources.removeAppWarning',
-      defaultMessage: `{ name } was removed from this source.`,
+      defaultMessage: `{ name } was removed from this integration.`,
     },
     {
       name: app.display_name,
@@ -13,7 +13,7 @@ const removeAppSubmit = (app, intl, onCancel, dispatch, source) => {
   const titleError = intl.formatMessage(
     {
       id: 'sources.removeAppError',
-      defaultMessage: `Removing of { name } application from this source was unsuccessful.`,
+      defaultMessage: `Removing of { name } application from this integration was unsuccessful.`,
     },
     {
       name: app.display_name,

--- a/src/components/CloseModal.js
+++ b/src/components/CloseModal.js
@@ -20,7 +20,7 @@ const CloseModal = ({ onExit, onStay, title, exitTitle, stayTitle, description }
       className="sources"
       variant="small"
       title={title}
-      aria-label={intl.formatMessage({ id: 'wizard.closeAriaLabel', defaultMessage: 'Close add source wizard' })}
+      aria-label={intl.formatMessage({ id: 'wizard.closeAriaLabel', defaultMessage: 'Close add integration wizard' })}
       header={
         <Title headingLevel="h1" size="2xl">
           <ExclamationTriangleIcon size="sm" className="src-c-warning-icon" aria-label="Exclamation icon" />

--- a/src/components/FormComponents/SourceWizardSummary.js
+++ b/src/components/FormComponents/SourceWizardSummary.js
@@ -80,7 +80,7 @@ const SummaryAlert = ({ appName, sourceType, hcsEnrolled }) => {
             {intl.formatMessage({
               id: 'cost.rbacWarningDescription',
               defaultMessage:
-                'Make sure to manage permissions for this source in custom roles that contain permissions for Cost Management.',
+                'Make sure to manage permissions for this integration in custom roles that contain permissions for Cost Management.',
             })}
           </Alert>
         )}

--- a/src/components/SourceDetail/NoApplications.js
+++ b/src/components/SourceDetail/NoApplications.js
@@ -19,7 +19,8 @@ const NoApplications = () => {
       <EmptyStateBody className="src-c-empty-state__body">
         {intl.formatMessage({
           id: 'detail.noapplications.description',
-          defaultMessage: 'You have not connected any applications to this source. Use the switches above to add applications.',
+          defaultMessage:
+            'You have not connected any applications to this integration. Use the switches above to add applications.',
         })}
       </EmptyStateBody>
     </EmptyState>

--- a/src/components/SourceRemoveModal/helpers.js
+++ b/src/components/SourceRemoveModal/helpers.js
@@ -22,7 +22,7 @@ export const bodyVariants = (variant, { name, count }) =>
       <FormattedMessage
         id="sources.deleteTextBodyWithApps"
         defaultMessage={`Removing { name } detaches the following
-        connected {count, plural, one {application} other {applications}} from this source:`}
+        connected {count, plural, one {application} other {applications}} from this integration:`}
         values={{
           name: <b>{name}</b>,
           count,

--- a/src/components/addSourceWizard/SourceAddSchema.js
+++ b/src/components/addSourceWizard/SourceAddSchema.js
@@ -218,7 +218,7 @@ export const typesStep = (sourceTypes, applicationTypes, disableAppSelection, in
       label: intl.formatMessage({
         id: 'wizard.selectRedHatType',
         defaultMessage:
-          'To import data for an application, you need to connect to a data source. Start by selecting your cloud provider and application.',
+          'To import data for an application, you need to configure an integration. Start by selecting your cloud provider and application.',
       }),
     },
     ...redhatTypes({ intl, sourceTypes, applicationTypes, disableAppSelection }),
@@ -239,7 +239,7 @@ export const cloudTypesStep = (sourceTypes, applicationTypes, intl) => ({
       label: intl.formatMessage({
         id: 'wizard.selectCloudType',
         defaultMessage:
-          'To import data for an application, you need to connect to a data source. Start by selecting your cloud provider.',
+          'To import data for an application, you need to configure an integration. Start by selecting your cloud provider.',
       }),
     },
     {

--- a/src/components/addSourceWizard/hardcodedComponents/aws/access_key.js
+++ b/src/components/addSourceWizard/hardcodedComponents/aws/access_key.js
@@ -32,7 +32,7 @@ export const DescriptionSummary = () => {
                 {intl.formatMessage({
                   id: 'wizard.createAccesKeyHelpText',
                   defaultMessage:
-                    'The Power user policy allows the user full access to API functionality and AWS services for user administration. Create an access key in the Security Credentials area of your AWS user account. When adding your AWS account as a source, the access key ID and secret access key act as your user ID and password.',
+                    'The Power user policy allows the user full access to API functionality and AWS services for user administration. Create an access key in the Security Credentials area of your AWS user account. When adding your AWS account as an integration, the access key ID and secret access key act as your user ID and password.',
                 })}
               </Text>
             </React.Fragment>

--- a/src/components/addSourceWizard/hardcodedComponents/openshift/costManagement.js
+++ b/src/components/addSourceWizard/hardcodedComponents/openshift/costManagement.js
@@ -38,7 +38,7 @@ export const ConfigureCostOperator = () => {
           {
             id: 'cost.openshift.operator_configured',
             defaultMessage:
-              'If you configured the operator to create a source (create_source: true), <b>STOP</b> here and <b>CANCEL</b> out of this flow.',
+              'If you configured the operator to create an integration (create_source: true), <b>STOP</b> here and <b>CANCEL</b> out of this flow.',
           },
           {
             b: bold,

--- a/src/components/addSourceWizard/stringConstants.js
+++ b/src/components/addSourceWizard/stringConstants.js
@@ -11,7 +11,7 @@ export const wizardDescription = (activeCategory) =>
   ) : (
     <FormattedMessage
       id="wizard.wizardDescriptionRedhat"
-      defaultMessage="Configure a data source to connect to your Red Hat applications."
+      defaultMessage="Configure an integration to connect to your Red Hat applications."
     />
   );
 export const wizardTitle = (activeCategory) =>

--- a/src/components/steps/AmazonFinishedStep.js
+++ b/src/components/steps/AmazonFinishedStep.js
@@ -55,7 +55,7 @@ const AmazonFinishedStep = ({ onClose }) => {
       >
         {intl.formatMessage({
           id: 'aws.alertDescription',
-          defaultMessage: 'Manage connections for this source at any time in Settings > Sources.',
+          defaultMessage: 'Manage connections for this integration at any time in Settings > Integrations.',
         })}
       </Alert>
       <Bullseye>
@@ -67,7 +67,7 @@ const AmazonFinishedStep = ({ onClose }) => {
           <EmptyStateBody>
             {intl.formatMessage({
               id: 'aws.successDescription',
-              defaultMessage: 'Discover the benefits of your connection or exit to manage your new source.',
+              defaultMessage: 'Discover the benefits of your connection or exit to manage your new integration.',
             })}
             <Grid hasGutter className="src-c-aws-grid pf-v5-u-mt-md">
               <GridItem md="6">

--- a/src/pages/Sources.js
+++ b/src/pages/Sources.js
@@ -151,11 +151,11 @@ const SourcesPage = () => {
   const noPermissionsText = isOrgAdmin
     ? intl.formatMessage({
         id: 'sources.notAdminAddButton',
-        defaultMessage: 'To add a source, you must add Cloud Administrator permissions to your user.',
+        defaultMessage: 'To add an integration, you must add Cloud Administrator permissions to your user.',
       })
     : intl.formatMessage({
         id: 'sources.notPermissionsAddButton',
-        defaultMessage: 'To add a source, your Organization Administrator must grant you Cloud Administrator permissions.',
+        defaultMessage: 'To add an integration, your Organization Administrator must grant you Cloud Administrator permissions.',
       });
 
   let actionsConfig;

--- a/src/test/addSourceWizard/addSourceWizard/addSourceSchema.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/addSourceSchema.test.js
@@ -159,7 +159,7 @@ describe('Add source schema', () => {
 
       expect(result.fields[0].component).toEqual(componentTypes.PLAIN_TEXT);
       expect(result.fields[0].label).toEqual(
-        'To import data for an application, you need to connect to a data source. Start by selecting your cloud provider.',
+        'To import data for an application, you need to configure an integration. Start by selecting your cloud provider.',
       );
 
       expect(result.fields[1].name).toEqual('source_type');
@@ -171,7 +171,7 @@ describe('Add source schema', () => {
 
       expect(result.fields[0].component).toEqual(componentTypes.PLAIN_TEXT);
       expect(result.fields[0].label).toEqual(
-        'To import data for an application, you need to connect to a data source. Start by selecting your cloud provider and application.',
+        'To import data for an application, you need to configure an integration. Start by selecting your cloud provider and application.',
       );
       expect(result.fields).toHaveLength(3);
       expect(result.fields[1].name).toEqual('source_type');

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/cost_management_openshift.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/cost_management_openshift.test.js
@@ -14,7 +14,7 @@ describe('Cost Management OpenShift steps components', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('costmanagement-metrics-operator')).toBeInTheDocument();
     expect(
-      screen.getByText('If you configured the operator to create a source (create_source: true),', { exact: false }),
+      screen.getByText('If you configured the operator to create an integration (create_source: true),', { exact: false }),
     ).toBeInTheDocument();
     expect(
       screen.getByText(

--- a/src/test/addSourceWizard/addSourceWizard/steps.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/steps.test.js
@@ -185,9 +185,13 @@ describe('Steps components', () => {
       render(<AmazonFinishedStep {...initialProps} />);
 
       expect(screen.getByText('Allow 24 hours for full activation')).toBeInTheDocument();
-      expect(screen.getByText('Manage connections for this source at any time in Settings > Sources.')).toBeInTheDocument();
+      expect(
+        screen.getByText('Manage connections for this integration at any time in Settings > Integrations.'),
+      ).toBeInTheDocument();
       expect(screen.getByText('Amazon Web Services connection established')).toBeInTheDocument();
-      expect(screen.getByText('Discover the benefits of your connection or exit to manage your new source.')).toBeInTheDocument();
+      expect(
+        screen.getByText('Discover the benefits of your connection or exit to manage your new integration.'),
+      ).toBeInTheDocument();
       expect([...screen.getAllByRole('link')].map((l) => [l.textContent, l.href])).toEqual([
         ['View enabled AWS gold images', 'https://access.redhat.com/management/cloud'],
         ['Subscription Watch usage', 'http://localhost/preview/subscriptions'],

--- a/src/test/components/addApplication/AddApplication.test.js
+++ b/src/test/components/addApplication/AddApplication.test.js
@@ -615,7 +615,9 @@ describe('AddApplication', () => {
       expect(attachSource.doAttachApp).toHaveBeenCalledWith(formValues, formApi, authenticationValues, initialValues, appTypes);
 
       expect(screen.getByText('Amazon Web Services connection established')).toBeInTheDocument();
-      expect(screen.getByText('Discover the benefits of your connection or exit to manage your new source.')).toBeInTheDocument();
+      expect(
+        screen.getByText('Discover the benefits of your connection or exit to manage your new integration.'),
+      ).toBeInTheDocument();
       expect([...screen.getAllByRole('link')].map((l) => [l.textContent, l.href])).toEqual([
         ['View enabled AWS gold images', 'https://access.redhat.com/management/cloud'],
         ['Subscription Watch usage', 'http://localhost/preview/subscriptions'],

--- a/src/test/components/addApplication/RemoveAppModal.test.js
+++ b/src/test/components/addApplication/RemoveAppModal.test.js
@@ -67,7 +67,7 @@ describe('RemoveAppModal', () => {
     expect(screen.getByText('Remove')).toBeInTheDocument();
     expect(screen.getByText('Cancel')).toBeInTheDocument();
     expect(screen.getByText(APP1_DISPLAY_NAME, { selector: 'b' })).toBeInTheDocument();
-    expect(screen.getByText('will be disconnected from this source.', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText('will be disconnected from this integration.', { exact: false })).toBeInTheDocument();
   });
 
   it('redirect when app does not exist', async () => {

--- a/src/test/components/addApplication/removeAppSubmit.test.js
+++ b/src/test/components/addApplication/removeAppSubmit.test.js
@@ -29,7 +29,9 @@ describe('removeAppSubmit', () => {
     expect(result).toEqual({
       meta: {
         appId: '123',
-        notifications: { fulfilled: { dismissable: true, title: 'Catalog was removed from this source.', variant: 'success' } },
+        notifications: {
+          fulfilled: { dismissable: true, title: 'Catalog was removed from this integration.', variant: 'success' },
+        },
         sourceId: '56',
       },
       payload: expect.any(Function),
@@ -40,7 +42,7 @@ describe('removeAppSubmit', () => {
     result.payload();
     expect(api.doDeleteApplication).toHaveBeenCalledWith(
       '123',
-      'Removing of Catalog application from this source was unsuccessful.',
+      'Removing of Catalog application from this integration was unsuccessful.',
     );
   });
 });

--- a/src/test/components/formComponents/sourceWizardSummary.test.js
+++ b/src/test/components/formComponents/sourceWizardSummary.test.js
@@ -203,7 +203,7 @@ describe('SourceWizardSummary component', () => {
       expect(screen.getByText('Manage permissions in User Access')).toBeInTheDocument();
       expect(
         screen.getByText(
-          'Make sure to manage permissions for this source in custom roles that contain permissions for Cost Management.',
+          'Make sure to manage permissions for this integration in custom roles that contain permissions for Cost Management.',
         ),
       ).toBeInTheDocument();
       expect(screen.getByText("Don't forget additional configuration steps!")).toBeInTheDocument();
@@ -249,7 +249,7 @@ describe('SourceWizardSummary component', () => {
       expect(screen.getByText('Manage permissions in User Access')).toBeInTheDocument();
       expect(
         screen.getByText(
-          'Make sure to manage permissions for this source in custom roles that contain permissions for Cost Management.',
+          'Make sure to manage permissions for this integration in custom roles that contain permissions for Cost Management.',
         ),
       ).toBeInTheDocument();
     });
@@ -414,7 +414,7 @@ describe('SourceWizardSummary component', () => {
       expect(screen.getByText('Manage permissions in User Access')).toBeInTheDocument();
       expect(
         screen.getByText(
-          'Make sure to manage permissions for this source in custom roles that contain permissions for Cost Management.',
+          'Make sure to manage permissions for this integration in custom roles that contain permissions for Cost Management.',
         ),
       ).toBeInTheDocument();
     });
@@ -455,7 +455,7 @@ describe('SourceWizardSummary component', () => {
       expect(screen.getByText('Manage permissions in User Access')).toBeInTheDocument();
       expect(
         screen.getByText(
-          'Make sure to manage permissions for this source in custom roles that contain permissions for Cost Management.',
+          'Make sure to manage permissions for this integration in custom roles that contain permissions for Cost Management.',
         ),
       ).toBeInTheDocument();
     });

--- a/src/test/components/sourceDetail/NoApplications.test.js
+++ b/src/test/components/sourceDetail/NoApplications.test.js
@@ -11,7 +11,9 @@ describe('NoApplications', () => {
 
     expect(screen.getByText('No connected applications')).toBeInTheDocument();
     expect(
-      screen.getByText('You have not connected any applications to this source. Use the switches above to add applications.'),
+      screen.getByText(
+        'You have not connected any applications to this integration. Use the switches above to add applications.',
+      ),
     ).toBeInTheDocument();
   });
 });

--- a/src/test/components/sourceRemoveModal/SourceRemoveModal.test.js
+++ b/src/test/components/sourceRemoveModal/SourceRemoveModal.test.js
@@ -191,7 +191,7 @@ describe('SourceRemoveModal', () => {
       );
 
       expect(
-        screen.getByText('detaches the following connected application from this source:', { exact: false }),
+        screen.getByText('detaches the following connected application from this integration:', { exact: false }),
       ).toBeInTheDocument();
     });
 

--- a/src/test/pages/Sources.test.js
+++ b/src/test/pages/Sources.test.js
@@ -502,7 +502,7 @@ describe('SourcesPage', () => {
     expect(screen.getByTestId('location-display').textContent).toEqual(`/${routes.sourcesNew.path}`);
     expect(
       screen.getByText(
-        'To import data for an application, you need to connect to a data source. Start by selecting your cloud provider.',
+        'To import data for an application, you need to configure an integration. Start by selecting your cloud provider.',
       ),
     ).toBeInTheDocument();
   });
@@ -1207,7 +1207,7 @@ describe('SourcesPage', () => {
 
       await waitFor(() =>
         expect(
-          screen.getByText('To add a source, you must add Cloud Administrator permissions to your user.'),
+          screen.getByText('To add an integration, you must add Cloud Administrator permissions to your user.'),
         ).toBeInTheDocument(),
       );
 
@@ -1238,7 +1238,9 @@ describe('SourcesPage', () => {
 
       await waitFor(() =>
         expect(
-          screen.getByText('To add a source, your Organization Administrator must grant you Cloud Administrator permissions.'),
+          screen.getByText(
+            'To add an integration, your Organization Administrator must grant you Cloud Administrator permissions.',
+          ),
         ).toBeInTheDocument(),
       );
 
@@ -1272,7 +1274,9 @@ describe('SourcesPage', () => {
 
       await waitFor(() =>
         expect(
-          screen.getByText('To add a source, your Organization Administrator must grant you Cloud Administrator permissions.'),
+          screen.getByText(
+            'To add an integration, your Organization Administrator must grant you Cloud Administrator permissions.',
+          ),
         ).toBeInTheDocument(),
       );
 

--- a/src/test/views/formatters.test.js
+++ b/src/test/views/formatters.test.js
@@ -147,7 +147,9 @@ describe('formatters', () => {
       });
 
       await waitFor(() =>
-        expect(screen.getByText('This source can be managed from your connected CloudForms application.')).toBeInTheDocument(),
+        expect(
+          screen.getByText('This integration can be managed from your connected CloudForms application.'),
+        ).toBeInTheDocument(),
       );
     });
   });
@@ -470,13 +472,13 @@ describe('formatters', () => {
     it('returns object for cfme', () => {
       render(wrapperWithIntl(importsTexts('cfme')));
 
-      expect(screen.getByText('This source can be managed from your connected CloudForms application.')).toBeInTheDocument();
+      expect(screen.getByText('This integration can be managed from your connected CloudForms application.')).toBeInTheDocument();
     });
 
     it('returns object for CFME', () => {
       render(wrapperWithIntl(importsTexts('CFME')));
 
-      expect(screen.getByText('This source can be managed from your connected CloudForms application.')).toBeInTheDocument();
+      expect(screen.getByText('This integration can be managed from your connected CloudForms application.')).toBeInTheDocument();
     });
 
     it('returns default undefined', () => {

--- a/src/views/formatters.js
+++ b/src/views/formatters.js
@@ -36,7 +36,7 @@ export const importsTexts = (value) =>
     cfme: (
       <FormattedMessage
         id="sources.cloudformImportTooltip"
-        defaultMessage="This source can be managed from your connected CloudForms application."
+        defaultMessage="This integration can be managed from your connected CloudForms application."
       />
     ),
   })[value.toLowerCase()];


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
On few pages in Integrations wizard and outside in Integrations detail page, there was "source" used as a name instead of "integration" - this should fix that.

[RHCLOUD-34320](https://issues.redhat.com/browse/RHCLOUD-34320)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
![Integrations 3](https://github.com/user-attachments/assets/2aea5c85-60b5-40f9-ad5f-361688477d61)
![Integrations 4](https://github.com/user-attachments/assets/5cf64566-16b0-4e15-82ce-8c5a0e12638f)
![Integrations 7](https://github.com/user-attachments/assets/a4ff8dbc-b358-46fe-ad44-cf9c10757061)

#### After:
<img width="1133" alt="image" src="https://github.com/user-attachments/assets/ddda40e6-4388-4cf4-81ad-30fd49ba830d">
<img width="1133" alt="image" src="https://github.com/user-attachments/assets/181f33dc-445e-483e-b8ee-c33fc6cb49b1">
![image](https://github.com/user-attachments/assets/1beadb7b-77fa-4a53-a528-d9e3eab23a8e)

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
