### PR TITLE
patch: use upcomming root widget CSS selectors

### DIFF
--- a/src/components/Widget/IntegrationsWidget.scss
+++ b/src/components/Widget/IntegrationsWidget.scss
@@ -1,4 +1,4 @@
-.sources-integrations {
+.sources-integrations, [class*="sources-sources-./IntegrationsWidget"] {
   overflow-y: auto;
   .pf-v6-c-card__body {
     padding: var(--pf-v5-global--spacer--sm) 0 0 0;


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-41601

Changes
Ensures that the root widget element class names match the future widget IDs