### PR TITLE
feat(RBAC): Add v1 wildcard fallback for v2 orgs

### DIFF
--- a/HYBRID_RBAC_SUMMARY.md
+++ b/HYBRID_RBAC_SUMMARY.md
@@ -166,6 +166,63 @@ useEffect(() => {
 - Monitor Kessel API calls
 - Monitor error rates
 
+## V2 RBAC with V1 Wildcard Fallback (TEMPORARY)
+
+### Current Behavior
+
+For v2 orgs (when `platform.rbac.workspaces` flag is ON), we fetch BOTH Kessel v2 permissions AND v1 Chrome API permissions, then combine them using OR logic in `PermissionsChecker.tsx`:
+
+```typescript
+// Load v1 Chrome API permissions for integrations (even on v2 orgs)
+useEffect(() => {
+  dispatch(loadIntegrationsEndpointsPermissions(getUserPermissions));
+  dispatch(loadIntegrationsReadPermissions(getUserPermissions));
+}, [getUserPermissions, dispatch]);
+
+// Then overlay Kessel v2 permissions (for v2 orgs only)
+useEffect(() => {
+  if (isV2Org && !isKesselLoading) {
+    dispatch(loadPermissionsFromKessel(kesselPermissions));
+  }
+}, [isV2Org, isKesselLoading, kesselPermissions, dispatch]);
+```
+
+The Redux reducer combines them with OR logic - permission granted if EITHER v1 OR v2 check passes.
+
+### Why This Exists
+
+Kessel v2 does not currently support **wildcard permission expansion**. Org Admins and some legacy roles have wildcard permissions like:
+- `integrations:*:*`
+- `integrations:endpoints:*`
+
+Without the v1 fallback, these users would **lose access** when their org is moved to v2.
+
+### Known Issue
+
+This creates a **permanent dependency on v1 Chrome API** for v2 orgs, which defeats the purpose of migrating to v2. Once we're fully on v2, we still call the v1 permissions endpoint.
+
+### When to Remove
+
+Remove this fallback logic once **EITHER**:
+1. Kessel v2 supports wildcard permission expansion, **OR**
+2. All wildcard permissions are migrated to explicit Kessel workspace relations
+
+### Coordinated Removal Required
+
+This same pattern exists in:
+- **notifications-frontend**: `src/app/useApp.ts`
+- **sources-ui**: `src/components/PermissionsChecker.tsx` (this repo)
+- **insights-chrome**: RBACProvider (see PR #3362)
+
+All three repos must be updated together to avoid breaking permissions.
+
+### References
+
+- Chrome PR: https://github.com/RedHatInsights/insights-chrome/pull/3362
+- Related Jira: RHCLOUD-48396
+
+---
+
 ## Future: Sources Migration to Kessel
 
 When the sources service team migrates to Kessel:

--- a/src/components/PermissionsChecker.tsx
+++ b/src/components/PermissionsChecker.tsx
@@ -49,7 +49,6 @@ const PermissionsChecker: React.FC<PermissionsCheckerProps> = ({ children }) => 
   // Effect to load v1 integrations permissions (for v1 orgs only)
   useEffect(() => {
     if (!isV2Org) {
-      console.log('[SOURCES RBAC DEBUG] v1 org - loading Chrome API permissions');
       Promise.all([
         dispatch(loadIntegrationsEndpointsPermissions(getUserPermissions)),
         dispatch(loadIntegrationsReadPermissions(getUserPermissions)),
@@ -64,15 +63,12 @@ const PermissionsChecker: React.FC<PermissionsCheckerProps> = ({ children }) => 
       // Kessel v2 does not support wildcard expansion, so we must check v1 wildcards
       // (integrations:*:*, notifications:*:*) as fallback for Org Admins and legacy roles.
       // See: https://github.com/RedHatInsights/insights-chrome/pull/3362
-      console.log('[SOURCES RBAC DEBUG] v2 org - loading Kessel + v1 fallback');
       dispatch(loadPermissionsFromKessel(kesselPermissions));
       // Also load v1 permissions for wildcard fallback
       Promise.all([
         dispatch(loadIntegrationsEndpointsPermissions(getUserPermissions)),
         dispatch(loadIntegrationsReadPermissions(getUserPermissions)),
-      ]).then(() => {
-        console.log('[SOURCES RBAC DEBUG] v1 fallback permissions loaded');
-      });
+      ]);
     }
   }, [isV2Org, isKesselLoading, kesselPermissions, getUserPermissions, dispatch]);
 

--- a/src/components/PermissionsChecker.tsx
+++ b/src/components/PermissionsChecker.tsx
@@ -46,25 +46,33 @@ const PermissionsChecker: React.FC<PermissionsCheckerProps> = ({ children }) => 
     dispatch(loadWritePermissions(getUserPermissions));
   }, [getUserPermissions, dispatch]);
 
-  // Effect to load integrations permissions
+  // Effect to load v1 integrations permissions (for v1 orgs only)
+  useEffect(() => {
+    if (!isV2Org) {
+      console.log('[SOURCES RBAC DEBUG] v1 org - loading Chrome API permissions');
+      Promise.all([
+        dispatch(loadIntegrationsEndpointsPermissions(getUserPermissions)),
+        dispatch(loadIntegrationsReadPermissions(getUserPermissions)),
+      ]);
+    }
+  }, [isV2Org, getUserPermissions, dispatch]);
+
+  // Effect to load integrations permissions for v2 orgs (Kessel + v1 fallback)
   useEffect(() => {
     if (isV2Org && !isKesselLoading) {
       // v2 org: Use Kessel for integrations permissions AND load v1 for wildcard fallback
       // Kessel v2 does not support wildcard expansion, so we must check v1 wildcards
       // (integrations:*:*, notifications:*:*) as fallback for Org Admins and legacy roles.
       // See: https://github.com/RedHatInsights/insights-chrome/pull/3362
+      console.log('[SOURCES RBAC DEBUG] v2 org - loading Kessel + v1 fallback');
       dispatch(loadPermissionsFromKessel(kesselPermissions));
       // Also load v1 permissions for wildcard fallback
       Promise.all([
         dispatch(loadIntegrationsEndpointsPermissions(getUserPermissions)),
         dispatch(loadIntegrationsReadPermissions(getUserPermissions)),
-      ]);
-    } else if (!isV2Org) {
-      // v1 org: Use Chrome API for integrations permissions
-      Promise.all([
-        dispatch(loadIntegrationsEndpointsPermissions(getUserPermissions)),
-        dispatch(loadIntegrationsReadPermissions(getUserPermissions)),
-      ]);
+      ]).then(() => {
+        console.log('[SOURCES RBAC DEBUG] v1 fallback permissions loaded');
+      });
     }
   }, [isV2Org, isKesselLoading, kesselPermissions, getUserPermissions, dispatch]);
 

--- a/src/components/PermissionsChecker.tsx
+++ b/src/components/PermissionsChecker.tsx
@@ -49,8 +49,16 @@ const PermissionsChecker: React.FC<PermissionsCheckerProps> = ({ children }) => 
   // Effect to load integrations permissions
   useEffect(() => {
     if (isV2Org && !isKesselLoading) {
-      // v2 org: Use Kessel for integrations permissions
+      // v2 org: Use Kessel for integrations permissions AND load v1 for wildcard fallback
+      // Kessel v2 does not support wildcard expansion, so we must check v1 wildcards
+      // (integrations:*:*, notifications:*:*) as fallback for Org Admins and legacy roles.
+      // See: https://github.com/RedHatInsights/insights-chrome/pull/3362
       dispatch(loadPermissionsFromKessel(kesselPermissions));
+      // Also load v1 permissions for wildcard fallback
+      Promise.all([
+        dispatch(loadIntegrationsEndpointsPermissions(getUserPermissions)),
+        dispatch(loadIntegrationsReadPermissions(getUserPermissions)),
+      ]);
     } else if (!isV2Org) {
       // v1 org: Use Chrome API for integrations permissions
       Promise.all([

--- a/src/redux/user/actions.js
+++ b/src/redux/user/actions.js
@@ -37,18 +37,12 @@ export const loadIntegrationsEndpointsPermissions = (getUserPermissions) => (dis
         allPermission.includes('integrations:*:write') ||
         allPermission.includes('integrations:endpoints:write');
 
-      console.log('[SOURCES RBAC DEBUG] loadIntegrationsEndpointsPermissions result:', {
-        allPermission,
-        integrationsEndpointsPermissions,
-      });
-
       dispatch({
         type: ACTION_TYPES.SET_INTEGRATIONS_ENDPOINTS_PERMISSIONS_FULFILLED,
         payload: integrationsEndpointsPermissions,
       });
     })
-    .catch((error) => {
-      console.error('[SOURCES RBAC DEBUG] loadIntegrationsEndpointsPermissions FAILED:', error);
+    .catch((error) =>
       dispatch({
         type: ACTION_TYPES.SET_INTEGRATIONS_ENDPOINTS_PERMISSIONS_REJECTED,
         payload: {
@@ -57,8 +51,8 @@ export const loadIntegrationsEndpointsPermissions = (getUserPermissions) => (dis
             title: "Cannot get user's credentials",
           },
         },
-      });
-    });
+      }),
+    );
 };
 
 export const loadIntegrationsReadPermissions = (getUserPermissions) => (dispatch) => {
@@ -72,18 +66,12 @@ export const loadIntegrationsReadPermissions = (getUserPermissions) => (dispatch
         allPermission.includes('integrations:*:read') ||
         allPermission.includes('integrations:endpoints:read');
 
-      console.log('[SOURCES RBAC DEBUG] loadIntegrationsReadPermissions result:', {
-        allPermission,
-        integrationsReadPermissions,
-      });
-
       dispatch({
         type: ACTION_TYPES.SET_INTEGRATIONS_READ_PERMISSIONS_FULFILLED,
         payload: integrationsReadPermissions,
       });
     })
-    .catch((error) => {
-      console.error('[SOURCES RBAC DEBUG] loadIntegrationsReadPermissions FAILED:', error);
+    .catch((error) =>
       dispatch({
         type: ACTION_TYPES.SET_INTEGRATIONS_READ_PERMISSIONS_REJECTED,
         payload: {
@@ -92,8 +80,8 @@ export const loadIntegrationsReadPermissions = (getUserPermissions) => (dispatch
             title: "Cannot get user's credentials",
           },
         },
-      });
-    });
+      }),
+    );
 };
 
 export const loadOrgAdmin = (getUser) => (dispatch) => {

--- a/src/redux/user/actions.js
+++ b/src/redux/user/actions.js
@@ -37,12 +37,18 @@ export const loadIntegrationsEndpointsPermissions = (getUserPermissions) => (dis
         allPermission.includes('integrations:*:write') ||
         allPermission.includes('integrations:endpoints:write');
 
+      console.log('[SOURCES RBAC DEBUG] loadIntegrationsEndpointsPermissions result:', {
+        allPermission,
+        integrationsEndpointsPermissions,
+      });
+
       dispatch({
         type: ACTION_TYPES.SET_INTEGRATIONS_ENDPOINTS_PERMISSIONS_FULFILLED,
         payload: integrationsEndpointsPermissions,
       });
     })
-    .catch((error) =>
+    .catch((error) => {
+      console.error('[SOURCES RBAC DEBUG] loadIntegrationsEndpointsPermissions FAILED:', error);
       dispatch({
         type: ACTION_TYPES.SET_INTEGRATIONS_ENDPOINTS_PERMISSIONS_REJECTED,
         payload: {
@@ -51,8 +57,8 @@ export const loadIntegrationsEndpointsPermissions = (getUserPermissions) => (dis
             title: "Cannot get user's credentials",
           },
         },
-      }),
-    );
+      });
+    });
 };
 
 export const loadIntegrationsReadPermissions = (getUserPermissions) => (dispatch) => {
@@ -62,14 +68,22 @@ export const loadIntegrationsReadPermissions = (getUserPermissions) => (dispatch
     .then((permissions) => {
       const allPermission = permissions.map((curr) => curr?.permission);
       const integrationsReadPermissions =
-        allPermission.includes('integrations:*:read') || allPermission.includes('integrations:endpoints:read');
+        allPermission.includes('integrations:*:*') ||
+        allPermission.includes('integrations:*:read') ||
+        allPermission.includes('integrations:endpoints:read');
+
+      console.log('[SOURCES RBAC DEBUG] loadIntegrationsReadPermissions result:', {
+        allPermission,
+        integrationsReadPermissions,
+      });
 
       dispatch({
         type: ACTION_TYPES.SET_INTEGRATIONS_READ_PERMISSIONS_FULFILLED,
         payload: integrationsReadPermissions,
       });
     })
-    .catch((error) =>
+    .catch((error) => {
+      console.error('[SOURCES RBAC DEBUG] loadIntegrationsReadPermissions FAILED:', error);
       dispatch({
         type: ACTION_TYPES.SET_INTEGRATIONS_READ_PERMISSIONS_REJECTED,
         payload: {
@@ -78,8 +92,8 @@ export const loadIntegrationsReadPermissions = (getUserPermissions) => (dispatch
             title: "Cannot get user's credentials",
           },
         },
-      }),
-    );
+      });
+    });
 };
 
 export const loadOrgAdmin = (getUser) => (dispatch) => {

--- a/src/redux/user/reducer.js
+++ b/src/redux/user/reducer.js
@@ -35,9 +35,10 @@ export const integrationsEndpointsPermissionsPending = (state) => ({
 export const integrationsEndpointsPermissionsLoaded = (state, { payload: integrationsEndpointsPermissions }) => ({
   ...state,
   // Use OR logic to combine permissions - if either Kessel v2 OR v1 wildcard grants access, allow it
+  // Prioritize new value, but keep true if state was already true
   // This handles the case where Kessel v2 doesn't support wildcard expansion
   // See: https://github.com/RedHatInsights/insights-chrome/pull/3362
-  integrationsEndpointsPermissions: state.integrationsEndpointsPermissions || integrationsEndpointsPermissions,
+  integrationsEndpointsPermissions: integrationsEndpointsPermissions || state.integrationsEndpointsPermissions,
 });
 
 export const integrationsReadPermissionsPending = (state) => ({
@@ -48,9 +49,10 @@ export const integrationsReadPermissionsPending = (state) => ({
 export const integrationsReadPermissionsLoaded = (state, { payload: integrationsReadPermissions }) => ({
   ...state,
   // Use OR logic to combine permissions - if either Kessel v2 OR v1 wildcard grants access, allow it
+  // Prioritize new value, but keep true if state was already true
   // This handles the case where Kessel v2 doesn't support wildcard expansion
   // See: https://github.com/RedHatInsights/insights-chrome/pull/3362
-  integrationsReadPermissions: state.integrationsReadPermissions || integrationsReadPermissions,
+  integrationsReadPermissions: integrationsReadPermissions || state.integrationsReadPermissions,
 });
 
 export default {

--- a/src/redux/user/reducer.js
+++ b/src/redux/user/reducer.js
@@ -34,7 +34,10 @@ export const integrationsEndpointsPermissionsPending = (state) => ({
 
 export const integrationsEndpointsPermissionsLoaded = (state, { payload: integrationsEndpointsPermissions }) => ({
   ...state,
-  integrationsEndpointsPermissions,
+  // Use OR logic to combine permissions - if either Kessel v2 OR v1 wildcard grants access, allow it
+  // This handles the case where Kessel v2 doesn't support wildcard expansion
+  // See: https://github.com/RedHatInsights/insights-chrome/pull/3362
+  integrationsEndpointsPermissions: state.integrationsEndpointsPermissions || integrationsEndpointsPermissions,
 });
 
 export const integrationsReadPermissionsPending = (state) => ({
@@ -44,7 +47,10 @@ export const integrationsReadPermissionsPending = (state) => ({
 
 export const integrationsReadPermissionsLoaded = (state, { payload: integrationsReadPermissions }) => ({
   ...state,
-  integrationsReadPermissions,
+  // Use OR logic to combine permissions - if either Kessel v2 OR v1 wildcard grants access, allow it
+  // This handles the case where Kessel v2 doesn't support wildcard expansion
+  // See: https://github.com/RedHatInsights/insights-chrome/pull/3362
+  integrationsReadPermissions: state.integrationsReadPermissions || integrationsReadPermissions,
 });
 
 export default {

--- a/src/test/components/PermissionsChecker.test.tsx
+++ b/src/test/components/PermissionsChecker.test.tsx
@@ -148,13 +148,15 @@ describe('PermissionsChecker - Hybrid RBAC', () => {
       });
     });
 
-    it('does NOT load integrations via Chrome API', async () => {
+    it('ALSO loads integrations via Chrome API for v1 wildcard fallback', async () => {
       renderWithProviders();
 
       await waitFor(() => {
         expect(kesselActions.loadPermissionsFromKessel).toHaveBeenCalled();
-        expect(actions.loadIntegrationsEndpointsPermissions).not.toHaveBeenCalled();
-        expect(actions.loadIntegrationsReadPermissions).not.toHaveBeenCalled();
+        // v2 orgs now ALSO load v1 permissions for wildcard fallback
+        // See: https://github.com/RedHatInsights/insights-chrome/pull/3362
+        expect(actions.loadIntegrationsEndpointsPermissions).toHaveBeenCalled();
+        expect(actions.loadIntegrationsReadPermissions).toHaveBeenCalled();
       });
     });
 
@@ -197,7 +199,7 @@ describe('PermissionsChecker - Hybrid RBAC', () => {
       });
     });
 
-    it('v2 org: sources via Chrome, integrations via Kessel', async () => {
+    it('v2 org: sources via Chrome, integrations via Kessel + v1 fallback', async () => {
       mockUseFlag.mockReturnValue(true);
       renderWithProviders();
 
@@ -208,9 +210,10 @@ describe('PermissionsChecker - Hybrid RBAC', () => {
         // Integrations via Kessel
         expect(kesselActions.loadPermissionsFromKessel).toHaveBeenCalled();
 
-        // Integrations NOT via Chrome
-        expect(actions.loadIntegrationsEndpointsPermissions).not.toHaveBeenCalled();
-        expect(actions.loadIntegrationsReadPermissions).not.toHaveBeenCalled();
+        // Integrations ALSO via Chrome (for v1 wildcard fallback)
+        // See: https://github.com/RedHatInsights/insights-chrome/pull/3362
+        expect(actions.loadIntegrationsEndpointsPermissions).toHaveBeenCalled();
+        expect(actions.loadIntegrationsReadPermissions).toHaveBeenCalled();
       });
     });
   });


### PR DESCRIPTION
For v2 orgs, load BOTH Kessel v2 permissions AND v1 Chrome API permissions, then combine them in Redux using OR logic. This ensures Org Admins and legacy roles with wildcard permissions (integrations:*:*, integrations:endpoints:*) maintain access when their org is migrated to v2.

Why: Kessel v2 does not currently support wildcard permission expansion. Without this fallback, users with wildcard permissions would lose access when their org is migrated to v2.

Implementation:
- PermissionsChecker.tsx: Load v1 permissions even for v2 orgs
- reducer.js: Combine permissions with OR logic in Redux state

Temporary workaround: Should be removed once EITHER:
1. Kessel v2 supports wildcard permission expansion, OR
2. All wildcard permissions are migrated to explicit Kessel workspace relations

Related: insights-chrome PR #3362, notifications-frontend PR (same branch)
Issue: RHCLOUD-48396

### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
description text...

[RHCLOUDXXXX](https://issues.redhat.com/browse/RHCLOUDXXXX)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
