### PR TITLE
fix(RHCLOUD-49426): add Kessel RBAC providers to integrations widget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@patternfly/react-data-view": "^6.5.0",
         "@patternfly/react-icons": "^6.5.1",
         "@patternfly/react-table": "^6.5.1",
-        "@project-kessel/react-kessel-access-check": "^0.5.1",
+        "@project-kessel/react-kessel-access-check": "^0.5.2",
         "@redhat-cloud-services/frontend-components": "^7.7.1",
         "@redhat-cloud-services/frontend-components-notifications": "^6.9.1",
         "@redhat-cloud-services/frontend-components-utilities": "^7.4.0",
@@ -5460,9 +5460,9 @@
       "dev": true
     },
     "node_modules/@project-kessel/react-kessel-access-check": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@project-kessel/react-kessel-access-check/-/react-kessel-access-check-0.5.1.tgz",
-      "integrity": "sha512-hi/z0I4ANeoxG1RYpcaNVmFus7K2bTFHsVLOleK4QojJPqmf0ZTICo8rxl6RdjFm6bWeOpSRzTL6jlRSQCSD/Q==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@project-kessel/react-kessel-access-check/-/react-kessel-access-check-0.5.3.tgz",
+      "integrity": "sha512-mA5yOO5l9laPYSkh6FDZ8RsIH1vCqvdx9EjZkpWZBbWGEbjZ0i1fQjYxEo6hpByfYy3dxpws54jT+smNr6aKNw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@patternfly/react-data-view": "^6.5.0",
     "@patternfly/react-icons": "^6.5.1",
     "@patternfly/react-table": "^6.5.1",
-    "@project-kessel/react-kessel-access-check": "^0.5.1",
+    "@project-kessel/react-kessel-access-check": "^0.5.2",
     "@redhat-cloud-services/frontend-components": "^7.7.1",
     "@redhat-cloud-services/frontend-components-notifications": "^6.9.1",
     "@redhat-cloud-services/frontend-components-utilities": "^7.4.0",

--- a/src/components/Widget/IntegrationsWidget.stories.tsx
+++ b/src/components/Widget/IntegrationsWidget.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { expect, waitFor, within } from 'storybook/test';
 import { Provider } from 'react-redux';
-import { http, HttpResponse } from 'msw';
+import { HttpResponse, http } from 'msw';
 import { getStore } from '../../utilities/store';
 import { IntegrationsWidget } from './IntegrationsWidget';
 import { KesselRbacAccessContext } from '../../rbac/KesselRbacAccessContext';
@@ -52,6 +52,7 @@ const graphqlHandler = (cloudSources: unknown[], redHatSources: unknown[]) =>
         },
       });
     }
+
     return HttpResponse.json({
       data: {
         sources: redHatSources,

--- a/src/components/Widget/IntegrationsWidget.stories.tsx
+++ b/src/components/Widget/IntegrationsWidget.stories.tsx
@@ -1,0 +1,201 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import { expect, waitFor, within } from 'storybook/test';
+import { Provider } from 'react-redux';
+import { http, HttpResponse } from 'msw';
+import { getStore } from '../../utilities/store';
+import { IntegrationsWidget } from './IntegrationsWidget';
+import { KesselRbacAccessContext } from '../../rbac/KesselRbacAccessContext';
+
+const kesselContextValue = {
+  workspaceId: 'mock-workspace-id',
+  isLoading: false,
+  permissions: {
+    canWriteIntegrationsEndpoints: true,
+    canReadIntegrationsEndpoints: true,
+  },
+  errors: [],
+};
+
+const createMockStore = (overrides: { user?: Record<string, unknown> } = {}) => {
+  const initialState = {
+    sources: {
+      entities: [],
+      loaded: 0,
+      sourceTypesLoaded: true,
+      appTypesLoaded: true,
+      numberOfEntities: 0,
+      pageNumber: 1,
+      pageSize: 50,
+      activeCategory: null,
+    },
+    user: {
+      isOrgAdmin: true,
+      writePermissions: true,
+      integrationsEndpointsPermissions: true,
+      integrationsReadPermissions: true,
+      ...overrides.user,
+    },
+  };
+
+  return getStore([], initialState);
+};
+
+const graphqlHandler = (cloudSources: unknown[], redHatSources: unknown[]) =>
+  http.post('/api/sources/v3.1/graphql', async ({ request }) => {
+    const body = (await request.json()) as { query: string };
+    if (body.query.includes('Cloud')) {
+      return HttpResponse.json({
+        data: {
+          sources: cloudSources,
+          meta: { count: cloudSources.length },
+        },
+      });
+    }
+    return HttpResponse.json({
+      data: {
+        sources: redHatSources,
+        meta: { count: redHatSources.length },
+      },
+    });
+  });
+
+const integrationsHandler = (integrations: { type: string; sub_type?: string }[]) =>
+  http.get('/api/integrations/v1.0/endpoints', () => HttpResponse.json({ data: integrations }));
+
+const rbacHandler = http.get('/api/rbac/v2/workspaces', () =>
+  HttpResponse.json({ data: [{ id: 'mock-workspace-id', type: 'default', name: 'Default' }] }),
+);
+
+const emptyHandlers = [graphqlHandler([], []), integrationsHandler([]), rbacHandler];
+
+const populatedCloudSources = [
+  { id: '1', source_type_id: '1', name: 'AWS Prod', created_at: '2024-01-01', availability_status: 'available' },
+  { id: '2', source_type_id: '1', name: 'AWS Dev', created_at: '2024-01-02', availability_status: 'available' },
+  { id: '3', source_type_id: '3', name: 'Azure Prod', created_at: '2024-01-03', availability_status: 'available' },
+];
+
+const populatedRedHatSources = [
+  { id: '10', source_type_id: '1', name: 'OpenShift Prod', created_at: '2024-01-01', availability_status: 'available' },
+];
+
+const populatedIntegrations = [
+  { type: 'camel', sub_type: 'slack' },
+  { type: 'camel', sub_type: 'slack' },
+  { type: 'camel', sub_type: 'google_chat' },
+  { type: 'ansible' },
+  { type: 'ansible' },
+  { type: 'ansible' },
+  { type: 'webhook' },
+];
+
+const populatedHandlers = [
+  graphqlHandler(populatedCloudSources, populatedRedHatSources),
+  integrationsHandler(populatedIntegrations),
+  rbacHandler,
+];
+
+const meta: Meta<typeof IntegrationsWidget> = {
+  component: IntegrationsWidget,
+  title: 'Components/Widget/IntegrationsWidget',
+  decorators: [
+    (Story, context) => {
+      const store = createMockStore(context.parameters.storeOverrides);
+      return (
+        <Provider store={store}>
+          <KesselRbacAccessContext.Provider value={kesselContextValue}>
+            <Story />
+          </KesselRbacAccessContext.Provider>
+        </Provider>
+      );
+    },
+  ],
+  parameters: {
+    featureFlags: {
+      'platform.integrations.pager-duty': false,
+      'platform.notifications.email.integration': false,
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof IntegrationsWidget>;
+
+export const EmptyState: Story = {
+  parameters: {
+    msw: { handlers: emptyHandlers },
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('Shows empty state card gallery', async () => {
+      await waitFor(() => expect(canvas.getByText('Learn more about Integrations.')).toBeInTheDocument());
+    });
+
+    await step('Renders integration tiles', async () => {
+      await waitFor(() => {
+        expect(canvas.getByText('Slack')).toBeInTheDocument();
+        expect(canvas.getByText('Amazon Web Services')).toBeInTheDocument();
+        expect(canvas.getByText('Google Cloud')).toBeInTheDocument();
+        expect(canvas.getByText('Microsoft Azure')).toBeInTheDocument();
+        expect(canvas.getByText('OpenShift Container Platform')).toBeInTheDocument();
+        expect(canvas.getByText('Event-Driven Ansible')).toBeInTheDocument();
+        expect(canvas.getByText('Webhooks')).toBeInTheDocument();
+      });
+    });
+  },
+};
+
+export const WithIntegrations: Story = {
+  parameters: {
+    msw: { handlers: populatedHandlers },
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('Shows DataList with category rows', async () => {
+      await waitFor(() => {
+        expect(canvas.getByText('Communications')).toBeInTheDocument();
+        expect(canvas.getByText('Reporting & automation')).toBeInTheDocument();
+        expect(canvas.getByText('Webhooks')).toBeInTheDocument();
+        expect(canvas.getByText('Cloud')).toBeInTheDocument();
+        expect(canvas.getByText('Red Hat')).toBeInTheDocument();
+      });
+    });
+
+    await step('Shows correct badge counts', async () => {
+      await waitFor(() => {
+        const badges = canvas.getAllByText(/^\d+$/);
+        expect(badges.length).toBeGreaterThan(0);
+      });
+    });
+
+    await step('Shows Manage buttons', async () => {
+      await waitFor(() => {
+        const manageButtons = canvas.getAllByText('Manage');
+        expect(manageButtons.length).toBe(5);
+      });
+    });
+  },
+};
+
+export const WithAllFlags: Story = {
+  parameters: {
+    msw: { handlers: emptyHandlers },
+    featureFlags: {
+      'platform.integrations.pager-duty': true,
+      'platform.notifications.email.integration': true,
+    },
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('Shows PagerDuty tile when flag is enabled', async () => {
+      await waitFor(() => expect(canvas.getByText('PagerDuty')).toBeInTheDocument());
+    });
+
+    await step('Shows Email tile when flag is enabled', async () => {
+      await waitFor(() => expect(canvas.getByText('Email')).toBeInTheDocument());
+    });
+  },
+};

--- a/src/components/Widget/IntegrationsWidget.tsx
+++ b/src/components/Widget/IntegrationsWidget.tsx
@@ -24,11 +24,13 @@ import {
   StackItem,
 } from '@patternfly/react-core';
 import React, { FunctionComponent, useEffect, useState } from 'react';
+import { AccessCheck } from '@project-kessel/react-kessel-access-check';
 import { Provider, useSelector, useStore } from 'react-redux';
 import IntegrationsDropdown from '../IntegrationsDropdown';
 import { CLOUD_VENDOR, COMMUNICATIONS, REDHAT_VENDOR, REPORTING, WEBHOOKS } from '../../utilities/constants';
 import { getProdStore } from '../../utilities/store';
 import { AsyncComponent } from '@redhat-cloud-services/frontend-components';
+import { KesselRbacAccessProvider } from '../../rbac/KesselRbacAccessProvider';
 import AddSourceWizard from '../addSourceWizard';
 import './IntegrationsWidget.scss';
 import { Link, useNavigate } from 'react-router-dom';
@@ -315,7 +317,11 @@ const IntegrationsWidget: FunctionComponent = () => {
 
 const IntegrationsWidgetWrapper = () => (
   <Provider store={getProdStore()}>
-    <IntegrationsWidget />
+    <AccessCheck.Provider baseUrl={window.location.origin} apiPath="/api/kessel/v1beta2">
+      <KesselRbacAccessProvider>
+        <IntegrationsWidget />
+      </KesselRbacAccessProvider>
+    </AccessCheck.Provider>
   </Provider>
 );
 

--- a/src/components/Widget/IntegrationsWidget.tsx
+++ b/src/components/Widget/IntegrationsWidget.tsx
@@ -41,7 +41,7 @@ import { IntegrationItem, createIntegrationsData } from './consts/widgetData';
 import { useFlag } from '@unleash/proxy-client-react';
 import PermissionsChecker from '../PermissionsChecker';
 
-const IntegrationsWidget: FunctionComponent = () => {
+export const IntegrationsWidget: FunctionComponent = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [hasInitialized, setHasInitialized] = useState(false);
   const [expandedIndex, setExpandedIndex] = useState<number[]>([]);


### PR DESCRIPTION
## Summary
- Adds `AccessCheck.Provider` and `KesselRbacAccessProvider` to the `IntegrationsWidgetWrapper` to fix the "useKesselRbacAccess must be used within KesselRbacAccessProvider" error
- Bumps `@project-kessel/react-kessel-access-check` from `^0.5.1` to `^0.5.2` to fix the workspaces call issue (RHINENG-28784), matching [notifications-frontend#1017](https://github.com/RedHatInsights/notifications-frontend/pull/1017)

## Test plan
- [ ] Verify the integrations widget loads without the `useKesselRbacAccess` error
- [ ] Verify integration counts still display correctly
- [ ] Verify create/manage actions still work from the widget

🤖 Generated with [Claude Code](https://claude.com/claude-code)