### PR TITLE
Replace deprecated PF table in source detail

### DIFF
--- a/src/components/SourceDetail/ResourcesTable.js
+++ b/src/components/SourceDetail/ResourcesTable.js
@@ -3,7 +3,7 @@ import { useIntl } from 'react-intl';
 import { shallowEqual, useSelector } from 'react-redux';
 import get from 'lodash/get';
 
-import { Table, TableBody, TableHeader } from '@patternfly/react-table/deprecated';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import { Alert, Bullseye, Card, CardBody, CardTitle, Spinner, Tab, TabTitleText, Tabs, Text } from '@patternfly/react-core';
 
@@ -146,19 +146,37 @@ const ResourcesTable = () => {
                       </Alert>
                     )}
                     {applicationsRows[app.id]?.length ? (
-                      <Table
-                        aria-label={intl.formatMessage({
-                          id: 'resourceTable.title',
-                          defaultMessage: 'Connected application resources',
-                        })}
-                        variant="compact"
-                        cells={columns}
-                        rows={applicationsRows[app.id]}
-                        className="pf-v5-u-mt-md"
-                      >
-                        <TableHeader />
-                        <TableBody />
-                      </Table>
+                      <React.Fragment>
+                        <Table
+                          variant="compact"
+                          aria-label={intl.formatMessage({
+                            id: 'resourceTable.title',
+                            defaultMessage: 'Connected application resources',
+                          })}
+                          className="pf-v5-u-mt-md"
+                        >
+                          <Thead>
+                            <Tr>
+                              {columns.map((item, key) => (
+                                <Th key={key} {...item.props}>
+                                  {item.title}
+                                </Th>
+                              ))}
+                            </Tr>
+                          </Thead>
+                          <Tbody>
+                            {applicationsRows[app.id].map((row, key) => (
+                              <Tr key={key}>
+                                {columns.map((cell, key) => (
+                                  <Td key={`cell-${key}`} data-label={cell.title} aria-label={cell.title} data-key={key}>
+                                    {row?.[key] || ''}
+                                  </Td>
+                                ))}
+                              </Tr>
+                            ))}
+                          </Tbody>
+                        </Table>
+                      </React.Fragment>
                     ) : (
                       <ResourcesEmptyState applicationName={appName} />
                     )}


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

Patternfly long in the past deprecated React tabular table, we should update all of our tables to use the new modular table. This PR updates the detail table for certain sources.

[RHCLOUD-28291](https://issues.redhat.com/browse/RHCLOUD-28291)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
![Screenshot 2025-01-17 at 16 05 10](https://github.com/user-attachments/assets/8286452f-906f-4d6c-8971-14fbf73008f9)


#### After:
![Screenshot 2025-01-17 at 16 04 22](https://github.com/user-attachments/assets/cfe01365-3a6c-46d3-9221-12f110fb1687)


---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [-] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [-] _(Optional) QE: Has been mentioned_
- [-] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [-] _(Optional) UX: Has been mentioned_
##
