### PR TITLE
fix(PF6): aria-label on surces table

### DIFF
--- a/src/components/SourcesTable/SourcesTable.js
+++ b/src/components/SourcesTable/SourcesTable.js
@@ -271,6 +271,7 @@ const SourcesTable = () => {
   return (
     <DataView activeState={activeState}>
       <DataViewTable
+        aria-label="List of Integrations"
         bodyStates={{
           [DataViewState.empty]: <EmptyStateDataView columns={dwColumns.length} />,
           [DataViewState.loading]: <DWPlaceHolderTable columns={dwColumns.length} />,


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

With PF6 upgrade of sources application the selector for sources table contained `aria-label` so let's add it back.