### PR TITLE
fix(source-tiles): update clouds logos

### DIFF
--- a/src/components/CloudTiles/CloudTiles.js
+++ b/src/components/CloudTiles/CloudTiles.js
@@ -14,7 +14,7 @@ const mapper = (type, openWizard, TileComponent) =>
         icon={
           <ImageWithPlaceholder
             className="provider-icon pf-v6-u-mb-sm"
-            src="/apps/frontend-assets/partners-icons/aws.svg"
+            src="/apps/frontend-assets/partners-icons/aws-logomark.svg"
             alt="aws logo"
           />
         }
@@ -30,7 +30,7 @@ const mapper = (type, openWizard, TileComponent) =>
         icon={
           <ImageWithPlaceholder
             className="provider-icon pf-v6-u-mb-sm"
-            src="/apps/frontend-assets/partners-icons/google-cloud-short.svg"
+            src="/apps/frontend-assets/partners-icons/google-cloud-logomark.svg"
             alt="google logo"
           />
         }
@@ -46,7 +46,7 @@ const mapper = (type, openWizard, TileComponent) =>
         icon={
           <ImageWithPlaceholder
             className="provider-icon pf-v6-u-mb-sm"
-            src="/apps/frontend-assets/partners-icons/microsoft-azure-short.svg"
+            src="/apps/frontend-assets/partners-icons/microsoft-azure-logomark.svg"
             alt="azure logo"
           />
         }

--- a/src/components/Widget/consts/widgetData.tsx
+++ b/src/components/Widget/consts/widgetData.tsx
@@ -153,7 +153,7 @@ export const createIntegrationsData = (
               id: 'aws',
               value: CLOUD_VENDOR,
               icon: (
-                <ImageWithPlaceholder className="aws-logo" src="/apps/frontend-assets/partners-icons/aws.svg" alt="aws logo" />
+                <ImageWithPlaceholder className="aws-logo" src="/apps/frontend-assets/partners-icons/aws-logomark.svg" alt="aws logo" />
               ),
             },
             {
@@ -163,7 +163,7 @@ export const createIntegrationsData = (
               icon: (
                 <ImageWithPlaceholder
                   className="google-logo"
-                  src="/apps/frontend-assets/partners-icons/google-cloud-short.svg"
+                  src="/apps/frontend-assets/partners-icons/google-cloud-logomark.svg"
                   alt="google logo"
                 />
               ),
@@ -175,7 +175,7 @@ export const createIntegrationsData = (
               icon: (
                 <ImageWithPlaceholder
                   className="azure-logo"
-                  src="/apps/frontend-assets/partners-icons/microsoft-azure-short.svg"
+                  src="/apps/frontend-assets/partners-icons/microsoft-azure-logomark.svg"
                   alt="azure logo"
                 />
               ),

--- a/src/components/addSourceWizard/SourceAddSchema.js
+++ b/src/components/addSourceWizard/SourceAddSchema.js
@@ -81,12 +81,12 @@ export const appMutatorRedHat = (appTypes) => (option, formOptions) => {
 };
 
 const shortIcons = {
-  amazon: '/apps/frontend-assets/partners-icons/aws.svg',
+  amazon: '/apps/frontend-assets/partners-icons/aws-logomark.svg',
   'ansible-tower': '/apps/frontend-assets/red-hat-logos/stacked.svg',
-  azure: '/apps/frontend-assets/partners-icons/microsoft-azure-short.svg',
+  azure: '/apps/frontend-assets/partners-icons/microsoft-azure-logomark.svg',
   openshift: '/apps/frontend-assets/red-hat-logos/stacked.svg',
   satellite: '/apps/frontend-assets/red-hat-logos/stacked.svg',
-  google: '/apps/frontend-assets/partners-icons/google-cloud-short.svg',
+  google: '/apps/frontend-assets/partners-icons/google-cloud-logomark.svg',
 };
 
 // eslint-disable-next-line react/display-name


### PR DESCRIPTION
### Description
Hi. We found out in the image builder services, that the asset's URL has changed. I figured out you might like knowing about this, too. :)
https://github.com/osbuild/image-builder-frontend/pull/3505
<img width="860" height="527" alt="image" src="https://github.com/user-attachments/assets/cfa9dd8a-1c66-4e52-8bff-ed2fb968ef41" />
