### PR TITLE
fix: Update URL when switching to Communications/Reporting/Webhooks tabs

### DIFF
--- a/src/redux/sources/actions.js
+++ b/src/redux/sources/actions.js
@@ -20,7 +20,7 @@ import { bold } from '../../utilities/intlShared';
 import handleError from '../../api/handleError';
 import tryAgainMessage from '../../utilities/tryAgainMessage';
 import { checkAccountHCS } from '../../api/checkAccountHCS';
-import { INTEGRATIONS, OVERVIEW } from '../../utilities/constants';
+import { COMMUNICATIONS, INTEGRATIONS, OVERVIEW, REPORTING, WEBHOOKS } from '../../utilities/constants';
 import notificationsStore from '../../utilities/notificationsStore';
 
 export const loadEntities = (options) => (dispatch, getState) => {
@@ -239,7 +239,7 @@ export const setActiveCategory = (category) => (dispatch) => {
     payload: { category },
   });
 
-  return [INTEGRATIONS, OVERVIEW].includes(category) || dispatch(loadEntities({ pageNumber: 1 }));
+  return [INTEGRATIONS, OVERVIEW, COMMUNICATIONS, REPORTING, WEBHOOKS].includes(category) || dispatch(loadEntities({ pageNumber: 1 }));
 };
 
 export const pauseSource = (sourceId, sourceName, intl) => (dispatch) => {

--- a/src/redux/sources/actions.js
+++ b/src/redux/sources/actions.js
@@ -239,7 +239,9 @@ export const setActiveCategory = (category) => (dispatch) => {
     payload: { category },
   });
 
-  return [INTEGRATIONS, OVERVIEW, COMMUNICATIONS, REPORTING, WEBHOOKS].includes(category) || dispatch(loadEntities({ pageNumber: 1 }));
+  return (
+    [INTEGRATIONS, OVERVIEW, COMMUNICATIONS, REPORTING, WEBHOOKS].includes(category) || dispatch(loadEntities({ pageNumber: 1 }))
+  );
 };
 
 export const pauseSource = (sourceId, sourceName, intl) => (dispatch) => {

--- a/src/test/utilities/store.test.js
+++ b/src/test/utilities/store.test.js
@@ -2,8 +2,9 @@ import { getProdStore, urlQueryMiddleware } from '../../utilities/store';
 import { defaultSourcesState } from '../../redux/sources/reducer';
 import { defaultUserState } from '../../redux/user/reducer';
 import * as queries from '../../utilities/urlQuery';
-import { ACTION_TYPES } from '../../redux/sources/actionTypes';
+import { ACTION_TYPES, SET_CATEGORY } from '../../redux/sources/actionTypes';
 import { getDevStore } from '../../utilities/getDevStore';
+import { CLOUD_VENDOR, COMMUNICATIONS, OVERVIEW, REPORTING, WEBHOOKS } from '../../utilities/constants';
 
 describe('store creator', () => {
   const EXPECTED_DEFAULT_STATE = {
@@ -111,6 +112,86 @@ describe('store creator', () => {
 
       expect(next).toHaveBeenCalledWith(action);
       expect(queries.updateQuery).not.toHaveBeenCalledWith(sources);
+    });
+
+    it('calls update url when SET_CATEGORY with OVERVIEW category', () => {
+      action = {
+        type: SET_CATEGORY,
+        payload: { category: OVERVIEW },
+      };
+
+      store = {
+        getState: () => ({ sources }),
+      };
+
+      urlQueryMiddleware(store)(next)(action);
+
+      expect(next).toHaveBeenCalledWith(action);
+      expect(queries.updateQuery).toHaveBeenCalledWith({ activeCategory: OVERVIEW });
+    });
+
+    it('calls update url when SET_CATEGORY with COMMUNICATIONS category', () => {
+      action = {
+        type: SET_CATEGORY,
+        payload: { category: COMMUNICATIONS },
+      };
+
+      store = {
+        getState: () => ({ sources }),
+      };
+
+      urlQueryMiddleware(store)(next)(action);
+
+      expect(next).toHaveBeenCalledWith(action);
+      expect(queries.updateQuery).toHaveBeenCalledWith({ activeCategory: COMMUNICATIONS });
+    });
+
+    it('calls update url when SET_CATEGORY with REPORTING category', () => {
+      action = {
+        type: SET_CATEGORY,
+        payload: { category: REPORTING },
+      };
+
+      store = {
+        getState: () => ({ sources }),
+      };
+
+      urlQueryMiddleware(store)(next)(action);
+
+      expect(next).toHaveBeenCalledWith(action);
+      expect(queries.updateQuery).toHaveBeenCalledWith({ activeCategory: REPORTING });
+    });
+
+    it('calls update url when SET_CATEGORY with WEBHOOKS category', () => {
+      action = {
+        type: SET_CATEGORY,
+        payload: { category: WEBHOOKS },
+      };
+
+      store = {
+        getState: () => ({ sources }),
+      };
+
+      urlQueryMiddleware(store)(next)(action);
+
+      expect(next).toHaveBeenCalledWith(action);
+      expect(queries.updateQuery).toHaveBeenCalledWith({ activeCategory: WEBHOOKS });
+    });
+
+    it('does not call update url when SET_CATEGORY with CLOUD_VENDOR category', () => {
+      action = {
+        type: SET_CATEGORY,
+        payload: { category: CLOUD_VENDOR },
+      };
+
+      store = {
+        getState: () => ({ sources }),
+      };
+
+      urlQueryMiddleware(store)(next)(action);
+
+      expect(next).toHaveBeenCalledWith(action);
+      expect(queries.updateQuery).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/utilities/store.js
+++ b/src/utilities/store.js
@@ -13,7 +13,7 @@ export const urlQueryMiddleware = (store) => (next) => (action) => {
   if (action.type === ACTION_TYPES.LOAD_ENTITIES_PENDING) {
     const sources = store.getState().sources;
     updateQuery({ ...sources, ...action.options });
-  } else if (action.type === SET_CATEGORY && [OVERVIEW, INTEGRATIONS].includes(action.payload?.category)) {
+  } else if (action.type === SET_CATEGORY && [OVERVIEW, INTEGRATIONS, COMMUNICATIONS, REPORTING, WEBHOOKS].includes(action.payload?.category)) {
     updateQuery({ activeCategory: action.payload?.category });
   }
 

--- a/src/utilities/store.js
+++ b/src/utilities/store.js
@@ -13,7 +13,10 @@ export const urlQueryMiddleware = (store) => (next) => (action) => {
   if (action.type === ACTION_TYPES.LOAD_ENTITIES_PENDING) {
     const sources = store.getState().sources;
     updateQuery({ ...sources, ...action.options });
-  } else if (action.type === SET_CATEGORY && [OVERVIEW, INTEGRATIONS, COMMUNICATIONS, REPORTING, WEBHOOKS].includes(action.payload?.category)) {
+  } else if (
+    action.type === SET_CATEGORY &&
+    [OVERVIEW, INTEGRATIONS, COMMUNICATIONS, REPORTING, WEBHOOKS].includes(action.payload?.category)
+  ) {
     updateQuery({ activeCategory: action.payload?.category });
   }
 


### PR DESCRIPTION
## Summary

Fixes the bug where the URL was not being updated when switching to the Communications, Reporting, or Webhooks tabs from other tabs (Overview, Cloud, Red Hat). The URL would briefly show the correct category parameter then clear back to just `/settings/integrations`.

## Root Cause

The issue was in two places:

1. **Redux Middleware**: The `urlQueryMiddleware` only updated the browser URL for `OVERVIEW` and `INTEGRATIONS` categories when the `SET_CATEGORY` action was dispatched. It didn't handle the newer breakdown categories: `COMMUNICATIONS`, `REPORTING`, and `WEBHOOKS`.

2. **Redux Action**: The `setActiveCategory` action was unnecessarily dispatching `loadEntities` for integration tabs that don't actually display the sources table (they show the IntegrationsTable component from the notifications module instead).

## Changes

- Updated `urlQueryMiddleware` in `src/utilities/store.js` to call `updateQuery()` for all integration categories (COMMUNICATIONS, REPORTING, WEBHOOKS)
- Updated `setActiveCategory` in `src/redux/sources/actions.js` to not dispatch `loadEntities` for integration categories since they render different content
- Added comprehensive test coverage in `src/test/utilities/store.test.js` with 5 new test cases

## Testing

✅ All existing tests pass
✅ Added tests verify URL updates correctly for Overview, Communications, Reporting, and Webhooks tabs
✅ Verified Cloud/Red Hat tabs still work correctly (they use loadEntities to update URL)

## Test Plan

1. Login to c.rh.c and go to /settings/integrations
2. From the Overview tab, click on the Communications tab
3. Verify the URL updates to `/settings/integrations?category=communications` and stays there
4. Click on Reporting tab - verify URL updates to `?category=reporting`
5. Click on Webhooks tab - verify URL updates to `?category=webhooks`
6. Click on Cloud tab - verify URL updates correctly
7. Switch back to Communications - verify URL persists

**Fixes:** RHCLOUD-48620

🤖 Generated with [Claude Code](https://claude.com/claude-code)