### PR TITLE
Fix inifite reload on integrations by removing permissions checker from dropdown

### DIFF
--- a/src/components/IntegrationsDropdown.js
+++ b/src/components/IntegrationsDropdown.js
@@ -6,7 +6,6 @@ import { CLOUD_VENDOR, COMMUNICATIONS, REDHAT_VENDOR, REPORTING, WEBHOOKS } from
 import { checkPropTypes } from 'prop-types';
 import { useFlag } from '@unleash/proxy-client-react';
 import { useSelector } from 'react-redux';
-import PermissionsChecker from './PermissionsChecker';
 
 const dropdownItems = (isPagerDutyEnabled, hasSourcesPermissions, hasIntegrationsPermissions) => [
   ...(hasSourcesPermissions
@@ -64,60 +63,58 @@ const IntegrationsDropdown = (props) => {
   };
 
   return (
-    <PermissionsChecker>
-      <div className="integrations-dropdown">
-        {[REDHAT_VENDOR, CLOUD_VENDOR].includes(selectedIntegration) && (
-          <AddSourceWizard
-            isOpen={isSourcesWizardOpen}
-            onClose={() => {
-              setIsSourcesWizardOpen(false);
-              setSelectedIntegration(null);
-            }}
-            activeCategory={selectedIntegration}
-          />
+    <div className="integrations-dropdown">
+      {[REDHAT_VENDOR, CLOUD_VENDOR].includes(selectedIntegration) && (
+        <AddSourceWizard
+          isOpen={isSourcesWizardOpen}
+          onClose={() => {
+            setIsSourcesWizardOpen(false);
+            setSelectedIntegration(null);
+          }}
+          activeCategory={selectedIntegration}
+        />
+      )}
+      {[COMMUNICATIONS, REPORTING, WEBHOOKS].includes(selectedIntegration) && (
+        <AsyncComponent
+          appName="notifications"
+          module="./IntegrationsWizard"
+          isOpen={isIntegrationsWizardOpen}
+          category={selectedIntegration}
+          closeModal={() => {
+            setIsIntegrationsWizardOpen(false);
+            setSelectedIntegration(null);
+          }}
+          fallback={<div id="fallback-modal" />}
+        />
+      )}
+      <Dropdown
+        isOpen={isOpen}
+        onSelect={handleSelect}
+        onOpenChange={setIsOpen}
+        toggle={(toggleRef) => (
+          <MenuToggle
+            ref={toggleRef}
+            onClick={() => setIsOpen(!isOpen)}
+            isExpanded={isOpen}
+            isDisabled={props.isDisabled || (!hasSourcesPermissions && !hasIntegrationsPermissions)}
+            variant="primary"
+          >
+            Create Integration
+          </MenuToggle>
         )}
-        {[COMMUNICATIONS, REPORTING, WEBHOOKS].includes(selectedIntegration) && (
-          <AsyncComponent
-            appName="notifications"
-            module="./IntegrationsWizard"
-            isOpen={isIntegrationsWizardOpen}
-            category={selectedIntegration}
-            closeModal={() => {
-              setIsIntegrationsWizardOpen(false);
-              setSelectedIntegration(null);
-            }}
-            fallback={<div id="fallback-modal" />}
-          />
-        )}
-        <Dropdown
-          isOpen={isOpen}
-          onSelect={handleSelect}
-          onOpenChange={setIsOpen}
-          toggle={(toggleRef) => (
-            <MenuToggle
-              ref={toggleRef}
-              onClick={() => setIsOpen(!isOpen)}
-              isExpanded={isOpen}
-              isDisabled={props.isDisabled || (!hasSourcesPermissions && !hasIntegrationsPermissions)}
-              variant="primary"
-            >
-              Create Integration
-            </MenuToggle>
+        {...props}
+      >
+        <DropdownList>
+          {dropdownItems(isPagerDutyEnabled, hasSourcesPermissions, hasIntegrationsPermissions).map(
+            ({ title, value, description }) => (
+              <DropdownItem key={title} value={value} description={description}>
+                {title}
+              </DropdownItem>
+            ),
           )}
-          {...props}
-        >
-          <DropdownList>
-            {dropdownItems(isPagerDutyEnabled, hasSourcesPermissions, hasIntegrationsPermissions).map(
-              ({ title, value, description }) => (
-                <DropdownItem key={title} value={value} description={description}>
-                  {title}
-                </DropdownItem>
-              ),
-            )}
-          </DropdownList>
-        </Dropdown>
-      </div>
-    </PermissionsChecker>
+        </DropdownList>
+      </Dropdown>
+    </div>
   );
 };
 


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

Integrations page is not loading because of infinite load. This PR fixes it by removing the permissions checker. The reason is that we're checking for permissions in parent component and dispatching the actions once again in the dropdown, this causes infinite loop because we are constantly updating parent component.

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [-] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [-] _(Optional) QE: Has been mentioned_
- [-] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [-] _(Optional) UX: Has been mentioned_
##
