### PR TITLE
Fix failing overview create integration

### DIFF
--- a/src/components/Overview/CustomDataListItem.js
+++ b/src/components/Overview/CustomDataListItem.js
@@ -23,6 +23,7 @@ import { CLOUD_VENDOR, COMMUNICATIONS, REDHAT_VENDOR, REPORTING, WEBHOOKS } from
 import { AsyncComponent } from '@redhat-cloud-services/frontend-components';
 import AddSourceWizard from '../addSourceWizard';
 import { useIntl } from 'react-intl';
+import { useStore } from 'react-redux';
 
 const CustomDataListItem = ({ initialExpanded, icon, title, actionTitle, action, content, learnMoreLink }) => {
   const [isExpanded, setIsExpanded] = useState(initialExpanded);
@@ -33,6 +34,8 @@ const CustomDataListItem = ({ initialExpanded, icon, title, actionTitle, action,
   const intl = useIntl();
 
   const toggleExpand = () => setIsExpanded((prev) => !prev);
+
+  const store = useStore();
 
   return (
     <React.Fragment>
@@ -107,6 +110,7 @@ const CustomDataListItem = ({ initialExpanded, icon, title, actionTitle, action,
         <AsyncComponent
           appName="notifications"
           module="./IntegrationsWizard"
+          store={store}
           isOpen={isIntegrationsWizardOpen}
           category={selectedIntegration}
           closeModal={() => {

--- a/src/components/Widget/IntegrationsWidget.tsx
+++ b/src/components/Widget/IntegrationsWidget.tsx
@@ -12,7 +12,7 @@ import {
   Tile,
 } from '@patternfly/react-core';
 import React, { FunctionComponent, useEffect, useState } from 'react';
-import { Provider, useSelector } from 'react-redux';
+import { Provider, useSelector, useStore } from 'react-redux';
 import IntegrationsDropdown from '../IntegrationsDropdown';
 import { CLOUD_VENDOR, COMMUNICATIONS, REDHAT_VENDOR, REPORTING, WEBHOOKS } from '../../utilities/constants';
 import { getProdStore } from '../../utilities/store';
@@ -99,6 +99,8 @@ const IntegrationsWidget: FunctionComponent = () => {
     );
   };
 
+  const store = useStore();
+
   const isEmptyState = Object.values(integrationCounts).reduce((total, count) => total + count, 0) === 0;
 
   return (
@@ -130,6 +132,7 @@ const IntegrationsWidget: FunctionComponent = () => {
               <AsyncComponent
                 appName="notifications"
                 module="./IntegrationsWizard"
+                store={store}
                 isOpen={isIntegrationsWizardOpen}
                 category={selectedTileValue}
                 closeModal={() => {


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

Currently when user tries to create integration from overview page section there's an error of missing store. This PR fixes it by passing store to the loaded module.

[RHINENG-15192](https://issues.redhat.com/browse/RHINENG-15192)
[RHCLOUD-36458](https://issues.redhat.com/browse/RHCLOUD-36458)
