### PR TITLE
RHCLOUD-37631 | feature: hard code the Cloud Meter wizard's AWS information

### DIFF
--- a/src/api/subscriptionWatch.js
+++ b/src/api/subscriptionWatch.js
@@ -1,3 +1,0 @@
-import { axiosInstance } from './entities';
-
-export const getSubWatchConfig = () => axiosInstance.get('/api/cloudigrade/v2/sysconfig/');

--- a/src/components/addSourceWizard/hardcodedComponents/aws/subscriptionWatch.js
+++ b/src/components/addSourceWizard/hardcodedComponents/aws/subscriptionWatch.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useIntl } from 'react-intl';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -13,32 +13,15 @@ import {
   TextVariants,
 } from '@patternfly/react-core';
 
-import { getSubWatchConfig } from '../../../../api/subscriptionWatch';
 import { useFormApi } from '@data-driven-forms/react-form-renderer';
 
 const b = (chunks) => <b key={`b-${chunks.length}-${Math.floor(Math.random() * 1000)}`}>{chunks}</b>;
 
 export const IAMRoleDescription = () => {
   const intl = useIntl();
-  const [config, setConfig] = useState();
   const externalId = useMemo(() => uuidv4(), []);
   const formOptions = useFormApi();
   const { authentication = {} } = formOptions.getState().values;
-
-  useEffect(() => {
-    getSubWatchConfig()
-      .then((conf) => setConfig(conf?.aws_account_id))
-      .catch((e) => {
-        // eslint-disable-next-line no-console
-        console.error(e);
-        setConfig(
-          intl.formatMessage({
-            id: 'subwatch.iampolicy.subWatchConfigError',
-            defaultMessage: 'There is an error with loading of the configuration. Please go back and return to this step.',
-          }),
-        );
-      });
-  }, []);
 
   useEffect(() => {
     formOptions.change('authentication', {
@@ -76,7 +59,7 @@ export const IAMRoleDescription = () => {
           )}
         </TextListItem>
         <ClipboardCopy className="pf-v5-u-m-sm-on-sm" isReadOnly>
-          {config || intl.formatMessage({ id: 'subwatch.iampolicy.loading', defaultMessage: 'Loading configuration...' })}
+          998366406740
         </ClipboardCopy>
         <TextListItem>
           {intl.formatMessage({
@@ -124,22 +107,6 @@ export const IAMRoleDescription = () => {
 
 export const IAMPolicyDescription = () => {
   const intl = useIntl();
-  const [config, setConfig] = useState();
-
-  useEffect(() => {
-    getSubWatchConfig()
-      .then((conf) => setConfig(conf?.aws_policies?.traditional_inspection))
-      .catch((e) => {
-        // eslint-disable-next-line no-console
-        console.error(e);
-        setConfig(
-          intl.formatMessage({
-            id: 'subwatch.iampolicy.subWatchConfigError',
-            defaultMessage: 'There is an error with loading of the configuration. Please go back and return to this step.',
-          }),
-        );
-      });
-  }, []);
 
   return (
     <TextContent>
@@ -181,9 +148,21 @@ export const IAMPolicyDescription = () => {
           })}
         </TextListItem>
         <ClipboardCopy isCode variant={ClipboardCopyVariant.expansion} className="pf-v5-u-m-sm-on-sm" isReadOnly>
-          {config
-            ? JSON.stringify(config, null, 2)
-            : intl.formatMessage({ id: 'subwatch.iampolicy.loading', defaultMessage: 'Loading configuration...' })}
+          {JSON.stringify(
+            {
+              Version: '2012-10-17',
+              Statement: [
+                {
+                  Sid: 'CloudigradePolicy',
+                  Effect: 'Allow',
+                  Action: ['sts:GetCallerIdentity'],
+                  Resource: '*',
+                },
+              ],
+            },
+            null,
+            2,
+          )}
         </ClipboardCopy>
         <TextListItem>
           {intl.formatMessage({

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/subscription_watch_arn.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/subscription_watch_arn.test.js
@@ -4,7 +4,6 @@ import { RendererContext } from '@data-driven-forms/react-form-renderer';
 import render from '../../__mocks__/render';
 
 import * as SubsAwsArn from '../../../../components/addSourceWizard/hardcodedComponents/aws/subscriptionWatch';
-import * as api from '../../../../api/subscriptionWatch';
 
 describe('AWS-ARN hardcoded schemas', () => {
   it('ARN DESCRIPTION is rendered correctly', () => {
@@ -18,15 +17,13 @@ describe('AWS-ARN hardcoded schemas', () => {
   });
 
   it('IAM POLICY is rendered correctly', async () => {
-    const IAM_POLICY = { version: '1234' };
-    const CONFIG = { some: 'fake', config: 'oh yeah', aws_policies: { traditional_inspection: IAM_POLICY } };
-    api.getSubWatchConfig = jest.fn().mockImplementation(() => Promise.resolve(CONFIG));
-
     render(<SubsAwsArn.IAMPolicyDescription />);
 
-    expect(screen.getByLabelText('Copyable input')).toHaveValue(`Loading configuration...`);
-
-    await waitFor(() => expect(screen.getByLabelText('Copyable input')).toHaveValue(`{   "version": "1234" }`));
+    await waitFor(() =>
+      expect(screen.getByLabelText('Copyable input')).toHaveValue(
+        `{   "Version": "2012-10-17",   "Statement": [     {       "Sid": "CloudigradePolicy",       "Effect": "Allow",       "Action": [         "sts:GetCallerIdentity"       ],       "Resource": "*"     }   ] }`,
+      ),
+    );
 
     expect(
       screen.getByText(
@@ -42,33 +39,7 @@ describe('AWS-ARN hardcoded schemas', () => {
     expect(screen.getByText('Complete the process to create your new policy.', { exact: false })).toBeInTheDocument();
   });
 
-  it('IAM POLICY is rendered correctly with error', async () => {
-    const _cons = console.error;
-    console.error = jest.fn();
-
-    const ERROR = 'Something went wrong';
-    api.getSubWatchConfig = jest.fn().mockImplementation(() => Promise.reject(ERROR));
-
-    render(<SubsAwsArn.IAMPolicyDescription />);
-
-    expect(screen.getByLabelText('Copyable input')).toHaveValue(`Loading configuration...`);
-
-    await waitFor(() =>
-      expect(screen.getByLabelText('Copyable input')).toHaveValue(
-        JSON.stringify('There is an error with loading of the configuration. Please go back and return to this step.', null, 2),
-      ),
-    );
-
-    expect(console.error).toHaveBeenCalledWith(ERROR);
-
-    console.error = _cons;
-  });
-
   it('IAM ROLE is rendered correctly with external ID', async () => {
-    const CM_ID = '372779871274';
-    const CONFIG = { aws_account_id: CM_ID };
-    api.getSubWatchConfig = jest.fn().mockImplementation(() => Promise.resolve(CONFIG));
-
     render(
       <RendererContext.Provider
         value={{
@@ -81,10 +52,9 @@ describe('AWS-ARN hardcoded schemas', () => {
         <SubsAwsArn.IAMRoleDescription />
       </RendererContext.Provider>,
     );
-    expect(screen.getAllByLabelText('Copyable input').at(0)).toHaveValue(`Loading configuration...`);
     expect(screen.getAllByLabelText('Copyable input').at(1)).toBeInTheDocument();
 
-    await waitFor(() => expect(screen.getAllByLabelText('Copyable input').at(0)).toHaveValue(CM_ID));
+    await waitFor(() => expect(screen.getAllByLabelText('Copyable input').at(0)).toHaveValue('998366406740'));
 
     expect(
       screen.getByText('To delegate account access, create an IAM role to associate with your IAM policy.', { exact: false }),
@@ -99,33 +69,5 @@ describe('AWS-ARN hardcoded schemas', () => {
       screen.getByText('You will need to be logged in to the IAM console to complete the next step', { exact: false }),
     ).toBeInTheDocument();
     expect(screen.getByText('Do not close your browser.', { exact: false })).toBeInTheDocument();
-  });
-
-  it('IAM ROLE is rendered correctly with error', async () => {
-    const _cons = console.error;
-    console.error = jest.fn();
-
-    const ERROR = 'Something went wrong';
-    api.getSubWatchConfig = jest.fn().mockImplementation(() => Promise.reject(ERROR));
-
-    render(
-      <RendererContext.Provider
-        value={{
-          formOptions: { getState: () => ({ values: {} }), change: () => null },
-        }}
-      >
-        <SubsAwsArn.IAMRoleDescription />
-      </RendererContext.Provider>,
-    );
-    expect(screen.getAllByLabelText('Copyable input').at(0)).toHaveValue(`Loading configuration...`);
-    expect(screen.getAllByLabelText('Copyable input').at(1)).toBeInTheDocument();
-
-    await waitFor(() =>
-      expect(screen.getAllByLabelText('Copyable input').at(0)).toHaveValue(
-        'There is an error with loading of the configuration. Please go back and return to this step.',
-      ),
-    );
-    expect(console.error).toHaveBeenCalledWith(ERROR);
-    console.error = _cons;
   });
 });


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
description text...
The Cloud Meter or subscription watch team wants to sunset and delete the endpoint they are maintaining right now to fetch the AWS information, especially because it is returning static data to the customers.

In that regard, we can follow the approach we follow with other applications like Cost Management, where the AWS information is just hard coded in the UI.

[RHCLOUD-37631](https://issues.redhat.com/browse/RHCLOUD-37631)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
None.

#### After:
None.

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
