### PR TITLE
fix: enable collapse/expand in integrations widget

### DIFF
--- a/src/components/Widget/IntegrationsWidget.tsx
+++ b/src/components/Widget/IntegrationsWidget.tsx
@@ -29,6 +29,7 @@ import PermissionsChecker from '../PermissionsChecker';
 
 const IntegrationsWidget: FunctionComponent = () => {
   const [isLoading, setIsLoading] = useState(false);
+  const [hasInitialized, setHasInitialized] = useState(false);
   const [expandedIndex, setExpandedIndex] = useState<number[]>([]);
   const [integrationCounts, setIntegrationCounts] = useState<{ [key: string]: number }>({});
 
@@ -81,13 +82,14 @@ const IntegrationsWidget: FunctionComponent = () => {
   };
 
   useEffect(() => {
-    const initiallyExpandedIndex = integrationsData
-      .map((integration, index) => 
-        badgeCounts(integration.items) > 0 ? index : null
-      )
-      .filter(index => index !== null) as number[];
-    setExpandedIndex(initiallyExpandedIndex);
-  }, [integrationsData, integrationCounts]);
+    if (!hasInitialized && Object.keys(integrationCounts).length > 0) {
+      const initiallyExpandedIndex = integrationsData
+        .map((integration, index) => (badgeCounts(integration.items) > 0 ? index : null))
+        .filter((index) => index !== null) as number[];
+      setExpandedIndex(initiallyExpandedIndex);
+      setHasInitialized(true);
+    }
+  }, [integrationsData, integrationCounts, hasInitialized]);
 
   const onToggle = (index: number) => {
     setExpandedIndex((prevIndices) =>


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
Fixed collapse/expand of list items within the notifications drawer. 

The issue was that the `useEffect` setting the initially expanded items would fire again whenever state changed, causing expanded items to immediately reset back to their initial state.

[RHCLOUD-36905](https://issues.redhat.com/browse/RHCLOUD-36905)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### After:
![collapseAndExpand](https://github.com/user-attachments/assets/f6594bb5-390e-4aa5-b9b5-9e84b6cd8dfc)


---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
