### PR TITLE
disable 'next' when no application has been selected cloud integration

### DIFF
--- a/src/components/addSourceWizard/SourceAddSchema.js
+++ b/src/components/addSourceWizard/SourceAddSchema.js
@@ -166,6 +166,18 @@ const redhatTypes = ({ intl, sourceTypes, applicationTypes, disableAppSelection 
   },
 ];
 
+// Custom validator to ensure a real application is selected (not NO_APPLICATION_VALUE)
+const validateApplicationSelection = (intl) => (value) => {
+  if (!value || value === NO_APPLICATION_VALUE) {
+    return intl.formatMessage({
+      id: 'wizard.applicationRequired',
+      defaultMessage: 'An application must be selected.',
+    });
+  }
+
+  return undefined;
+};
+
 export const applicationStep = (applicationTypes, intl, activeCategory, hcsEnrolled) => ({
   name: 'application_step',
   title: intl.formatMessage({
@@ -212,7 +224,7 @@ export const applicationStep = (applicationTypes, intl, activeCategory, hcsEnrol
       mutator: appMutatorRedHat(applicationTypes),
       menuIsPortal: true,
       isRequired: true,
-      validate: [{ type: validatorTypes.REQUIRED }],
+      validate: [validateApplicationSelection(intl)],
     },
     {
       component: componentTypes.TEXT_FIELD,


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
Next button on Step 4 in Add a cloud integration wizard not behaving properly

[RHCLOUD-40993](https://issues.redhat.com/browse/RHCLOUD-40993)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
