### PR TITLE
feat: Add feature flag to hide PagerDuty alert severity field

### DIFF
--- a/PAGERDUTY_SEVERITY_REMOVAL.md
+++ b/PAGERDUTY_SEVERITY_REMOVAL.md
@@ -1,0 +1,132 @@
+# PagerDuty Alert Severity Field Removal Plan
+
+## Overview
+This document outlines the implementation plan for removing the "Alert severity" field from PagerDuty integrations across the HCC platform.
+
+## Feature Flag
+**Flag Name:** `platform.integrations.pager-duty.hide-severity`
+
+**Purpose:** Hide the "Alert severity" field from all PagerDuty integration pages and wizards to enable synchronized removal across frontend, backend, documentation, and user communications.
+
+## Implementation Status
+
+### ✅ Frontend (sources-ui) - COMPLETED
+The feature flag has been implemented in all components that load the IntegrationsWizard from the notifications microfrontend:
+
+1. **`src/components/IntegrationsDropdown.js`** (Lines 54, 88)
+   - Added `hidePagerDutySeverity` flag using `useFlag('platform.integrations.pager-duty.hide-severity')`
+   - Passes `hidePagerDutySeverity` prop to IntegrationsWizard AsyncComponent
+
+2. **`src/components/Widget/IntegrationsWidget.tsx`** (Lines 56, 295)
+   - Added `hidePagerDutySeverity` flag using `useFlag('platform.integrations.pager-duty.hide-severity')`
+   - Passes `hidePagerDutySeverity` prop to IntegrationsWizard AsyncComponent
+
+3. **`src/components/Overview/CustomDataListItem.js`** (Lines 25, 34, 116)
+   - Imported `useFlag` from '@unleash/proxy-client-react'
+   - Added `hidePagerDutySeverity` flag using `useFlag('platform.integrations.pager-duty.hide-severity')`
+   - Passes `hidePagerDutySeverity` prop to IntegrationsWizard AsyncComponent
+
+### 🔄 Notifications Backend - PENDING
+The notifications microfrontend needs to:
+
+1. **Accept the `hidePagerDutySeverity` prop** in the IntegrationsWizard component
+2. **Conditionally render** the "Alert severity" field based on the flag value:
+   ```tsx
+   // In IntegrationsWizard component
+   {!hidePagerDutySeverity && (
+     <FormGroup label="Alert severity" fieldId="alert-severity">
+       {/* Alert severity field implementation */}
+     </FormGroup>
+   )}
+   ```
+3. **Update validation logic** to make the field optional when hidden
+4. **Ensure backward compatibility** - existing integrations should continue to work
+
+### 📝 Required Actions
+
+#### Phase 1: Pre-Deployment (Flag OFF)
+- [ ] Deploy sources-ui with feature flag support (this PR)
+- [ ] Deploy notifications backend with feature flag support
+- [ ] Create Unleash feature flag `platform.integrations.pager-duty.hide-severity` (default: OFF)
+- [ ] Test flag toggle in staging/development environments
+
+#### Phase 2: Coordination Day (Flag ON)
+On the agreed coordination date:
+1. [ ] **8:00 AM ET** - Enable feature flag in production
+2. [ ] **8:00 AM ET** - Update backend API to stop requiring/processing severity field
+3. [ ] **8:00 AM ET** - Publish documentation updates
+4. [ ] **8:00 AM ET** - Send user announcement email
+5. [ ] Monitor for issues throughout the day
+
+#### Phase 3: Post-Removal Cleanup (2-4 weeks later)
+- [ ] Remove feature flag code from frontend
+- [ ] Remove feature flag code from backend
+- [ ] Remove severity field from database schema (after migration period)
+- [ ] Remove Unleash feature flag definition
+
+## Testing Checklist
+
+### Frontend Testing
+- [ ] Feature flag OFF: Alert severity field is visible in PagerDuty wizard
+- [ ] Feature flag ON: Alert severity field is hidden in PagerDuty wizard
+- [ ] Feature flag ON: PagerDuty integration can be created without severity field
+- [ ] Feature flag ON: Existing PagerDuty integrations can be edited without severity field
+- [ ] Feature flag works correctly in:
+  - [ ] IntegrationsDropdown (Create Integration button)
+  - [ ] IntegrationsWidget (Home page widget)
+  - [ ] Overview page (Getting started)
+
+### Backend Testing (Notifications Team)
+- [ ] Feature flag OFF: Severity field is required
+- [ ] Feature flag ON: Severity field is optional/hidden
+- [ ] Feature flag ON: API accepts PagerDuty integrations without severity field
+- [ ] Feature flag ON: Existing integrations continue to function
+- [ ] Feature flag ON: Severity field is ignored if provided
+
+## Files Modified
+
+### sources-ui Repository
+- `src/components/IntegrationsDropdown.js`
+- `src/components/Widget/IntegrationsWidget.tsx`
+- `src/components/Overview/CustomDataListItem.js`
+
+### notifications Repository (PENDING)
+- `src/IntegrationsWizard/[component-path]` - Update to accept and handle `hidePagerDutySeverity` prop
+- `src/api/[pagerduty-api]` - Update validation to make severity field optional
+
+## Rollback Plan
+If issues are discovered after enabling the flag:
+1. Disable the feature flag in Unleash immediately
+2. Field will reappear for all users
+3. Investigate and fix issues
+4. Re-enable when ready
+
+## Communication Template
+
+### User Announcement Email (Draft)
+**Subject:** Important Update: PagerDuty Integration Configuration Change
+
+Dear Red Hat Hybrid Cloud Console Users,
+
+On [DATE], we will be removing the "Alert severity" field from PagerDuty integration configuration. This change simplifies the integration setup process while maintaining full functionality of your PagerDuty integrations.
+
+**What's changing:**
+- The "Alert severity" field will no longer appear when creating or editing PagerDuty integrations
+- All existing PagerDuty integrations will continue to work without interruption
+- No action is required on your part
+
+**When:**
+This change will take effect on [DATE] at [TIME] ET.
+
+If you have any questions or concerns, please contact Red Hat Support.
+
+Thank you,
+The Red Hat Hybrid Cloud Console Team
+
+---
+
+## Additional Notes
+- The feature flag approach allows for easy rollback if issues are discovered
+- All components that load the IntegrationsWizard now pass the flag
+- The flag is fetched once per component instance, so performance impact is minimal
+- Consider adding analytics to track usage before/after the change

--- a/src/components/IntegrationsDropdown.js
+++ b/src/components/IntegrationsDropdown.js
@@ -51,6 +51,7 @@ const IntegrationsDropdown = (props) => {
   const [isSourcesWizardOpen, setIsSourcesWizardOpen] = useState(false);
   const [selectedIntegration, setSelectedIntegration] = useState(null);
   const isPagerDutyEnabled = useFlag('platform.integrations.pager-duty');
+  const hidePagerDutySeverity = useFlag('platform.integrations.pager-duty.hide-severity');
   const hasSourcesPermissions = useSelector(({ user }) => user?.writePermissions);
   const hasIntegrationsPermissions = useSelector(({ user }) => user?.integrationsEndpointsPermissions);
 
@@ -85,6 +86,7 @@ const IntegrationsDropdown = (props) => {
           store={store}
           isOpen={isIntegrationsWizardOpen}
           category={selectedIntegration}
+          hidePagerDutySeverity={hidePagerDutySeverity}
           closeModal={() => {
             setIsIntegrationsWizardOpen(false);
             setSelectedIntegration(null);

--- a/src/components/Overview/CustomDataListItem.js
+++ b/src/components/Overview/CustomDataListItem.js
@@ -23,6 +23,7 @@ import { AsyncComponent } from '@redhat-cloud-services/frontend-components';
 import AddSourceWizard from '../addSourceWizard';
 import { useIntl } from 'react-intl';
 import { useStore } from 'react-redux';
+import { useFlag } from '@unleash/proxy-client-react';
 
 const CustomDataListItem = ({ initialExpanded, icon, title, actionTitle, action, content, learnMoreLink }) => {
   const [isExpanded, setIsExpanded] = useState(initialExpanded);
@@ -31,6 +32,7 @@ const CustomDataListItem = ({ initialExpanded, icon, title, actionTitle, action,
   const [selectedIntegration, setSelectedIntegration] = useState(null);
 
   const intl = useIntl();
+  const hidePagerDutySeverity = useFlag('platform.integrations.pager-duty.hide-severity');
 
   const toggleExpand = () => setIsExpanded((prev) => !prev);
 
@@ -112,6 +114,7 @@ const CustomDataListItem = ({ initialExpanded, icon, title, actionTitle, action,
           store={store}
           isOpen={isIntegrationsWizardOpen}
           category={selectedIntegration}
+          hidePagerDutySeverity={hidePagerDutySeverity}
           closeModal={() => {
             setIsIntegrationsWizardOpen(false);
             setSelectedIntegration(null);

--- a/src/components/Widget/IntegrationsWidget.tsx
+++ b/src/components/Widget/IntegrationsWidget.tsx
@@ -53,6 +53,7 @@ const IntegrationsWidget: FunctionComponent = () => {
   const hasSourcesPermissions = useSelector(({ user }) => user?.writePermissions);
   const hasIntegrationsPermissions = useSelector(({ user }) => user?.integrationsEndpointsPermissions);
   const isPagerDutyEnabled = useFlag('platform.integrations.pager-duty');
+  const hidePagerDutySeverity = useFlag('platform.integrations.pager-duty.hide-severity');
   const isEmailEnabled = useFlag('platform.notifications.email.integration');
   const integrationsData = createIntegrationsData(
     isPagerDutyEnabled,
@@ -292,6 +293,7 @@ const IntegrationsWidget: FunctionComponent = () => {
           store={store}
           isOpen={isIntegrationsWizardOpen}
           category={wizardCategory}
+          hidePagerDutySeverity={hidePagerDutySeverity}
           closeModal={() => {
             setIsIntegrationsWizardOpen(false);
             setWizardCategory(null);


### PR DESCRIPTION
## Summary
Add support for the `platform.integrations.pager-duty.hide-severity` feature flag to conditionally hide the Alert Severity field from all PagerDuty integration wizards.

This enables synchronized removal of the field across frontend, backend, documentation, and user communications on a single deployment day.

## Changes
- **IntegrationsDropdown**: Added `hidePagerDutySeverity` flag and passes it to IntegrationsWizard
- **IntegrationsWidget**: Added `hidePagerDutySeverity` flag and passes it to IntegrationsWizard  
- **CustomDataListItem**: Added `hidePagerDutySeverity` flag and passes it to IntegrationsWizard
- **Documentation**: Added comprehensive `PAGERDUTY_SEVERITY_REMOVAL.md` with implementation plan

## Behavior
- **Flag OFF (default)**: No changes, alert severity field remains visible
- **Flag ON**: Alert severity field is hidden from the PagerDuty wizard

## Testing
- [ ] Verify flag OFF: Alert severity field is visible
- [ ] Verify flag ON: Alert severity field is hidden
- [ ] Test in all three locations: IntegrationsDropdown, IntegrationsWidget, Overview page

## Dependencies
**Requires corresponding changes in the notifications backend** to:
1. Accept the `hidePagerDutySeverity` prop in IntegrationsWizard
2. Conditionally render the alert severity field based on the flag
3. Update validation to make the field optional when hidden

See `PAGERDUTY_SEVERITY_REMOVAL.md` for complete implementation and coordination plan.

## JIRA
RHCLOUD-48862