### PR TITLE
fix: Resolve intermittent SVG loading issues in ImageWithPlaceholder

### DIFF
--- a/src/components/TilesShared/ImageWithPlaceholder.js
+++ b/src/components/TilesShared/ImageWithPlaceholder.js
@@ -1,18 +1,44 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { Loader } from '../SourcesTable/loaders';
 
 const ImageWithPlaceholder = ({ src, width = '110px', height = '40px', ...rest }) => {
   const [loaded, setLoaded] = useState(false);
+  const imgRef = useRef(null);
+
+  useEffect(() => {
+    // Check if image is already loaded (cached)
+    if (imgRef.current && imgRef.current.complete && imgRef.current.naturalHeight !== 0) {
+      setLoaded(true);
+    }
+
+    // Fallback timeout for cases where onLoad doesn't fire
+    const fallbackTimer = setTimeout(() => {
+      setLoaded(true);
+    }, 3000);
+
+    return () => clearTimeout(fallbackTimer);
+  }, [src]);
+
+  const handleLoad = () => {
+    setLoaded(true);
+  };
+
+  const handleError = () => {
+    // Show image even if there's an error to prevent permanent loading state
+    setLoaded(true);
+  };
 
   return (
     <React.Fragment>
       {!loaded && <Loader height={height} width={width} {...rest} />}
       <img
+        ref={imgRef}
         src={src}
         data-testid="ImageWithPlaceholder"
-        onLoad={() => setLoaded(true)}
+        onLoad={handleLoad}
+        onError={handleError}
         style={{ display: loaded ? 'initial' : 'none' }}
         width={width}
         height={height}


### PR DESCRIPTION
- Add useRef to detect already cached/loaded images
- Implement onError handler to prevent permanent loading states
- Add 3-second fallback timeout for cases where onLoad doesn't fire
- Fix race conditions with SVG loading, especially for cached assets
- Improve reliability of cloud provider logo display (AWS, Google, Azure, IBM)

Fixes intermittent display issues where SVGs would sometimes not appear in the cloud integration selection tiles.

### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
description text...

[RHCLOUDXXXX](https://issues.redhat.com/browse/RHCLOUDXXXX)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
<img width="1059" height="726" alt="Screenshot 2025-08-29 at 9 42 56 AM" src="https://github.com/user-attachments/assets/fb00cd16-1b1b-4438-a341-4fd25bfb8425" />

#### After:
<img width="1051" height="737" alt="Screenshot 2025-08-29 at 9 42 44 AM" src="https://github.com/user-attachments/assets/9983f7f6-ce28-4d77-8a41-38da16d2d4f8" />

---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
