### PR TITLE
refactor: Cost Management's stage AWS account

### DIFF
--- a/src/components/addSourceWizard/hardcodedComponents/aws/arn.js
+++ b/src/components/addSourceWizard/hardcodedComponents/aws/arn.js
@@ -215,7 +215,6 @@ export const IAMRoleDescription = () => {
   const externalId = useMemo(() => uuidv4(), []);
   const formOptions = useFormApi();
   const { authentication = {} } = formOptions.getState().values;
-  const isNewHccmStgAwsAccount = useFlag('platform.sources.integrations.new-hccm-stg-account');
 
   useEffect(() => {
     formOptions.change('authentication', {
@@ -247,7 +246,7 @@ export const IAMRoleDescription = () => {
           })}
         </Content>
         <ClipboardCopy className="pf-v6-u-m-sm-on-sm" isReadOnly>
-          {isNewHccmStgAwsAccount ? '148761653619' : '589173575009'}
+          148761653619
         </ClipboardCopy>
         <Content component="li">
           {intl.formatMessage({

--- a/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/arn.test.js
+++ b/src/test/addSourceWizard/addSourceWizard/hardCodedComponents/arn.test.js
@@ -126,7 +126,7 @@ describe('AWS-ARN hardcoded schemas', () => {
     expect(screen.getByText('Attach the permissions policy that you just created.')).toBeInTheDocument();
     expect(screen.getByText('Complete the process to create your new role.')).toBeInTheDocument();
     expect(screen.getAllByRole('textbox', { name: 'Copyable input' })).toHaveLength(2);
-    expect(screen.getAllByRole('textbox', { name: 'Copyable input' })[0]).toHaveValue('589173575009');
+    expect(screen.getAllByRole('textbox', { name: 'Copyable input' })[0]).toHaveValue('148761653619');
     expect(screen.getAllByRole('textbox', { name: 'Copyable input' })[1]).toHaveValue('test-uuid');
     expect(changeSpy).toHaveBeenCalledWith('authentication', {
       extra: expect.objectContaining({ external_id: expect.any(String) }),
@@ -164,7 +164,7 @@ describe('AWS-ARN hardcoded schemas', () => {
     expect(screen.getByText('Attach the permissions policy that you just created.')).toBeInTheDocument();
     expect(screen.getByText('Complete the process to create your new role.')).toBeInTheDocument();
     expect(screen.getAllByRole('textbox', { name: 'Copyable input' })).toHaveLength(2);
-    expect(screen.getAllByRole('textbox', { name: 'Copyable input' })[0]).toHaveValue('589173575009');
+    expect(screen.getAllByRole('textbox', { name: 'Copyable input' })[0]).toHaveValue('148761653619');
     expect(screen.getAllByRole('textbox', { name: 'Copyable input' })[1]).toHaveValue('test-uuid');
     expect(changeSpy).toHaveBeenCalledWith('authentication', {
       extra: expect.objectContaining({ external_id: expect.any(String) }),


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
Cost Management requested to replace the stage's AWS account.

[RHCLOUD-42135](https://issues.redhat.com/browse/RHCLOUD-42135)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)
