### PR TITLE
fix(source-detail): add aria labels to actions on source detail

### DIFF
--- a/src/components/SourceDetail/SourceKebab.js
+++ b/src/components/SourceDetail/SourceKebab.js
@@ -64,6 +64,10 @@ const SourceKebab = () => {
           id: 'detail.resume.description',
           defaultMessage: 'Unpause data collection for this integration',
         })}
+        aria-label={intl.formatMessage({
+          id: 'detail.resume.button',
+          defaultMessage: 'Resume',
+        })}
       >
         {intl.formatMessage({
           id: 'detail.resume.button',
@@ -87,6 +91,10 @@ const SourceKebab = () => {
         description={intl.formatMessage({
           id: 'detail.pause.description',
           defaultMessage: 'Temporarily disable data collection',
+        })}
+        aria-label={intl.formatMessage({
+          id: 'detail.pause.button',
+          defaultMessage: 'Pause',
         })}
       >
         {intl.formatMessage({
@@ -113,6 +121,10 @@ const SourceKebab = () => {
         id: 'detail.remove.description',
         defaultMessage: 'Permanently delete this integration and all collected data',
       })}
+      aria-label={intl.formatMessage({
+        id: 'detail.remove.button',
+        defaultMessage: 'Remove',
+      })}
     >
       {intl.formatMessage({
         id: 'detail.remove.button',
@@ -121,6 +133,10 @@ const SourceKebab = () => {
     </DropdownItem>,
     <DropdownItem
       key="rename"
+      aria-label={intl.formatMessage({
+        id: 'detail.rename.button',
+        defaultMessage: 'Rename',
+      })}
       component={forwardRef(({ isDisabled, ...props }, ref) => {
         return (
           <DisabledDropdownItemWithTooltip


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

Currently if user navigates to source detail they don't have aria label available on integration actions. This PR fixes it by adding this prop to each action.
