### PR TITLE
chore: disable Dependabot — updates handled by Konflux

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,2 @@
 version: 2
-updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: weekly
-    day: wednesday
-    time: "12:00"
-    timezone: EST
-  open-pull-requests-limit: 10
-  reviewers:
-  - RedHatInsights/platform-experience
-  allow:
-  - dependency-name: "@redhat-cloud-services/frontend*"
-  - dependency-name: "@patternfly/*"
-    dependency-type: direct
-  ignore:
-  - dependency-name: "@redhat-cloud-services/frontend-components-config"
-    versions:
-    - 4.0.20
-  - dependency-name: "@redhat-cloud-services/frontend-components"
-    versions:
-    - 3.0.4
-  - dependency-name: "@redhat-cloud-services/frontend-components-notifications"
-    versions:
-    - 3.0.3
+updates: []


### PR DESCRIPTION
Dependabot is disabled because dependency updates are handled through centralized Konflux flows. This avoids duplicate PRs and reduces review noise.