### PR TITLE
RHCLOUD-50361 chore: migrate Chromatic workflow to shared reusable pipeline

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,37 +1,21 @@
-# Chromatic Visual Testing Workflow
-# Documentation: https://www.chromatic.com/docs/github-actions/
+name: Chromatic Upload
 
-name: "Chromatic"
+on:
+  workflow_run:
+    workflows: ["Storybook"]
+    types: [completed]
 
-on: push
+concurrency:
+  group: chromatic-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
 
 jobs:
   chromatic:
-    name: Run Chromatic
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: 20
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run Chromatic
-        uses: chromaui/action@latest
-        with:
-          # Make sure to configure a `CHROMATIC_PROJECT_TOKEN` repository secret
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          # Automatically accept all changes on main branch
-          autoAcceptChanges: "master"
-          # Exit with zero code even when changes are detected
-          exitZeroOnChanges: true
-          # Skip builds for dependabot branches
-          skip: "dependabot/**"
+    uses: RedHatInsights/experience-ui-governance/.github/workflows/reusable-chromatic.yml@5a772c75817a80fc30fae4e5c2bbd54b4ba114eb # main
+    secrets:
+      chromatic-project-token: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,0 +1,39 @@
+name: Storybook
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build Storybook
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Storybook
+        run: npm run build-storybook
+
+      - name: Upload Storybook Artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: storybook-static
+          path: storybook-static
+          retention-days: 3


### PR DESCRIPTION
## Summary
- Replaces the standalone Chromatic workflow with the shared reusable workflow from `experience-ui-governance`
- Adds a new `storybook.yml` workflow to build and upload the Storybook artifact separately
- Centralizes Chromatic upload logic for easier maintenance and consistent behavior across repos

## Test plan
- [ ] Verify Storybook builds correctly on PR and push
- [ ] Verify Chromatic upload works on a PR build
- [ ] Verify Chromatic baseline is auto-accepted on push to master
- [ ] Verify PR comment with Storybook/Build links appears correctly