### PR TITLE
fix(integrations-widget): auth refresh breaks the widget

### DIFF
--- a/src/components/PermissionsChecker.js
+++ b/src/components/PermissionsChecker.js
@@ -17,7 +17,7 @@ const PermissionsChecker = ({ children }) => {
       dispatch(loadOrgAdmin(getUser)),
       dispatch(loadIntegrationsEndpointsPermissions(getUserPermissions)),
     ]);
-  }, []);
+  }, [getUser, getUserPermissions]);
 
   return children;
 };


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

Auth refresh breaks the integrations widget because we have old reference to user and their permissions. This PR fixes it by running the auth check on each user change

[RHCLOUD-37479](https://issues.redhat.com/browse/RHCLOUD-37479)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
![Screenshot 2025-06-04 at 16 21 06](https://github.com/user-attachments/assets/cc30c1f6-a0d0-46ed-8b73-02867f79a669)


#### After:
![Screenshot 2025-06-04 at 16 21 01](https://github.com/user-attachments/assets/96ce2414-2b3a-443c-a6bf-d69d9291e6f7)


---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [-] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [-] _(Optional) QE: Has been mentioned_
- [-] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [-] _(Optional) UX: Has been mentioned_
##
