### PR TITLE
fix(RHCLOUD-49447): remove per-org v2 gating, use global Kessel access checks

### DIFF
--- a/src/components/PermissionsChecker.tsx
+++ b/src/components/PermissionsChecker.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
-import { useFlag } from '@unleash/proxy-client-react';
 import { ThunkDispatch } from 'redux-thunk';
 import { AnyAction } from 'redux';
 
@@ -28,49 +27,31 @@ const PermissionsChecker: React.FC<PermissionsCheckerProps> = ({ children }) => 
     getUserPermissions,
   } = useChrome();
 
-  // Determine if org is using RBAC v2
-  const isV2Org = useFlag('platform.rbac.workspaces');
+  const { permissions: kesselPermissions, isLoading: isKesselLoading, workspaceId } = useKesselRbacAccess();
 
-  // Get Kessel v2 permissions (only used if isV2Org is true)
-  const kesselRbacContext = useKesselRbacAccess();
-  const { permissions: kesselPermissions, isLoading: isKesselLoading } = kesselRbacContext;
-
-  // Always load org admin status (works for both v1 and v2)
   useEffect(() => {
     dispatch(loadOrgAdmin(getUser));
   }, [getUser, dispatch]);
 
-  // Effect to load sources permissions (always uses v1 Chrome API)
-  // Sources service has not migrated to Kessel v2 yet
   useEffect(() => {
     dispatch(loadWritePermissions(getUserPermissions));
   }, [getUserPermissions, dispatch]);
 
-  // Effect to load v1 integrations permissions (for v1 orgs only)
   useEffect(() => {
-    if (!isV2Org) {
-      Promise.all([
-        dispatch(loadIntegrationsEndpointsPermissions(getUserPermissions)),
-        dispatch(loadIntegrationsReadPermissions(getUserPermissions)),
-      ]);
-    }
-  }, [isV2Org, getUserPermissions, dispatch]);
+    Promise.all([
+      dispatch(loadIntegrationsEndpointsPermissions(getUserPermissions)),
+      dispatch(loadIntegrationsReadPermissions(getUserPermissions)),
+    ]);
+  }, [getUserPermissions, dispatch]);
 
-  // Effect to load integrations permissions for v2 orgs (Kessel + v1 fallback)
+  // Dispatch Kessel v2 results only when a workspace was resolved — if the workspace
+  // fetch failed (no Kessel in this environment), Kessel has no signal to contribute
+  // and the v1 Chrome API results above are authoritative.
   useEffect(() => {
-    if (isV2Org && !isKesselLoading) {
-      // v2 org: Use Kessel for integrations permissions AND load v1 for wildcard fallback
-      // Kessel v2 does not support wildcard expansion, so we must check v1 wildcards
-      // (integrations:*:*, notifications:*:*) as fallback for Org Admins and legacy roles.
-      // See: https://github.com/RedHatInsights/insights-chrome/pull/3362
+    if (!isKesselLoading && workspaceId) {
       dispatch(loadPermissionsFromKessel(kesselPermissions));
-      // Also load v1 permissions for wildcard fallback
-      Promise.all([
-        dispatch(loadIntegrationsEndpointsPermissions(getUserPermissions)),
-        dispatch(loadIntegrationsReadPermissions(getUserPermissions)),
-      ]);
     }
-  }, [isV2Org, isKesselLoading, kesselPermissions, getUserPermissions, dispatch]);
+  }, [isKesselLoading, workspaceId, kesselPermissions, dispatch]);
 
   return children;
 };

--- a/src/rbac/KesselRbacAccessProvider.tsx
+++ b/src/rbac/KesselRbacAccessProvider.tsx
@@ -81,10 +81,7 @@ export const KesselRbacAccessProvider: React.FC<{
   // Aggregate loading states — permission hook loading only matters when a workspace
   // exists for them to check against; without one the hooks never fire.
   const isLoading =
-    isLoadingWorkspace ||
-    (!!defaultWorkspaceId &&
-      (integrationsEndpointsEdit.loading ||
-        integrationsEndpointsView.loading));
+    isLoadingWorkspace || (!!defaultWorkspaceId && (integrationsEndpointsEdit.loading || integrationsEndpointsView.loading));
 
   // Build context value
   const contextValue: KesselRbacAccessContextValue = useMemo(

--- a/src/rbac/KesselRbacAccessProvider.tsx
+++ b/src/rbac/KesselRbacAccessProvider.tsx
@@ -80,7 +80,11 @@ export const KesselRbacAccessProvider: React.FC<{
 
   // Aggregate loading states — permission hook loading only matters when a workspace
   // exists for them to check against; without one the hooks never fire.
-  const isLoading = isLoadingWorkspace || (!!defaultWorkspaceId && (integrationsEndpointsEdit.loading || integrationsEndpointsView.loading));
+  const isLoading =
+    isLoadingWorkspace ||
+    (!!defaultWorkspaceId &&
+      (integrationsEndpointsEdit.loading ||
+        integrationsEndpointsView.loading));
 
   // Build context value
   const contextValue: KesselRbacAccessContextValue = useMemo(

--- a/src/rbac/KesselRbacAccessProvider.tsx
+++ b/src/rbac/KesselRbacAccessProvider.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useSelfAccessCheck } from '@project-kessel/react-kessel-access-check';
+import type { SelfAccessCheckResource } from '@project-kessel/react-kessel-access-check';
 import { KesselRbacAccessContext, KesselRbacAccessContextValue } from './KesselRbacAccessContext';
 import { KESSEL_WORKSPACE_RELATIONS } from './kesselWorkspaceRelations';
 import { useDefaultWorkspace } from './hooks/useDefaultWorkspace';
@@ -34,13 +35,18 @@ export const KesselRbacAccessProvider: React.FC<{
     }
   }, [workspaceError]);
 
-  // Build workspace resource for permission checks
+  // Build workspace resource for permission checks.
+  // When no workspace is available, return undefined so the SDK skips the API call
+  // (its internal guard: `if (!resource) return`) — prevents 400 errors from empty resource_id.
   const workspace = useMemo(
-    () => ({
-      id: defaultWorkspaceId || '',
-      type: 'workspace' as const,
-      reporter: { type: 'rbac' as const },
-    }),
+    () =>
+      defaultWorkspaceId
+        ? {
+            id: defaultWorkspaceId,
+            type: 'workspace' as const,
+            reporter: { type: 'rbac' as const },
+          }
+        : undefined,
     [defaultWorkspaceId],
   );
 
@@ -48,12 +54,12 @@ export const KesselRbacAccessProvider: React.FC<{
   // Note: Only checking integrations permissions - sources continues using Chrome API v1
   const integrationsEndpointsEdit = useSelfAccessCheck({
     relation: KESSEL_WORKSPACE_RELATIONS.INTEGRATIONS_ENDPOINTS_EDIT,
-    resource: workspace,
+    resource: workspace as unknown as SelfAccessCheckResource,
   });
 
   const integrationsEndpointsView = useSelfAccessCheck({
     relation: KESSEL_WORKSPACE_RELATIONS.INTEGRATIONS_ENDPOINTS_VIEW,
-    resource: workspace,
+    resource: workspace as unknown as SelfAccessCheckResource,
   });
 
   // Track permission check errors
@@ -72,8 +78,9 @@ export const KesselRbacAccessProvider: React.FC<{
     }
   }, [integrationsEndpointsEdit.error, integrationsEndpointsView.error]);
 
-  // Aggregate loading states
-  const isLoading = isLoadingWorkspace || integrationsEndpointsEdit.loading || integrationsEndpointsView.loading;
+  // Aggregate loading states — permission hook loading only matters when a workspace
+  // exists for them to check against; without one the hooks never fire.
+  const isLoading = isLoadingWorkspace || (!!defaultWorkspaceId && (integrationsEndpointsEdit.loading || integrationsEndpointsView.loading));
 
   // Build context value
   const contextValue: KesselRbacAccessContextValue = useMemo(

--- a/src/rbac/README.md
+++ b/src/rbac/README.md
@@ -1,21 +1,22 @@
 # RBAC v2 Migration with Kessel SDK
 
-This directory contains the implementation for RBAC v2 using the Kessel SDK, allowing the application to work with both RBAC v1 and v2 organizations.
+This directory contains the implementation for RBAC v2 using the Kessel SDK.
 
 ## Overview
 
-The application now supports both RBAC v1 (legacy) and v2 (Kessel-based) permission checks using a **hybrid approach**:
+The application uses Kessel v2 for integrations permission checks globally, with v1 wildcard fallback:
 
-- **Integrations permissions**: Switches based on `platform.rbac.workspaces` feature flag (v1 → v2)
+- **Integrations permissions**: Kessel v2 access checks for all orgs, plus Chrome v1 for wildcard fallback
 - **Sources permissions**: Always uses Chrome API v1 until sources service migrates to Kessel
 
 ## Architecture
 
-### Feature Flag Detection (Hybrid Approach)
+### Permission Strategy
 
 **For Integrations permissions:**
-- **v1 orgs**: `platform.rbac.workspaces` = `false` → Uses Chrome's `getUserPermissions('integrations')`
-- **v2 orgs**: `platform.rbac.workspaces` = `true` → Uses Kessel SDK
+- Kessel v2 access checks run globally (no per-org feature flag gating)
+- Chrome v1 `getUserPermissions('integrations')` also runs for wildcard fallback (`integrations:*:*`)
+- Redux reducer uses OR logic so either path can grant access
 
 **For Sources permissions:**
 - **All orgs**: Always uses Chrome's `getUserPermissions('sources')` until sources service migrates
@@ -40,8 +41,8 @@ src/rbac/
 
 | v1 Permission | Status |
 |--------------|--------|
-| `sources:*:*` or `sources:*:write` | ✅ Uses Chrome API v1 (all orgs) |
-| `sources:*:read` | ✅ Uses Chrome API v1 (all orgs) |
+| `sources:*:*` or `sources:*:write` | Uses Chrome API v1 (all orgs) |
+| `sources:*:read` | Uses Chrome API v1 (all orgs) |
 
 **Note**: Sources permissions will continue using Chrome's `getUserPermissions('sources')` until the sources service migrates to Kessel. No v2 schema needed yet.
 
@@ -79,21 +80,18 @@ Kessel v2 permissions are mapped to the existing Redux state structure in `user`
 </AccessCheck.Provider>
 ```
 
-### 2. Permission Loading (PermissionsChecker.tsx) - Hybrid Approach
+### 2. Permission Loading (PermissionsChecker.tsx)
 ```tsx
-const isV2Org = useFlag('platform.rbac.workspaces');
-
-// Sources permissions: Always use v1 Chrome API (all orgs)
+// Sources permissions: Always use v1 Chrome API
 dispatch(loadWritePermissions(getUserPermissions));
 
-// Integrations permissions: Use v2 for v2 orgs, v1 for v1 orgs
-if (isV2Org && !isKesselLoading) {
-  // v2 org: Load integrations from Kessel
+// Integrations permissions: v1 Chrome API loads unconditionally
+dispatch(loadIntegrationsEndpointsPermissions(getUserPermissions));
+dispatch(loadIntegrationsReadPermissions(getUserPermissions));
+
+// Kessel v2: supplements v1 results when workspace is available
+if (!isKesselLoading && workspaceId) {
   dispatch(loadPermissionsFromKessel(kesselPermissions));
-} else if (!isV2Org) {
-  // v1 org: Load integrations from Chrome API
-  dispatch(loadIntegrationsEndpointsPermissions(getUserPermissions));
-  dispatch(loadIntegrationsReadPermissions(getUserPermissions));
 }
 ```
 
@@ -115,12 +113,12 @@ const hasIntegrationsPermissions = useSelector(({ user }) => user?.integrationsE
 - **`sources`** (this app) - Integration sources for Hybrid Cloud Console
   - Calls: `getUserPermissions('sources')`
   - Permissions: `sources:*:write`, `sources:*:read`
-  - **Status**: ⏳ Continues using v1 until service migration
+  - **Status**: Continues using v1 until service migration
 
 - **`content-sources`** (different app) - Content management (repositories, templates)
   - Has schema: [`content-sources.ksl`](https://github.com/RedHatInsights/rbac-config/blob/master/configs/prod/schemas/src/content-sources.ksl)
   - Permissions: `content_sources_repository_view`, `content_sources_template_edit`, etc.
-  - **Status**: ✅ Already has v2 schema
+  - **Status**: Already has v2 schema
 
 ### Future Migration (when sources service is ready):
 1. Sources team will create `sources.ksl` in [rbac-config](https://github.com/RedHatInsights/rbac-config)
@@ -128,15 +126,6 @@ const hasIntegrationsPermissions = useSelector(({ user }) => user?.integrationsE
 3. Update this codebase to use Kessel for sources permissions
 
 ## Testing
-
-### v1 Organization (Feature Flag Off)
-- Permissions loaded via Chrome API `getUserPermissions()`
-- Existing behavior unchanged
-
-### v2 Organization (Feature Flag On)
-- Permissions loaded via Kessel SDK
-- Workspace fetched from `/api/rbac/v2/workspaces/?type=default`
-- Access checks via `/api/kessel/v1beta2` endpoints
 
 ### Test Checklist
 - [ ] Sources write operations (add/edit/delete source)

--- a/src/rbac/utils/permissionMapper.ts
+++ b/src/rbac/utils/permissionMapper.ts
@@ -2,7 +2,7 @@ import { KesselRbacAccessContextValue } from '../KesselRbacAccessContext';
 
 /**
  * Maps v2 Kessel permissions to v1 Redux user state structure.
- * This allows v2 orgs to use the existing Redux state API without changes to consuming components.
+ * This allows Kessel v2 results to supplement v1 Chrome API permissions without changes to consuming components.
  *
  * Note: Sources permissions are NOT included here - they continue using Chrome API v1
  * until the sources service migrates to Kessel.

--- a/src/redux/user/kesselActions.ts
+++ b/src/redux/user/kesselActions.ts
@@ -6,7 +6,7 @@ import { KesselRbacAccessContextValue } from '../../rbac/KesselRbacAccessContext
 
 /**
  * Load integrations permissions from Kessel v2 and map them to the existing Redux state structure.
- * This allows v2 orgs to use Kessel permissions for integrations without changing the rest of the application.
+ * Kessel v2 permissions supplement v1 Chrome API permissions via Redux OR logic.
  *
  * Note: Sources permissions continue using Chrome API v1 (loaded separately) until sources service migrates to Kessel.
  *

--- a/src/test/components/PermissionsChecker.test.tsx
+++ b/src/test/components/PermissionsChecker.test.tsx
@@ -21,12 +21,6 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
   }),
 }));
 
-// Mock Unleash flag
-const mockUseFlag = jest.fn();
-jest.mock('@unleash/proxy-client-react', () => ({
-  useFlag: () => mockUseFlag(),
-}));
-
 // Mock actions
 jest.mock('../../redux/user/actions', () => ({
   loadWritePermissions: jest.fn(() => ({ type: 'LOAD_WRITE_PERMISSIONS' })),
@@ -39,29 +33,26 @@ jest.mock('../../redux/user/kesselActions', () => ({
   loadPermissionsFromKessel: jest.fn(() => ({ type: 'LOAD_KESSEL_PERMISSIONS' })),
 }));
 
-describe('PermissionsChecker - Hybrid RBAC', () => {
+describe('PermissionsChecker', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let store: any;
 
-  const mockKesselContext = {
-    workspaceId: 'test-workspace-id',
-    isLoading: false,
-    permissions: {
-      canWriteIntegrationsEndpoints: true,
-      canReadIntegrationsEndpoints: true,
-    },
-    errors: [],
-  };
-
   const Children = () => <h1>App</h1>;
 
-  const renderWithProviders = (kesselLoading = false) => {
+  const renderWithProviders = (
+    { kesselLoading, workspaceId }: { kesselLoading?: boolean; workspaceId?: string | undefined } = {},
+  ) => {
     const mockReducer = (state = {}) => state;
     store = createStore(mockReducer);
 
     const contextValue = {
-      ...mockKesselContext,
-      isLoading: kesselLoading,
+      workspaceId: workspaceId !== undefined ? workspaceId : 'test-workspace-id',
+      isLoading: kesselLoading ?? false,
+      permissions: {
+        canWriteIntegrationsEndpoints: true,
+        canReadIntegrationsEndpoints: true,
+      },
+      errors: [],
     };
 
     return render(
@@ -83,138 +74,73 @@ describe('PermissionsChecker - Hybrid RBAC', () => {
     mockGetUserPermissions.mockResolvedValue([]);
   });
 
-  describe('v1 Organization (feature flag OFF)', () => {
-    beforeEach(() => {
-      mockUseFlag.mockReturnValue(false); // platform.rbac.workspaces = false
-    });
+  it('renders children', () => {
+    renderWithProviders();
+    expect(screen.getByText('App')).toBeInTheDocument();
+  });
 
-    it('loads sources permissions via Chrome API', async () => {
-      renderWithProviders();
+  it('loads org admin status', async () => {
+    renderWithProviders();
 
-      await waitFor(() => {
-        expect(actions.loadWritePermissions).toHaveBeenCalledWith(mockGetUserPermissions);
-      });
-    });
-
-    it('loads integrations permissions via Chrome API', async () => {
-      renderWithProviders();
-
-      await waitFor(() => {
-        expect(actions.loadIntegrationsEndpointsPermissions).toHaveBeenCalledWith(mockGetUserPermissions);
-        expect(actions.loadIntegrationsReadPermissions).toHaveBeenCalledWith(mockGetUserPermissions);
-      });
-    });
-
-    it('loads org admin status', async () => {
-      renderWithProviders();
-
-      await waitFor(() => {
-        expect(actions.loadOrgAdmin).toHaveBeenCalledWith(mockGetUser);
-      });
-    });
-
-    it('does NOT load permissions from Kessel', async () => {
-      renderWithProviders();
-
-      await waitFor(() => {
-        expect(kesselActions.loadPermissionsFromKessel).not.toHaveBeenCalled();
-      });
-    });
-
-    it('renders children', () => {
-      renderWithProviders();
-      expect(screen.getByText('App')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(actions.loadOrgAdmin).toHaveBeenCalledWith(mockGetUser);
     });
   });
 
-  describe('v2 Organization (feature flag ON)', () => {
-    beforeEach(() => {
-      mockUseFlag.mockReturnValue(true); // platform.rbac.workspaces = true
-    });
+  it('loads sources permissions via Chrome API', async () => {
+    renderWithProviders();
 
-    it('loads sources permissions via Chrome API (not Kessel)', async () => {
-      renderWithProviders();
+    await waitFor(() => {
+      expect(actions.loadWritePermissions).toHaveBeenCalledWith(mockGetUserPermissions);
+    });
+  });
+
+  it('loads v1 integrations permissions immediately', async () => {
+    renderWithProviders();
+
+    await waitFor(() => {
+      expect(actions.loadIntegrationsEndpointsPermissions).toHaveBeenCalledWith(mockGetUserPermissions);
+      expect(actions.loadIntegrationsReadPermissions).toHaveBeenCalledWith(mockGetUserPermissions);
+    });
+  });
+
+  it('loads v1 integrations permissions even while Kessel is still loading', async () => {
+    renderWithProviders({ kesselLoading: true });
+
+    await waitFor(() => {
+      expect(actions.loadIntegrationsEndpointsPermissions).toHaveBeenCalledWith(mockGetUserPermissions);
+      expect(actions.loadIntegrationsReadPermissions).toHaveBeenCalledWith(mockGetUserPermissions);
+    });
+  });
+
+  describe('when Kessel workspace is available', () => {
+    it('loads integrations permissions via Kessel', async () => {
+      renderWithProviders({ workspaceId: 'test-workspace-id' });
 
       await waitFor(() => {
-        expect(actions.loadWritePermissions).toHaveBeenCalledWith(mockGetUserPermissions);
-      });
-    });
-
-    it('loads integrations permissions via Kessel SDK', async () => {
-      renderWithProviders();
-
-      await waitFor(() => {
-        expect(kesselActions.loadPermissionsFromKessel).toHaveBeenCalledWith(mockKesselContext.permissions);
-      });
-    });
-
-    it('ALSO loads integrations via Chrome API for v1 wildcard fallback', async () => {
-      renderWithProviders();
-
-      await waitFor(() => {
-        expect(kesselActions.loadPermissionsFromKessel).toHaveBeenCalled();
-        // v2 orgs now ALSO load v1 permissions for wildcard fallback
-        // See: https://github.com/RedHatInsights/insights-chrome/pull/3362
-        expect(actions.loadIntegrationsEndpointsPermissions).toHaveBeenCalled();
-        expect(actions.loadIntegrationsReadPermissions).toHaveBeenCalled();
+        expect(kesselActions.loadPermissionsFromKessel).toHaveBeenCalledWith({
+          canWriteIntegrationsEndpoints: true,
+          canReadIntegrationsEndpoints: true,
+        });
       });
     });
 
     it('waits for Kessel to finish loading before dispatching', async () => {
-      renderWithProviders(true); // isLoading = true
+      renderWithProviders({ kesselLoading: true });
 
-      // Should not dispatch while loading
       expect(kesselActions.loadPermissionsFromKessel).not.toHaveBeenCalled();
-    });
-
-    it('loads org admin status', async () => {
-      renderWithProviders();
-
-      await waitFor(() => {
-        expect(actions.loadOrgAdmin).toHaveBeenCalledWith(mockGetUser);
-      });
-    });
-
-    it('renders children', () => {
-      renderWithProviders();
-      expect(screen.getByText('App')).toBeInTheDocument();
     });
   });
 
-  describe('Hybrid Behavior Verification', () => {
-    it('v1 org: all permissions from Chrome API', async () => {
-      mockUseFlag.mockReturnValue(false);
-      renderWithProviders();
+  describe('when Kessel workspace is not available', () => {
+    it('does NOT dispatch Kessel permissions', async () => {
+      renderWithProviders({ workspaceId: '' });
 
       await waitFor(() => {
-        // Sources via Chrome
-        expect(actions.loadWritePermissions).toHaveBeenCalled();
-
-        // Integrations via Chrome
         expect(actions.loadIntegrationsEndpointsPermissions).toHaveBeenCalled();
-        expect(actions.loadIntegrationsReadPermissions).toHaveBeenCalled();
-
-        // NOT via Kessel
-        expect(kesselActions.loadPermissionsFromKessel).not.toHaveBeenCalled();
       });
-    });
 
-    it('v2 org: sources via Chrome, integrations via Kessel + v1 fallback', async () => {
-      mockUseFlag.mockReturnValue(true);
-      renderWithProviders();
-
-      await waitFor(() => {
-        // Sources via Chrome (always)
-        expect(actions.loadWritePermissions).toHaveBeenCalled();
-
-        // Integrations via Kessel
-        expect(kesselActions.loadPermissionsFromKessel).toHaveBeenCalled();
-
-        // Integrations ALSO via Chrome (for v1 wildcard fallback)
-        // See: https://github.com/RedHatInsights/insights-chrome/pull/3362
-        expect(actions.loadIntegrationsEndpointsPermissions).toHaveBeenCalled();
-        expect(actions.loadIntegrationsReadPermissions).toHaveBeenCalled();
-      });
+      expect(kesselActions.loadPermissionsFromKessel).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/test/components/PermissionsChecker.test.tsx
+++ b/src/test/components/PermissionsChecker.test.tsx
@@ -39,9 +39,10 @@ describe('PermissionsChecker', () => {
 
   const Children = () => <h1>App</h1>;
 
-  const renderWithProviders = (
-    { kesselLoading, workspaceId }: { kesselLoading?: boolean; workspaceId?: string | undefined } = {},
-  ) => {
+  const renderWithProviders = ({
+    kesselLoading,
+    workspaceId,
+  }: { kesselLoading?: boolean; workspaceId?: string | undefined } = {}) => {
     const mockReducer = (state = {}) => state;
     store = createStore(mockReducer);
 


### PR DESCRIPTION
## Summary

- Remove `platform.rbac.workspaces` Unleash flag from `PermissionsChecker` — Kessel v2 access checks now run globally instead of per-org
- v1 Chrome API permissions load unconditionally as the always-on baseline; Kessel v2 supplements via Redux OR logic when a workspace is available
- Fix `KesselRbacAccessProvider` bug: empty `resource_id` sent to `/api/kessel/v1beta2/checkself` when workspace fetch fails (HTTP 400)
- Fix `KesselRbacAccessProvider` stuck `isLoading` when workspace is unavailable — SDK hooks stay in `loading: true` initial state forever

## Context

Under dual-write, v2 permission checks return the same results as v1 for all orgs, so per-org gating via `platform.rbac.workspaces` was unnecessary. Per clarification from Keith Walsh and Josejulio Martinez Magana, the workspace flag should only gate UX-level decisions, not API call routing.

Ref: [RHCLOUD-49447](https://redhat.atlassian.net/browse/RHCLOUD-49447)

## Changes

| File | Change |
|------|--------|
| `PermissionsChecker.tsx` | Remove `useFlag('platform.rbac.workspaces')`, load v1 unconditionally, dispatch Kessel only when `workspaceId` available |
| `KesselRbacAccessProvider.tsx` | Return `undefined` workspace when no ID (prevents 400), fix `isLoading` stuck state |
| `PermissionsChecker.test.tsx` | Rewrite tests for global approach (removed Unleash mock) |
| `kesselActions.ts`, `permissionMapper.ts` | Doc comment updates (removed "v2 orgs" language) |
| `README.md` | Updated architecture docs to reflect global approach |

## Test plan

- [x] All 147 test suites pass (1063 tests)
- [ ] Manual: org admin can create integrations (all tabs)
- [ ] Manual: non-admin sees correct tabs based on permissions
- [ ] Manual: no Kessel 400 errors in network tab when workspace unavailable
- [ ] Manual: FedRAMP/no-Kessel environment falls back to v1 gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHCLOUD-49447]: https://redhat.atlassian.net/browse/RHCLOUD-49447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ