### PR TITLE
fix(svg-contrast): fix issue with insufficient svg contrast

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -158,6 +158,10 @@ form.src-c-uuid {
   }
 }
 
+.pf-v6-c-tile {
+  background-color: var(--pf-t--global--background--color--600);
+}
+
 .src-c-application_flex {
   display: flex;
   align-items: center;


### PR DESCRIPTION
### Description
Adds an explicit `background-color` to the `.pf-v6-c-tile` component using the PatternFly design token `--pf-t--global--background--color--600`. Without this, the tile's default background does not meet sufficient contrast requirements for SVG icons rendered inside it. This brings the tile component in line with accessibility contrast standards.

[RHCLOUD47093](https://issues.redhat.com/browse/RHCLOUD-47093)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
<img width="1020" height="406" alt="image" src="https://github.com/user-attachments/assets/97a6a074-7b89-456d-84af-356940a5f5a7" />
<img width="1018" height="417" alt="image" src="https://github.com/user-attachments/assets/e2209bfb-1645-4b67-b8e6-db903d1e5d79" />


#### After:
<img width="988" height="408" alt="image" src="https://github.com/user-attachments/assets/2bc71ee6-b769-4db6-ae7d-e61ecc41004a" />
<img width="776" height="403" alt="image" src="https://github.com/user-attachments/assets/480c1628-0446-4652-998e-c4d21dd06c9f" />




---

### Checklist ☑️
- [X] PR only fixes one issue or story <!-- open new PR for others -->
- [X] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [X] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [X] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
